### PR TITLE
Support prior versions to 3.10

### DIFF
--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
       - name: git clone
         uses: actions/checkout@v4

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
       - name: git clone
         uses: actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -123,7 +123,7 @@ celerybeat.pid
 .env
 .venv
 env/
-venv/
+venv*/
 ENV/
 env.bak/
 venv.bak/

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Visit the [docs][docs] for more information.
 
 ## Installation
 
-Requires Python `>=3.10`. Install using `pip`:
+Requires Python `>=3.8`. Install using `pip`:
 
 ```bash
 pip install nextmv

--- a/nextmv/base_model.py
+++ b/nextmv/base_model.py
@@ -1,6 +1,6 @@
 """JSON class for data wrangling JSON objects."""
 
-from typing import Any
+from typing import Any, Dict
 
 from pydantic import BaseModel
 
@@ -9,12 +9,12 @@ class BaseModel(BaseModel):
     """Base class for data wrangling tasks with JSON."""
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]):
+    def from_dict(cls, data: Dict[str, Any]):
         """Instantiates the class from a dict."""
 
         return cls(**data)
 
-    def to_dict(self) -> dict[str, Any]:
+    def to_dict(self) -> Dict[str, Any]:
         """Converts the class to a dict."""
 
         return self.model_dump(mode="json", exclude_none=True)

--- a/nextmv/cloud/acceptance_test.py
+++ b/nextmv/cloud/acceptance_test.py
@@ -2,6 +2,7 @@
 
 from datetime import datetime
 from enum import Enum
+from typing import List
 
 from nextmv.base_model import BaseModel
 
@@ -82,7 +83,7 @@ class AcceptanceTest(BaseModel):
     """Control instance of the acceptance test."""
     candidate: ComparisonInstance
     """Candidate instance of the acceptance test."""
-    metrics: list[Metric]
+    metrics: List[Metric]
     """Metrics of the acceptance test."""
     created_at: datetime
     """Creation date of the acceptance test."""

--- a/nextmv/cloud/application.py
+++ b/nextmv/cloud/application.py
@@ -3,7 +3,7 @@
 import time
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any
+from typing import Any, Optional, Union
 
 from nextmv.base_model import BaseModel
 from nextmv.cloud.acceptance_test import AcceptanceTest, Metric
@@ -26,11 +26,11 @@ class DownloadURL(BaseModel):
 class ErrorLog(BaseModel):
     """Error log of a run, when it was not successful."""
 
-    error: str | None = None
+    error: Optional[str] = None
     """Error message."""
-    stdout: str | None = None
+    stdout: Optional[str] = None
     """Standard output."""
-    stderr: str | None = None
+    stderr: Optional[str] = None
     """Standard error."""
 
 
@@ -100,9 +100,9 @@ class RunInformation(BaseModel):
 class RunResult(RunInformation):
     """Result of a run, wheter it was successful or not."""
 
-    error_log: ErrorLog | None = None
+    error_log: Optional[ErrorLog] = None
     """Error log of the run. Only available if the run failed."""
-    output: dict[str, Any] | None = None
+    output: Optional[dict[str, Any]] = None
     """Output of the run. Only available if the run succeeded."""
 
 
@@ -118,7 +118,7 @@ class UploadURL(BaseModel):
 class Configuration(BaseModel):
     """Configuration of an instance."""
 
-    execution_class: str | None = None
+    execution_class: Optional[str] = None
     """Execution class for the instance."""
 
 
@@ -266,10 +266,10 @@ class Application:
         candidate_instance_id: str,
         control_instance_id: str,
         id: str,
-        metrics: list[Metric | dict[str, Any]],
+        metrics: list[Union[Metric, dict[str, Any]]],
         name: str,
-        input_set_id: str | None = None,
-        description: str | None = None,
+        input_set_id: Optional[str] = None,
+        description: Optional[str] = None,
     ) -> AcceptanceTest:
         """
         Create a new acceptance test. The acceptance test is based on a batch
@@ -342,10 +342,10 @@ class Application:
         name: str,
         input_set_id: str,
         instance_ids: list[str],
-        description: str | None = None,
-        id: str | None = None,
-        option_sets: dict[str, Any] | None = None,
-        runs: list[BatchExperimentRun | dict[str, Any]] | None = None,
+        description: Optional[str] = None,
+        id: Optional[str] = None,
+        option_sets: Optional[dict[str, Any]] = None,
+        runs: Optional[list[Union[BatchExperimentRun, dict[str, Any]]]] = None,
     ) -> str:
         """
         Create a new batch experiment.
@@ -395,12 +395,12 @@ class Application:
         self,
         id: str,
         name: str,
-        description: str | None = None,
-        end_time: datetime | None = None,
-        instance_id: str | None = None,
-        maximum_runs: int | None = None,
-        run_ids: list[str] | None = None,
-        start_time: datetime | None = None,
+        description: Optional[str] = None,
+        end_time: Optional[datetime] = None,
+        instance_id: Optional[str] = None,
+        maximum_runs: Optional[int] = None,
+        run_ids: Optional[list[str]] = None,
+        start_time: Optional[datetime] = None,
     ) -> InputSet:
         """
         Create a new input set.
@@ -450,13 +450,13 @@ class Application:
 
     def new_run(
         self,
-        input: dict[str, Any] | BaseModel = None,
-        instance_id: str | None = None,
-        name: str | None = None,
-        description: str | None = None,
-        upload_id: str | None = None,
-        options: dict[str, Any] | None = None,
-        configuration: Configuration | None = None,
+        input: Union[dict[str, Any], BaseModel] = None,
+        instance_id: Optional[str] = None,
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+        upload_id: Optional[str] = None,
+        options: Optional[dict[str, Any]] = None,
+        configuration: Optional[Configuration] = None,
     ) -> str:
         """
         Submit an input to start a new run of the application. Returns the
@@ -522,14 +522,14 @@ class Application:
 
     def new_run_with_result(
         self,
-        input: dict[str, Any] | BaseModel = None,
-        instance_id: str | None = None,
-        name: str | None = None,
-        description: str | None = None,
-        upload_id: str | None = None,
-        run_options: dict[str, Any] | None = None,
+        input: Union[dict[str, Any], BaseModel] = None,
+        instance_id: Optional[str] = None,
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+        upload_id: Optional[str] = None,
+        run_options: Optional[dict[str, Any]] = None,
         polling_options: PollingOptions = _DEFAULT_POLLING_OPTIONS,
-        configuration: Configuration | None = None,
+        configuration: Optional[Configuration] = None,
     ) -> RunResult:
         """
         Submit an input to start a new run of the application and poll for the

--- a/nextmv/cloud/application.py
+++ b/nextmv/cloud/application.py
@@ -3,7 +3,7 @@
 import time
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 from nextmv.base_model import BaseModel
 from nextmv.cloud.acceptance_test import AcceptanceTest, Metric
@@ -102,7 +102,7 @@ class RunResult(RunInformation):
 
     error_log: Optional[ErrorLog] = None
     """Error log of the run. Only available if the run failed."""
-    output: Optional[dict[str, Any]] = None
+    output: Optional[Dict[str, Any]] = None
     """Output of the run. Only available if the run succeeded."""
 
 
@@ -207,7 +207,7 @@ class Application:
 
         return InputSet.from_dict(response.json())
 
-    def list_acceptance_tests(self) -> list[AcceptanceTest]:
+    def list_acceptance_tests(self) -> List[AcceptanceTest]:
         """
         List all acceptance tests.
 
@@ -225,7 +225,7 @@ class Application:
 
         return [AcceptanceTest.from_dict(acceptance_test) for acceptance_test in response.json()]
 
-    def list_batch_experiments(self) -> list[BatchExperimentMetadata]:
+    def list_batch_experiments(self) -> List[BatchExperimentMetadata]:
         """
         List all batch experiments.
 
@@ -243,7 +243,7 @@ class Application:
 
         return [BatchExperimentMetadata.from_dict(batch_experiment) for batch_experiment in response.json()]
 
-    def list_input_sets(self) -> list[InputSet]:
+    def list_input_sets(self) -> List[InputSet]:
         """
         List all input sets.
 
@@ -266,7 +266,7 @@ class Application:
         candidate_instance_id: str,
         control_instance_id: str,
         id: str,
-        metrics: list[Union[Metric, dict[str, Any]]],
+        metrics: List[Union[Metric, Dict[str, Any]]],
         name: str,
         input_set_id: Optional[str] = None,
         description: Optional[str] = None,
@@ -341,11 +341,11 @@ class Application:
         self,
         name: str,
         input_set_id: str,
-        instance_ids: list[str],
+        instance_ids: List[str],
         description: Optional[str] = None,
         id: Optional[str] = None,
-        option_sets: Optional[dict[str, Any]] = None,
-        runs: Optional[list[Union[BatchExperimentRun, dict[str, Any]]]] = None,
+        option_sets: Optional[Dict[str, Any]] = None,
+        runs: Optional[List[Union[BatchExperimentRun, Dict[str, Any]]]] = None,
     ) -> str:
         """
         Create a new batch experiment.
@@ -399,7 +399,7 @@ class Application:
         end_time: Optional[datetime] = None,
         instance_id: Optional[str] = None,
         maximum_runs: Optional[int] = None,
-        run_ids: Optional[list[str]] = None,
+        run_ids: Optional[List[str]] = None,
         start_time: Optional[datetime] = None,
     ) -> InputSet:
         """
@@ -450,12 +450,12 @@ class Application:
 
     def new_run(
         self,
-        input: Union[dict[str, Any], BaseModel] = None,
+        input: Union[Dict[str, Any], BaseModel] = None,
         instance_id: Optional[str] = None,
         name: Optional[str] = None,
         description: Optional[str] = None,
         upload_id: Optional[str] = None,
-        options: Optional[dict[str, Any]] = None,
+        options: Optional[Dict[str, Any]] = None,
         configuration: Optional[Configuration] = None,
     ) -> str:
         """
@@ -522,12 +522,12 @@ class Application:
 
     def new_run_with_result(
         self,
-        input: Union[dict[str, Any], BaseModel] = None,
+        input: Union[Dict[str, Any], BaseModel] = None,
         instance_id: Optional[str] = None,
         name: Optional[str] = None,
         description: Optional[str] = None,
         upload_id: Optional[str] = None,
-        run_options: Optional[dict[str, Any]] = None,
+        run_options: Optional[Dict[str, Any]] = None,
         polling_options: PollingOptions = _DEFAULT_POLLING_OPTIONS,
         configuration: Optional[Configuration] = None,
     ) -> RunResult:
@@ -577,7 +577,7 @@ class Application:
     def run_input(
         self,
         run_id: str,
-    ) -> dict[str, Any]:
+    ) -> Dict[str, Any]:
         """
         Get the input of a run.
 
@@ -702,7 +702,7 @@ class Application:
 
     def upload_large_input(
         self,
-        input: dict[str, Any],
+        input: Dict[str, Any],
         upload_url: UploadURL,
     ) -> None:
         """

--- a/nextmv/cloud/batch_experiment.py
+++ b/nextmv/cloud/batch_experiment.py
@@ -1,7 +1,7 @@
 """This module contains definitions for batch experiments."""
 
 from datetime import datetime
-from typing import Any
+from typing import Any, Optional
 
 from nextmv.base_model import BaseModel
 
@@ -17,9 +17,9 @@ class BatchExperimentInformation(BaseModel):
     instance_ids: list[str]
     """List of instance IDs used for the experiment."""
 
-    description: str | None = None
+    description: Optional[str] = None
     """Description of the batch experiment."""
-    id: str | None = None
+    id: Optional[str] = None
     """ID of the batch experiment."""
 
 
@@ -32,9 +32,9 @@ class BatchExperiment(BatchExperimentInformation):
     status: str
     """Status of the batch experiment."""
 
-    grouped_distributional_summaries: list[dict[str, Any]] | None = None
+    grouped_distributional_summaries: Optional[list[dict[str, Any]]] = None
     """Grouped distributional summaries of the batch experiment."""
-    option_sets: dict[str, Any] | None = None
+    option_sets: Optional[dict[str, Any]] = None
     """Option sets used for the experiment."""
 
 
@@ -46,9 +46,9 @@ class BatchExperimentRun(BaseModel):
     input_id: str
     """ID of the input used for the experiment."""
 
-    instance_id: str | None = None
+    instance_id: Optional[str] = None
     """ID of the instance used for the experiment."""
-    version_id: str | None = None
+    version_id: Optional[str] = None
     """ID of the version used for the experiment."""
 
 

--- a/nextmv/cloud/batch_experiment.py
+++ b/nextmv/cloud/batch_experiment.py
@@ -1,7 +1,7 @@
 """This module contains definitions for batch experiments."""
 
 from datetime import datetime
-from typing import Any, Optional
+from typing import Any, Dict, List, Optional
 
 from nextmv.base_model import BaseModel
 
@@ -14,7 +14,7 @@ class BatchExperimentInformation(BaseModel):
     """Name of the batch experiment."""
     input_set_id: str
     """ID of the input set used for the experiment."""
-    instance_ids: list[str]
+    instance_ids: List[str]
     """List of instance IDs used for the experiment."""
 
     description: Optional[str] = None
@@ -32,9 +32,9 @@ class BatchExperiment(BatchExperimentInformation):
     status: str
     """Status of the batch experiment."""
 
-    grouped_distributional_summaries: Optional[list[dict[str, Any]]] = None
+    grouped_distributional_summaries: Optional[List[Dict[str, Any]]] = None
     """Grouped distributional summaries of the batch experiment."""
-    option_sets: Optional[dict[str, Any]] = None
+    option_sets: Optional[Dict[str, Any]] = None
     """Option sets used for the experiment."""
 
 

--- a/nextmv/cloud/client.py
+++ b/nextmv/cloud/client.py
@@ -3,7 +3,7 @@
 import json
 import os
 from dataclasses import dataclass, field
-from typing import Any, Optional
+from typing import Any, Dict, List, Optional
 from urllib.parse import urljoin
 
 import requests
@@ -27,7 +27,7 @@ class Client:
     """API key to use for authenticating with the Nextmv Cloud API. If not
     provided, the client will look for the NEXTMV_API_KEY environment
     variable."""
-    allowed_methods: list[str] = field(
+    allowed_methods: List[str] = field(
         default_factory=lambda: ["GET", "POST", "PUT", "DELETE"],
     )
     """Allowed HTTP methods to use for retries in requests to the Nextmv Cloud
@@ -42,12 +42,12 @@ class Client:
     seconds."""
     configuration_file: str = "~/.nextmv/config.yaml"
     """Path to the configuration file used by the Nextmv CLI."""
-    headers: Optional[dict[str, str]] = None
+    headers: Optional[Dict[str, str]] = None
     """Headers to use for requests to the Nextmv Cloud API."""
     max_retries: int = 10
     """Maximum number of retries to use for requests to the Nextmv Cloud
     API."""
-    status_forcelist: list[int] = field(
+    status_forcelist: List[int] = field(
         default_factory=lambda: [429, 500, 502, 503, 504, 507, 509],
     )
     """Status codes to retry for requests to the Nextmv Cloud API."""
@@ -104,9 +104,9 @@ class Client:
         method: str,
         endpoint: str,
         data: Optional[Any] = None,
-        headers: Optional[dict[str, str]] = None,
-        payload: Optional[dict[str, Any]] = None,
-        query_params: Optional[dict[str, Any]] = None,
+        headers: Optional[Dict[str, str]] = None,
+        payload: Optional[Dict[str, Any]] = None,
+        query_params: Optional[Dict[str, Any]] = None,
     ) -> requests.Response:
         """
         Method to make a request to the Nextmv Cloud API.
@@ -189,7 +189,7 @@ class Client:
         }
 
 
-def get_size(obj: dict[str, Any]) -> int:
+def get_size(obj: Dict[str, Any]) -> int:
     """Finds the size of an object in bytes."""
 
     obj_str = json.dumps(obj, separators=(",", ":"))

--- a/nextmv/cloud/client.py
+++ b/nextmv/cloud/client.py
@@ -3,7 +3,7 @@
 import json
 import os
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Optional
 from urllib.parse import urljoin
 
 import requests
@@ -23,7 +23,7 @@ class Client:
     ~/.nextmv/config.yaml file used by the Nextmv CLI.
     """
 
-    api_key: str | None = None
+    api_key: Optional[str] = None
     """API key to use for authenticating with the Nextmv Cloud API. If not
     provided, the client will look for the NEXTMV_API_KEY environment
     variable."""
@@ -42,7 +42,7 @@ class Client:
     seconds."""
     configuration_file: str = "~/.nextmv/config.yaml"
     """Path to the configuration file used by the Nextmv CLI."""
-    headers: dict[str, str] | None = None
+    headers: Optional[dict[str, str]] = None
     """Headers to use for requests to the Nextmv Cloud API."""
     max_retries: int = 10
     """Maximum number of retries to use for requests to the Nextmv Cloud
@@ -103,10 +103,10 @@ class Client:
         self,
         method: str,
         endpoint: str,
-        data: Any | None = None,
-        headers: dict[str, str] | None = None,
-        payload: dict[str, Any] | None = None,
-        query_params: dict[str, Any] | None = None,
+        data: Optional[Any] = None,
+        headers: Optional[dict[str, str]] = None,
+        payload: Optional[dict[str, Any]] = None,
+        query_params: Optional[dict[str, Any]] = None,
     ) -> requests.Response:
         """
         Method to make a request to the Nextmv Cloud API.

--- a/nextmv/cloud/input_set.py
+++ b/nextmv/cloud/input_set.py
@@ -1,6 +1,7 @@
 """This module contains definitions for input sets."""
 
 from datetime import datetime
+from typing import List
 
 from nextmv.base_model import BaseModel
 
@@ -16,7 +17,7 @@ class InputSet(BaseModel):
     """Description of the input set."""
     id: str
     """ID of the input set."""
-    input_ids: list[str]
+    input_ids: List[str]
     """IDs of the inputs in the input set."""
     name: str
     """Name of the input set."""

--- a/nextmv/nextroute/check/schema.py
+++ b/nextmv/nextroute/check/schema.py
@@ -1,7 +1,6 @@
 """This module contains definitions for the schema in the Nextroute check."""
 
-
-from typing import Optional
+from typing import Dict, List, Optional
 
 from nextmv.base_model import BaseModel
 
@@ -23,7 +22,7 @@ class ObjectiveTerm(BaseModel):
 class Objective(BaseModel):
     """Estimate of an objective of a move."""
 
-    terms: Optional[list[ObjectiveTerm]] = None
+    terms: Optional[List[ObjectiveTerm]] = None
     """Check of the individual terms of the objective."""
     value: Optional[float] = None
     """Value of the objective."""
@@ -92,17 +91,17 @@ class PlanUnit(BaseModel):
     best_move_objective: Optional[Objective] = None
     """Estimate of the objective of the best move if the plan unit has a best
     move."""
-    constraints: Optional[dict[str, int]] = None
+    constraints: Optional[Dict[str, int]] = None
     """Constraints that are violated for the plan unit."""
     has_best_move: Optional[bool] = None
     """True if a move is found for the plan unit. A plan unit has no move found
     if the plan unit is over-constrained or the move found is too expensive."""
-    stops: Optional[list[str]] = None
+    stops: Optional[List[str]] = None
     """IDs of the sops in the plan unit."""
     vehicles_have_moves: Optional[int] = None
     """Number of vehicles that have moves for the plan unit. Only calculated if
     the verbosity is very high."""
-    vehicles_with_moves: Optional[list[str]] = None
+    vehicles_with_moves: Optional[List[str]] = None
     """IDs of the vehicles that have moves for the plan unit. Only calculated
     if the verbosity is very high."""
 
@@ -127,7 +126,7 @@ class Output(BaseModel):
     """Duration used by the check, in seconds."""
     error: Optional[str] = None
     """Error raised during the check."""
-    plan_units: Optional[list[PlanUnit]] = None
+    plan_units: Optional[List[PlanUnit]] = None
     """Check of the individual plan units."""
     remark: Optional[str] = None
     """Remark of the check. It can be "ok", "timeout" or anything else that
@@ -136,7 +135,7 @@ class Output(BaseModel):
     """Start soltuion of the check."""
     summary: Optional[Summary] = None
     """Summary of the check."""
-    vehicles: Optional[list[Vehicle]] = None
+    vehicles: Optional[List[Vehicle]] = None
     """Check of the vehicles."""
     verbosity: Optional[str] = None
     """Verbosity level of the check."""

--- a/nextmv/nextroute/check/schema.py
+++ b/nextmv/nextroute/check/schema.py
@@ -1,19 +1,21 @@
 """This module contains definitions for the schema in the Nextroute check."""
 
 
+from typing import Optional
+
 from nextmv.base_model import BaseModel
 
 
 class ObjectiveTerm(BaseModel):
     """Check of the individual terms of the objective for a move."""
 
-    base: float | None = None
+    base: Optional[float] = None
     """Base of the objective term."""
-    factor: float | None = None
+    factor: Optional[float] = None
     """Factor of the objective term."""
-    name: str | None = None
+    name: Optional[str] = None
     """Name of the objective term."""
-    value: float | None = None
+    value: Optional[float] = None
     """Value of the objective term, which is equivalent to `self.base *
     self.factor`."""
 
@@ -21,35 +23,35 @@ class ObjectiveTerm(BaseModel):
 class Objective(BaseModel):
     """Estimate of an objective of a move."""
 
-    terms: list[ObjectiveTerm] | None = None
+    terms: Optional[list[ObjectiveTerm]] = None
     """Check of the individual terms of the objective."""
-    value: float | None = None
+    value: Optional[float] = None
     """Value of the objective."""
-    vehicle: str | None = None
+    vehicle: Optional[str] = None
     """ID of the vehicle for which it reports the objective."""
 
 
 class Solution(BaseModel):
     """Solution that the check has been executed on."""
 
-    objective: Objective | None = None
+    objective: Optional[Objective] = None
     """Objective of the start solution."""
-    plan_units_planned: int | None = None
+    plan_units_planned: Optional[int] = None
     """Number of plan units planned in the start solution."""
-    plan_units_unplanned: int | None = None
+    plan_units_unplanned: Optional[int] = None
     """Number of plan units unplanned in the start solution."""
-    stops_planned: int | None = None
+    stops_planned: Optional[int] = None
     """Number of stops planned in the start solution."""
-    vehicles_not_used: int | None = None
+    vehicles_not_used: Optional[int] = None
     """Number of vehicles not used in the start solution."""
-    vehicles_used: int | None = None
+    vehicles_used: Optional[int] = None
     """Number of vehicles used in the start solution."""
 
 
 class Summary(BaseModel):
     """Summary of the check."""
 
-    moves_failed: int | None = None
+    moves_failed: Optional[int] = None
     """number of moves that failed. A move can fail if the estimate of a
     constraint is incorrect. A constraint is incorrect if `ModelConstraint.
     EstimateIsViolated` returns true and one of the violation checks returns
@@ -60,47 +62,47 @@ class Summary(BaseModel):
     number of moves failed can be more than one per plan unit as we continue to
     try moves on different vehicles until we find a move that is executable or
     all vehicles have been visited."""
-    plan_units_best_move_failed: int | None = None
+    plan_units_best_move_failed: Optional[int] = None
     """Number of plan units for which the best move can not be planned. This
     should not happen if all the constraints are implemented correct."""
-    plan_units_best_move_found: int | None = None
+    plan_units_best_move_found: Optional[int] = None
     """Number of plan units for which at least one move has been found and the
     move is executable."""
-    plan_units_best_move_increases_objective: int | None = None
+    plan_units_best_move_increases_objective: Optional[int] = None
     """Number of plan units for which the best move is executable but would
     increase the objective value instead of decreasing it."""
-    plan_units_checked: int | None = None
+    plan_units_checked: Optional[int] = None
     """Number of plan units that have been checked. If this is less than
     `self.plan_units_to_be_checked` the check timed out."""
-    plan_units_have_no_move: int | None = None
+    plan_units_have_no_move: Optional[int] = None
     """Number of plan units for which no feasible move has been found. This
     implies there is no move that can be executed without violating a
     constraint."""
-    plan_units_to_be_checked: int | None = None
+    plan_units_to_be_checked: Optional[int] = None
     """Number of plan units to be checked."""
 
 
 class PlanUnit(BaseModel):
     """Check of a plan unit."""
 
-    best_move_failed: bool | None = None
+    best_move_failed: Optional[bool] = None
     """True if the plan unit's best move failed to execute."""
-    best_move_increases_objective: bool | None = None
+    best_move_increases_objective: Optional[bool] = None
     """True if the best move for the plan unit increases the objective."""
-    best_move_objective: Objective | None = None
+    best_move_objective: Optional[Objective] = None
     """Estimate of the objective of the best move if the plan unit has a best
     move."""
-    constraints: dict[str, int] | None = None
+    constraints: Optional[dict[str, int]] = None
     """Constraints that are violated for the plan unit."""
-    has_best_move: bool | None = None
+    has_best_move: Optional[bool] = None
     """True if a move is found for the plan unit. A plan unit has no move found
     if the plan unit is over-constrained or the move found is too expensive."""
-    stops: list[str] | None = None
+    stops: Optional[list[str]] = None
     """IDs of the sops in the plan unit."""
-    vehicles_have_moves: int | None = None
+    vehicles_have_moves: Optional[int] = None
     """Number of vehicles that have moves for the plan unit. Only calculated if
     the verbosity is very high."""
-    vehicles_with_moves: list[str] | None = None
+    vehicles_with_moves: Optional[list[str]] = None
     """IDs of the vehicles that have moves for the plan unit. Only calculated
     if the verbosity is very high."""
 
@@ -111,7 +113,7 @@ class Vehicle(BaseModel):
     id: str
     """ID of the vehicle."""
 
-    plan_units_have_moves: int | None = None
+    plan_units_have_moves: Optional[int] = None
     """Number of plan units that have moves for the vehicle. Only calculated if
     the depth is medium."""
 
@@ -119,22 +121,22 @@ class Vehicle(BaseModel):
 class Output(BaseModel):
     """Output of a feasibility check."""
 
-    duration_maximum: float | None = None
+    duration_maximum: Optional[float] = None
     """Maximum duration of the check, in seconds."""
-    duration_used: float | None = None
+    duration_used: Optional[float] = None
     """Duration used by the check, in seconds."""
-    error: str | None = None
+    error: Optional[str] = None
     """Error raised during the check."""
-    plan_units: list[PlanUnit] | None = None
+    plan_units: Optional[list[PlanUnit]] = None
     """Check of the individual plan units."""
-    remark: str | None = None
+    remark: Optional[str] = None
     """Remark of the check. It can be "ok", "timeout" or anything else that
     should explain itself."""
-    solution: Solution | None = None
+    solution: Optional[Solution] = None
     """Start soltuion of the check."""
-    summary: Summary | None = None
+    summary: Optional[Summary] = None
     """Summary of the check."""
-    vehicles: list[Vehicle] | None = None
+    vehicles: Optional[list[Vehicle]] = None
     """Check of the vehicles."""
-    verbosity: str | None = None
+    verbosity: Optional[str] = None
     """Verbosity level of the check."""

--- a/nextmv/nextroute/schema/input.py
+++ b/nextmv/nextroute/schema/input.py
@@ -1,6 +1,6 @@
 """Defines the input class."""
 
-from typing import Any
+from typing import Any, Optional
 
 from nextmv.base_model import BaseModel
 from nextmv.nextroute.schema.stop import AlternateStop, Stop, StopDefaults
@@ -10,9 +10,9 @@ from nextmv.nextroute.schema.vehicle import Vehicle, VehicleDefaults
 class Defaults(BaseModel):
     """Default values for vehicles and stops."""
 
-    stops: StopDefaults | None = None
+    stops: Optional[StopDefaults] = None
     """Default values for stops."""
-    vehicles: VehicleDefaults | None = None
+    vehicles: Optional[VehicleDefaults] = None
     """Default values for vehicles."""
 
 
@@ -34,19 +34,19 @@ class Input(BaseModel):
     vehicles: list[Vehicle]
     """Vehicles that service the stops."""
 
-    alternate_stops: list[AlternateStop] | None = None
+    alternate_stops: Optional[list[AlternateStop]] = None
     """A set of alternate stops for the vehicles."""
-    custom_data: Any | None = None
+    custom_data: Optional[Any] = None
     """Arbitrary data associated with the input."""
-    defaults: Defaults | None = None
+    defaults: Optional[Defaults] = None
     """Default values for vehicles and stops."""
-    distance_matrix: list[list[float]] | None = None
+    distance_matrix: Optional[list[list[float]]] = None
     """Matrix of travel distances in meters between stops."""
-    duratrion_groups: list[DurationGroup] | None = None
+    duratrion_groups: Optional[list[DurationGroup]] = None
     """Duration in seconds added when approaching the group."""
-    duration_matrix: list[list[float]] | None = None
+    duration_matrix: Optional[list[list[float]]] = None
     """Matrix of travel durations in seconds between stops."""
-    options: Any | None = None
+    options: Optional[Any] = None
     """Arbitrary options."""
-    stop_groups: list[list[str]] | None = None
+    stop_groups: Optional[list[list[str]]] = None
     """Groups of stops that must be part of the same route."""

--- a/nextmv/nextroute/schema/input.py
+++ b/nextmv/nextroute/schema/input.py
@@ -1,6 +1,6 @@
 """Defines the input class."""
 
-from typing import Any, Optional
+from typing import Any, List, Optional
 
 from nextmv.base_model import BaseModel
 from nextmv.nextroute.schema.stop import AlternateStop, Stop, StopDefaults
@@ -22,31 +22,31 @@ class DurationGroup(BaseModel):
 
     duration: int
     """Duration to add when visiting the group."""
-    group: list[str]
+    group: List[str]
     """Stop IDs contained in the group."""
 
 
 class Input(BaseModel):
     """Input schema for Nextroute."""
 
-    stops: list[Stop]
+    stops: List[Stop]
     """Stops that must be visited by the vehicles."""
-    vehicles: list[Vehicle]
+    vehicles: List[Vehicle]
     """Vehicles that service the stops."""
 
-    alternate_stops: Optional[list[AlternateStop]] = None
+    alternate_stops: Optional[List[AlternateStop]] = None
     """A set of alternate stops for the vehicles."""
     custom_data: Optional[Any] = None
     """Arbitrary data associated with the input."""
     defaults: Optional[Defaults] = None
     """Default values for vehicles and stops."""
-    distance_matrix: Optional[list[list[float]]] = None
+    distance_matrix: Optional[List[List[float]]] = None
     """Matrix of travel distances in meters between stops."""
-    duratrion_groups: Optional[list[DurationGroup]] = None
+    duratrion_groups: Optional[List[DurationGroup]] = None
     """Duration in seconds added when approaching the group."""
-    duration_matrix: Optional[list[list[float]]] = None
+    duration_matrix: Optional[List[List[float]]] = None
     """Matrix of travel durations in seconds between stops."""
     options: Optional[Any] = None
     """Arbitrary options."""
-    stop_groups: Optional[list[list[str]]] = None
+    stop_groups: Optional[List[List[str]]] = None
     """Groups of stops that must be part of the same route."""

--- a/nextmv/nextroute/schema/output.py
+++ b/nextmv/nextroute/schema/output.py
@@ -1,8 +1,7 @@
 """Defines the output class."""
 
-
 from datetime import datetime
-from typing import Any, Optional
+from typing import Any, Dict, List, Optional
 
 from pydantic import Field
 
@@ -72,11 +71,11 @@ class VehicleOutput(BaseModel):
     id: str
     """ID of the vehicle."""
 
-    alternate_stops: Optional[list[str]] = None
+    alternate_stops: Optional[List[str]] = None
     """List of alternate stops that were planned on the vehicle."""
     custom_data: Optional[Any] = None
     """Custom data of the vehicle."""
-    route: Optional[list[PlannedStopOutput]] = None
+    route: Optional[List[PlannedStopOutput]] = None
     """Route of the vehicle, which is a list of stops that were planned on
     it."""
     route_duration: Optional[float] = None
@@ -103,7 +102,7 @@ class ObjectiveOutput(BaseModel):
     """Custom data of the objective."""
     factor: Optional[float] = None
     """Factor of the objective."""
-    objectives: Optional[list[dict[str, Any]]] = None
+    objectives: Optional[List[Dict[str, Any]]] = None
     """List of objectives. Each list is actually of the same class
     `ObjectiveOutput`, but we avoid a recursive definition here."""
     value: Optional[float] = None
@@ -114,9 +113,9 @@ class ObjectiveOutput(BaseModel):
 class Solution(BaseModel):
     """Solution to a Vehicle Routing Problem (VRP)."""
 
-    unplanned: Optional[list[StopOutput]] = None
+    unplanned: Optional[List[StopOutput]] = None
     """List of stops that were not planned in the solution."""
-    vehicles: Optional[list[VehicleOutput]] = None
+    vehicles: Optional[List[VehicleOutput]] = None
     """List of vehicles in the solution."""
     objective: Optional[ObjectiveOutput] = None
     """Information of the objective (value function)."""
@@ -132,7 +131,7 @@ class RunStatistics(BaseModel):
     iterations: Optional[int] = None
     """Number of iterations."""
     custom: Optional[Any] = None
-    """Custom statistics created by the user. Can normally expect a `dict[str,
+    """Custom statistics created by the user. Can normally expect a `Dict[str,
     Any]`."""
 
 
@@ -144,7 +143,7 @@ class ResultStatistics(BaseModel):
     value: Optional[float] = None
     """Value of the result."""
     custom: Optional[Any] = None
-    """Custom statistics created by the user. Can normally expect a `dict[str,
+    """Custom statistics created by the user. Can normally expect a `Dict[str,
     Any]`."""
 
 
@@ -162,7 +161,7 @@ class Series(BaseModel):
 
     name: Optional[str] = None
     """Name of the series."""
-    data_points: Optional[list[DataPoint]] = None
+    data_points: Optional[List[DataPoint]] = None
     """Data of the series."""
 
 
@@ -171,7 +170,7 @@ class SeriesData(BaseModel):
 
     value: Optional[Series] = None
     """A series for the value of the solution."""
-    custom: Optional[list[Series]] = None
+    custom: Optional[List[Series]] = None
     """A list of series for custom statistics."""
 
 
@@ -191,12 +190,12 @@ class Statistics(BaseModel):
 class Output(BaseModel):
     """Output schema for Nextroute."""
 
-    options: dict[str, Any]
+    options: Dict[str, Any]
     """Options used to obtain this output."""
     version: Version
     """Versions used for the solution."""
 
-    solutions: Optional[list[Solution]] = None
+    solutions: Optional[List[Solution]] = None
     """Solutions to the problem."""
     statistics: Optional[Statistics] = None
     """Statistics of the solution."""

--- a/nextmv/nextroute/schema/output.py
+++ b/nextmv/nextroute/schema/output.py
@@ -2,7 +2,7 @@
 
 
 from datetime import datetime
-from typing import Any
+from typing import Any, Optional
 
 from pydantic import Field
 
@@ -26,7 +26,7 @@ class StopOutput(BaseModel):
     location: Location
     """Location of the stop."""
 
-    custom_data: Any | None = None
+    custom_data: Optional[Any] = None
     """Custom data of the stop."""
 
 
@@ -36,33 +36,33 @@ class PlannedStopOutput(BaseModel):
     stop: StopOutput
     """Basic information on the stop."""
 
-    arrival_time: datetime | None = None
+    arrival_time: Optional[datetime] = None
     """Actual arrival time at this stop."""
-    cumulative_travel_distance: float | None = None
+    cumulative_travel_distance: Optional[float] = None
     """Cumulative distance to travel from the first stop to this one, in meters."""
-    cumulative_travel_duration: float | None = None
+    cumulative_travel_duration: Optional[float] = None
     """Cumulative duration to travel from the first stop to this one, in seconds."""
-    custom_data: Any | None = None
+    custom_data: Optional[Any] = None
     """Custom data of the stop."""
-    duration: float | None = None
+    duration: Optional[float] = None
     """Duration of the service at the stop, in seconds."""
-    early_arrival_duration: float | None = None
+    early_arrival_duration: Optional[float] = None
     """Duration of early arrival at the stop, in seconds."""
-    end_time: datetime | None = None
+    end_time: Optional[datetime] = None
     """End time of the service at the stop."""
-    late_arrival_duration: float | None = None
+    late_arrival_duration: Optional[float] = None
     """Duration of late arrival at the stop, in seconds."""
-    mix_items: Any | None = None
+    mix_items: Optional[Any] = None
     """Mix items at the stop."""
-    start_time: datetime | None = None
+    start_time: Optional[datetime] = None
     """Start time of the service at the stop."""
-    target_arrival_time: datetime | None = None
+    target_arrival_time: Optional[datetime] = None
     """Target arrival time at this stop."""
-    travel_distance: float | None = None
+    travel_distance: Optional[float] = None
     """Distance to travel from the previous stop to this one, in meters."""
-    travel_duration: float | None = None
+    travel_duration: Optional[float] = None
     """Duration to travel from the previous stop to this one, in seconds."""
-    waiting_duration: float | None = None
+    waiting_duration: Optional[float] = None
     """Waiting duratino at the stop, in seconds."""
 
 
@@ -72,22 +72,22 @@ class VehicleOutput(BaseModel):
     id: str
     """ID of the vehicle."""
 
-    alternate_stops: list[str] | None = None
+    alternate_stops: Optional[list[str]] = None
     """List of alternate stops that were planned on the vehicle."""
-    custom_data: Any | None = None
+    custom_data: Optional[Any] = None
     """Custom data of the vehicle."""
-    route: list[PlannedStopOutput] | None = None
+    route: Optional[list[PlannedStopOutput]] = None
     """Route of the vehicle, which is a list of stops that were planned on
     it."""
-    route_duration: float | None = None
+    route_duration: Optional[float] = None
     """Total duration of the vehicle's route, in seconds."""
-    route_stops_duration: float | None = None
+    route_stops_duration: Optional[float] = None
     """Total duration of the stops of the vehicle, in seconds."""
-    route_travel_distance: float | None = None
+    route_travel_distance: Optional[float] = None
     """Total travel distance of the vehicle, in meters."""
-    route_travel_duration: float | None = None
+    route_travel_duration: Optional[float] = None
     """Total travel duration of the vehicle, in seconds."""
-    route_waiting_duration: float | None = None
+    route_waiting_duration: Optional[float] = None
     """Total waiting duration of the vehicle, in seconds."""
 
 
@@ -97,16 +97,16 @@ class ObjectiveOutput(BaseModel):
     name: str
     """Name of the objective."""
 
-    base: float | None = None
+    base: Optional[float] = None
     """Base of the objective."""
-    custom_data: Any | None = None
+    custom_data: Optional[Any] = None
     """Custom data of the objective."""
-    factor: float | None = None
+    factor: Optional[float] = None
     """Factor of the objective."""
-    objectives: list[dict[str, Any]] | None = None
+    objectives: Optional[list[dict[str, Any]]] = None
     """List of objectives. Each list is actually of the same class
     `ObjectiveOutput`, but we avoid a recursive definition here."""
-    value: float | None = None
+    value: Optional[float] = None
     """Value of the objective, which is equivalent to `self.base *
     self.factor`."""
 
@@ -114,24 +114,24 @@ class ObjectiveOutput(BaseModel):
 class Solution(BaseModel):
     """Solution to a Vehicle Routing Problem (VRP)."""
 
-    unplanned: list[StopOutput] | None = None
+    unplanned: Optional[list[StopOutput]] = None
     """List of stops that were not planned in the solution."""
-    vehicles: list[VehicleOutput] | None = None
+    vehicles: Optional[list[VehicleOutput]] = None
     """List of vehicles in the solution."""
-    objective: ObjectiveOutput | None = None
+    objective: Optional[ObjectiveOutput] = None
     """Information of the objective (value function)."""
-    check: checkOutput | None = None
+    check: Optional[checkOutput] = None
     """Check of the solution, if enabled."""
 
 
 class RunStatistics(BaseModel):
     """Statistics about a general run."""
 
-    duration: float | None = None
+    duration: Optional[float] = None
     """Duration of the run in seconds."""
-    iterations: int | None = None
+    iterations: Optional[int] = None
     """Number of iterations."""
-    custom: Any | None = None
+    custom: Optional[Any] = None
     """Custom statistics created by the user. Can normally expect a `dict[str,
     Any]`."""
 
@@ -139,11 +139,11 @@ class RunStatistics(BaseModel):
 class ResultStatistics(BaseModel):
     """Statistics about a specific result."""
 
-    duration: float | None = None
+    duration: Optional[float] = None
     """Duration of the run in seconds."""
-    value: float | None = None
+    value: Optional[float] = None
     """Value of the result."""
-    custom: Any | None = None
+    custom: Optional[Any] = None
     """Custom statistics created by the user. Can normally expect a `dict[str,
     Any]`."""
 
@@ -160,31 +160,31 @@ class DataPoint(BaseModel):
 class Series(BaseModel):
     """A series of data points."""
 
-    name: str | None = None
+    name: Optional[str] = None
     """Name of the series."""
-    data_points: list[DataPoint] | None = None
+    data_points: Optional[list[DataPoint]] = None
     """Data of the series."""
 
 
 class SeriesData(BaseModel):
     """Data of a series."""
 
-    value: Series | None = None
+    value: Optional[Series] = None
     """A series for the value of the solution."""
-    custom: list[Series] | None = None
+    custom: Optional[list[Series]] = None
     """A list of series for custom statistics."""
 
 
 class Statistics(BaseModel):
     """Statistics of a solution."""
 
-    run: RunStatistics | None = None
+    run: Optional[RunStatistics] = None
     """Statistics about the run."""
-    result: ResultStatistics | None = None
+    result: Optional[ResultStatistics] = None
     """Statistics about the last result."""
-    series_data: SeriesData | None = None
+    series_data: Optional[SeriesData] = None
     """Data of the series."""
-    statistics_schema: str | None = Field(alias="schema")
+    statistics_schema: Optional[str] = Field(alias="schema")
     """Schema (version)."""
 
 
@@ -196,7 +196,7 @@ class Output(BaseModel):
     version: Version
     """Versions used for the solution."""
 
-    solutions: list[Solution] | None = None
+    solutions: Optional[list[Solution]] = None
     """Solutions to the problem."""
-    statistics: Statistics | None = None
+    statistics: Optional[Statistics] = None
     """Statistics of the solution."""

--- a/nextmv/nextroute/schema/stop.py
+++ b/nextmv/nextroute/schema/stop.py
@@ -1,7 +1,7 @@
 """Defines the stop class."""
 
 from datetime import datetime
-from typing import Any, Optional
+from typing import Any, List, Optional
 
 from nextmv.base_model import BaseModel
 from nextmv.nextroute.schema.location import Location

--- a/nextmv/nextroute/schema/stop.py
+++ b/nextmv/nextroute/schema/stop.py
@@ -2,7 +2,7 @@
 
 
 from datetime import datetime
-from typing import Any
+from typing import Any, Optional
 
 from nextmv.base_model import BaseModel
 from nextmv.nextroute.schema.location import Location
@@ -11,23 +11,23 @@ from nextmv.nextroute.schema.location import Location
 class StopDefaults(BaseModel):
     """Default values for a stop."""
 
-    compatibility_attributes: list[str] | None = None
+    compatibility_attributes: Optional[list[str]] = None
     """Attributes that the stop is compatible with."""
-    duration: int | None = None
+    duration: Optional[int] = None
     """Duration of the stop in seconds."""
-    early_arrival_time_penalty: float | None = None
+    early_arrival_time_penalty: Optional[float] = None
     """Penalty per second for arriving at the stop before the target arrival time."""
-    late_arrival_time_penalty: float | None = None
+    late_arrival_time_penalty: Optional[float] = None
     """Penalty per second for arriving at the stop after the target arrival time."""
-    max_wait: int | None = None
+    max_wait: Optional[int] = None
     """Maximum waiting duration in seconds at the stop."""
-    quantity: Any | None = None
+    quantity: Optional[Any] = None
     """Quantity of the stop."""
-    start_time_window: Any | None = None
+    start_time_window: Optional[Any] = None
     """Time window in which the stop can start service."""
-    target_arrival_time: datetime | None = None
+    target_arrival_time: Optional[datetime] = None
     """Target arrival time at the stop."""
-    unplanned_penalty: int | None = None
+    unplanned_penalty: Optional[int] = None
     """Penalty for not planning a stop."""
 
 
@@ -40,13 +40,13 @@ class Stop(StopDefaults):
     location: Location
     """Location of the stop."""
 
-    custom_data: Any | None = None
+    custom_data: Optional[Any] = None
     """Arbitrary data associated with the stop."""
-    mixing_items: Any | None = None
+    mixing_items: Optional[Any] = None
     """Defines the items that are inserted or removed from the vehicle when visiting the stop."""
-    precedes: Any | None = None
+    precedes: Optional[Any] = None
     """Stops that must be visited after this one on the same route."""
-    succeeds: Any | None = None
+    succeeds: Optional[Any] = None
     """Stops that must be visited before this one on the same route."""
 
 
@@ -58,5 +58,5 @@ class AlternateStop(StopDefaults):
     location: Location
     """Location of the stop."""
 
-    custom_data: Any | None = None
+    custom_data: Optional[Any] = None
     """Arbitrary data associated with the stop."""

--- a/nextmv/nextroute/schema/stop.py
+++ b/nextmv/nextroute/schema/stop.py
@@ -1,6 +1,5 @@
 """Defines the stop class."""
 
-
 from datetime import datetime
 from typing import Any, Optional
 
@@ -11,7 +10,7 @@ from nextmv.nextroute.schema.location import Location
 class StopDefaults(BaseModel):
     """Default values for a stop."""
 
-    compatibility_attributes: Optional[list[str]] = None
+    compatibility_attributes: Optional[List[str]] = None
     """Attributes that the stop is compatible with."""
     duration: Optional[int] = None
     """Duration of the stop in seconds."""

--- a/nextmv/nextroute/schema/vehicle.py
+++ b/nextmv/nextroute/schema/vehicle.py
@@ -2,7 +2,7 @@
 
 
 from datetime import datetime
-from typing import Any
+from typing import Any, Optional
 
 from nextmv.base_model import BaseModel
 from nextmv.nextroute.schema.location import Location
@@ -14,44 +14,44 @@ class InitialStop(BaseModel):
     id: str
     """Unique identifier of the stop."""
 
-    fixed: bool | None = None
+    fixed: Optional[bool] = None
     """Whether the stop is fixed on the route."""
 
 
 class VehicleDefaults(BaseModel):
     """Default values for vehicles."""
 
-    activation_penalty: int | None = None
+    activation_penalty: Optional[int] = None
     """Penalty of using the vehicle."""
-    alternate_stops: list[str] | None = None
+    alternate_stops: Optional[list[str]] = None
     """A set of alternate stops for which only one should be serviced."""
-    capacity: Any | None = None
+    capacity: Optional[Any] = None
     """Capacity of the vehicle."""
-    compatibility_attributes: list[str] | None = None
+    compatibility_attributes: Optional[list[str]] = None
     """Attributes that the vehicle is compatible with."""
-    end_location: Location | None = None
+    end_location: Optional[Location] = None
     """Location where the vehicle ends."""
-    end_time: datetime | None = None
+    end_time: Optional[datetime] = None
     """Latest time at which the vehicle ends its route."""
-    max_distance: int | None = None
+    max_distance: Optional[int] = None
     """Maximum distance in meters that the vehicle can travel."""
-    max_duration: int | None = None
+    max_duration: Optional[int] = None
     """Maximum duration in seconds that the vehicle can travel."""
-    max_stops: int | None = None
+    max_stops: Optional[int] = None
     """Maximum number of stops that the vehicle can visit."""
-    max_wait: int | None = None
+    max_wait: Optional[int] = None
     """Maximum aggregated waiting time that the vehicle can wait across route stops."""
-    min_stops: int | None = None
+    min_stops: Optional[int] = None
     """Minimum stops that a vehicle should visit."""
-    min_stops_penalty: float | None = None
+    min_stops_penalty: Optional[float] = None
     """Penalty for not visiting the minimum number of stops."""
-    speed: float | None = None
+    speed: Optional[float] = None
     """Speed of the vehicle in meters per second."""
-    start_level: Any | None = None
+    start_level: Optional[Any] = None
     """Initial level of the vehicle."""
-    start_location: Location | None = None
+    start_location: Optional[Location] = None
     """Location where the vehicle starts."""
-    start_time: datetime | None = None
+    start_time: Optional[datetime] = None
     """Time when the vehicle starts its route."""
 
 
@@ -61,9 +61,9 @@ class Vehicle(VehicleDefaults):
     id: str
     """Unique identifier of the vehicle."""
 
-    custom_data: Any | None = None
+    custom_data: Optional[Any] = None
     """Arbitrary custom data."""
-    initial_stops: list[InitialStop] | None = None
+    initial_stops: Optional[list[InitialStop]] = None
     """Initial stops planned on the vehicle."""
-    stop_duration_multiplier: float | None = None
+    stop_duration_multiplier: Optional[float] = None
     """Multiplier for the duration of stops."""

--- a/nextmv/nextroute/schema/vehicle.py
+++ b/nextmv/nextroute/schema/vehicle.py
@@ -1,8 +1,7 @@
 """Defines the vehicle class."""
 
-
 from datetime import datetime
-from typing import Any, Optional
+from typing import Any, List, Optional
 
 from nextmv.base_model import BaseModel
 from nextmv.nextroute.schema.location import Location
@@ -23,11 +22,11 @@ class VehicleDefaults(BaseModel):
 
     activation_penalty: Optional[int] = None
     """Penalty of using the vehicle."""
-    alternate_stops: Optional[list[str]] = None
+    alternate_stops: Optional[List[str]] = None
     """A set of alternate stops for which only one should be serviced."""
     capacity: Optional[Any] = None
     """Capacity of the vehicle."""
-    compatibility_attributes: Optional[list[str]] = None
+    compatibility_attributes: Optional[List[str]] = None
     """Attributes that the vehicle is compatible with."""
     end_location: Optional[Location] = None
     """Location where the vehicle ends."""
@@ -63,7 +62,7 @@ class Vehicle(VehicleDefaults):
 
     custom_data: Optional[Any] = None
     """Arbitrary custom data."""
-    initial_stops: Optional[list[InitialStop]] = None
+    initial_stops: Optional[List[InitialStop]] = None
     """Initial stops planned on the vehicle."""
     stop_duration_multiplier: Optional[float] = None
     """Multiplier for the duration of stops."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ maintainers = [
 ]
 name = "nextmv"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.8"
 
 [project.urls]
 Homepage = "https://www.nextmv.io"
@@ -46,7 +46,7 @@ Documentation = "https://www.nextmv.io/docs"
 Repository = "https://github.com/nextmv-io/nextmv-py"
 
 [tool.ruff]
-target-version = "py312"
+target-version = "py38"
 lint.select = [
     "E",  # pycodestyle errors
     "W",  # pycodestyle warnings

--- a/tests/test_base_model.py
+++ b/tests/test_base_model.py
@@ -1,17 +1,18 @@
 import unittest
+from typing import Optional
 
 from nextmv.base_model import BaseModel
 
 
 class Foo(BaseModel):
     bar: str
-    baz: int | None = None
+    baz: Optional[int] = None
 
 
 class Roh(BaseModel):
     foo: Foo
-    qux: list[str] | None = None
-    lorem: str | None = None
+    qux: Optional[list[str]] = None
+    lorem: Optional[str] = None
 
 
 class TestBaseModel(unittest.TestCase):

--- a/tests/test_base_model.py
+++ b/tests/test_base_model.py
@@ -1,5 +1,5 @@
 import unittest
-from typing import Optional
+from typing import List, Optional
 
 from nextmv.base_model import BaseModel
 
@@ -11,7 +11,7 @@ class Foo(BaseModel):
 
 class Roh(BaseModel):
     foo: Foo
-    qux: Optional[list[str]] = None
+    qux: Optional[List[str]] = None
     lorem: Optional[str] = None
 
 


### PR DESCRIPTION
# Description

Modifies most of the type hints used to avoid using the Union Type Operator (`|`) and replace it for `typing.Union` and `typing.Optional`. Made some other more backwards-compatible changes such as using `typing.Dict` and `typing.List` instead of `dict` and `list` (which is the recommended way in more modern versions).

This changes allow support for Python `>=3.8`.