### PR TITLE
Allows non-JSON inputs for runs

### DIFF
--- a/nextmv/cloud/application.py
+++ b/nextmv/cloud/application.py
@@ -718,9 +718,11 @@ class Application:
             requests.HTTPError: If the response status code is not 2xx.
         """
 
-        _ = self.client.upload_to_presigned_url(
+        _ = self.client.request(
+            method="PUT",
+            endpoint=upload_url.upload_url,
             data=input,
-            url=upload_url.upload_url,
+            headers={"Content-Type": "application/json"},
         )
 
     def upload_url(self) -> UploadURL:

--- a/nextmv/cloud/application.py
+++ b/nextmv/cloud/application.py
@@ -704,7 +704,7 @@ class Application:
 
     def upload_large_input(
         self,
-        input: Dict[str, Any],
+        input: Union[Dict[str, Any], str],
         upload_url: UploadURL,
     ) -> None:
         """
@@ -718,11 +718,9 @@ class Application:
             requests.HTTPError: If the response status code is not 2xx.
         """
 
-        _ = self.client.request(
-            method="PUT",
-            endpoint=upload_url.upload_url,
-            payload=input,
-            headers={"Content-Type": "application/json"},
+        _ = self.client.upload_to_presigned_url(
+            data=input,
+            url=upload_url.upload_url,
         )
 
     def upload_url(self) -> UploadURL:

--- a/nextmv/cloud/application.py
+++ b/nextmv/cloud/application.py
@@ -450,7 +450,7 @@ class Application:
 
     def new_run(
         self,
-        input: Union[Dict[str, Any], BaseModel] = None,
+        input: Union[Dict[str, Any], BaseModel, str] = None,
         instance_id: Optional[str] = None,
         name: Optional[str] = None,
         description: Optional[str] = None,
@@ -463,7 +463,8 @@ class Application:
         run_id of the submitted run.
 
         Args:
-            input: Input to use for the run.
+            input: Input to use for the run. This can be JSON (given as dict
+            or BaseModel) or text (given as str).
             instance_id: ID of the instance to use for the run. If not
                 provided, the default_instance_id will be used.
             name: Name of the run.
@@ -479,15 +480,16 @@ class Application:
             requests.HTTPError: If the response status code is not 2xx.
         """
 
+        input_size = 0
         if isinstance(input, BaseModel):
             input = input.to_dict()
+            if input is not None:
+                input_size = get_size(input)
 
-        input_size = 0
-        if input is not None:
-            input_size = get_size(input)
+        upload_url_required = isinstance(input, str) or input_size > _MAX_RUN_SIZE
 
         upload_id_used = upload_id is not None
-        if not upload_id_used and input_size > _MAX_RUN_SIZE:
+        if not upload_id_used and upload_url_required:
             upload_url = self.upload_url()
             self.upload_large_input(input=input, upload_url=upload_url)
             upload_id = upload_url.upload_id

--- a/nextmv/cloud/client.py
+++ b/nextmv/cloud/client.py
@@ -3,7 +3,7 @@
 import json
 import os
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional
 from urllib.parse import urljoin
 
 import requests
@@ -179,39 +179,6 @@ class Client:
             ) from e
 
         return response
-
-    def upload_to_presigned_url(
-        self,
-        data: Union[Dict[str, Any], str],
-        url: str,
-    ) -> None:
-        """
-        Method to upload data to a presigned URL of the Nextmv Cloud API.
-
-        Args:
-            data: data to upload.
-            url: URL to upload the data to.
-        """
-
-        input_size = get_size(data) if isinstance(data, dict) else len(data.encode("utf-8"))
-        if isinstance(data, dict) and input_size > _MAX_LAMBDA_PAYLOAD_SIZE:
-            raise ValueError(
-                f"input data size of {input_size} bytes exceeds the maximum "
-                f"allowed size of {_MAX_LAMBDA_PAYLOAD_SIZE} bytes"
-            )
-
-        response = requests.put(
-            url=url,
-            data=data if isinstance(data, str) else json.dumps(data, separators=(",", ":")),
-        )
-
-        try:
-            response.raise_for_status()
-        except requests.HTTPError as e:
-            raise requests.HTTPError(
-                f"upload to presigned URL {url} failed with "
-                + f"status code {response.status_code} and message: {response.text}"
-            ) from e
 
     def _set_headers_api_key(self, api_key: str) -> None:
         """Sets the API key to use for requests to the Nextmv Cloud API."""

--- a/nextmv/cloud/client.py
+++ b/nextmv/cloud/client.py
@@ -3,7 +3,7 @@
 import json
 import os
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 from urllib.parse import urljoin
 
 import requests
@@ -179,6 +179,39 @@ class Client:
             ) from e
 
         return response
+
+    def upload_to_presigned_url(
+        self,
+        data: Union[Dict[str, Any], str],
+        url: str,
+    ) -> None:
+        """
+        Method to upload data to a presigned URL of the Nextmv Cloud API.
+
+        Args:
+            data: data to upload.
+            url: URL to upload the data to.
+        """
+
+        input_size = get_size(data) if isinstance(data, dict) else len(data.encode("utf-8"))
+        if isinstance(data, dict) and input_size > _MAX_LAMBDA_PAYLOAD_SIZE:
+            raise ValueError(
+                f"input data size of {input_size} bytes exceeds the maximum "
+                f"allowed size of {_MAX_LAMBDA_PAYLOAD_SIZE} bytes"
+            )
+
+        response = requests.put(
+            url=url,
+            data=data if isinstance(data, str) else json.dumps(data, separators=(",", ":")),
+        )
+
+        try:
+            response.raise_for_status()
+        except requests.HTTPError as e:
+            raise requests.HTTPError(
+                f"upload to presigned URL {url} failed with "
+                + f"status code {response.status_code} and message: {response.text}"
+            ) from e
 
     def _set_headers_api_key(self, api_key: str) -> None:
         """Sets the API key to use for requests to the Nextmv Cloud API."""


### PR DESCRIPTION
# Description
This update allows the `new_run` method in the Application class to accept text inputs directly, alongside the existing dict and BaseModel inputs.

# Changes
- Added string type as an acceptable input format for runs.
- Modified input size calculation and upload logic to accommodate the new input type.
- Added `upload_to_presigned_url` method to handle upload put requests.
