### PR TITLE
Support for StatusV2

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,0 +1,53 @@
+import json
+import os
+import time
+
+from nextmv.cloud import Application, Client
+from nextmv.cloud.account import Account
+from nextmv.cloud.application import Configuration
+
+input = {
+    "defaults": {"vehicles": {"speed": 20}},
+    "stops": [
+        {
+            "id": "Nijō Castle",
+            "location": {"lon": 135.748134, "lat": 35.014239},
+            "quantity": -1,
+        },
+        {
+            "id": "Kyoto Imperial Palace",
+            "location": {"lon": 135.762057, "lat": 35.025431},
+            "quantity": -1,
+        },
+    ],
+    "vehicles": [
+        {
+            "id": "v2",
+            "capacity": 2,
+            "start_location": {"lon": 135.728898, "lat": 35.039705},
+        },
+    ],
+}
+
+client = Client(api_key=os.getenv("NEXTMV_API_KEY_PROD"))
+app = Application(client=client, id="routing")
+acc = Account(client=client)
+
+for _ in range(10):
+    result = app.new_run(
+        input=input,
+        instance_id="latest",
+        # run_options={"solve.duration": "1s"},
+        options={"solve.duration": "1s"},
+        # polling_options=PollingOptions(max_tries=2, delay=3),  # Customize the polling options.
+        configuration=Configuration(execution_class="8c16gb120m"),
+    )
+    print(result)
+
+    time.sleep(2)
+
+    result2 = acc.queue()
+
+    print(json.dumps(result2.to_dict(), indent=2))
+
+    # app.cancel_run(result)

--- a/main2.py
+++ b/main2.py
@@ -1,0 +1,11 @@
+import json
+import os
+
+from nextmv.cloud import Client
+from nextmv.cloud.account import Account
+
+client = Client(api_key=os.getenv("NEXTMV_API_KEY_PROD"))
+account = Account(client=client)
+queue = account.queue()
+
+print(json.dumps(queue.to_dict(), indent=2))  # Pretty print.

--- a/metrics.json
+++ b/metrics.json
@@ -1,0 +1,1 @@
+[{"field":"result.value","statistic":"mean","metric_type":"direct-comparison","params":{"operator":"gt"}}]

--- a/nextmv/cloud/__init__.py
+++ b/nextmv/cloud/__init__.py
@@ -6,6 +6,9 @@ from .acceptance_test import ComparisonInstance as ComparisonInstance
 from .acceptance_test import Metric as Metric
 from .acceptance_test import MetricParams as MetricParams
 from .acceptance_test import MetricType as MetricType
+from .account import Account as Account
+from .account import Queue as Queue
+from .account import QueuedRun as QueuedRun
 from .application import Application as Application
 from .application import Configuration as Configuration
 from .application import DownloadURL as DownloadURL
@@ -21,3 +24,5 @@ from .batch_experiment import BatchExperimentMetadata as BatchExperimentMetadata
 from .batch_experiment import BatchExperimentRun as BatchExperimentRun
 from .client import Client as Client
 from .input_set import InputSet as InputSet
+from .status import Status as Status
+from .status import StatusV2 as StatusV2

--- a/nextmv/cloud/account.py
+++ b/nextmv/cloud/account.py
@@ -1,0 +1,69 @@
+from dataclasses import dataclass
+from datetime import datetime
+from typing import List
+
+from nextmv.base_model import BaseModel
+from nextmv.cloud.client import Client
+from nextmv.cloud.status import Status, StatusV2
+
+
+class QueuedRun(BaseModel):
+    """A run that is pending to be executed in the account."""
+
+    id: str
+    """ID of the run."""
+    user_email: str
+    """Email of the user who created the run."""
+    name: str
+    """Name of the run."""
+    description: str
+    """Description of the run."""
+    created_at: datetime
+    """Creation date of the run."""
+    application_id: str
+    """ID of the application used for the run."""
+    application_instance_id: str
+    """ID of the application instance used for the run."""
+    application_version_id: str
+    """ID of the application version used for the run."""
+    execution_class: str
+    """Execution class used for the run."""
+    status: Status
+    """Deprecated: use status_v2."""
+    status_v2: StatusV2
+    """Status of the run."""
+
+
+class Queue(BaseModel):
+    """A queue is a list of runs that are pending to be executed in the
+    account."""
+
+    runs: List[QueuedRun]
+    """List of runs in the queue."""
+
+
+@dataclass
+class Account:
+    """The Nextmv Platform account."""
+
+    client: Client
+    """Client to use for interacting with the Nextmv Cloud API."""
+
+    endpoint: str = "v1/account"
+    """Base endpoint for the account."""
+
+    def queue(self) -> Queue:
+        """Get the queue of runs in the account.
+
+        Returns:
+            Queue: Queue of runs in the account.
+
+        Raises:
+            requests.HTTPError: If the response status code is not 2xx.
+        """
+        response = self.client.request(
+            method="GET",
+            endpoint=self.endpoint + "/queue",
+        )
+
+        return Queue.from_dict(response.json())

--- a/nextmv/cloud/account.py
+++ b/nextmv/cloud/account.py
@@ -35,8 +35,8 @@ class QueuedRun(BaseModel):
 
 
 class Queue(BaseModel):
-    """A queue is a list of runs that are pending to be executed in the
-    account."""
+    """A queue is a list of runs that are pending to be executed, or currently
+    being executed, in the account."""
 
     runs: List[QueuedRun]
     """List of runs in the queue."""

--- a/nextmv/cloud/application.py
+++ b/nextmv/cloud/application.py
@@ -3,6 +3,7 @@
 import time
 from dataclasses import dataclass
 from datetime import datetime
+from enum import Enum
 from typing import Any, Dict, List, Optional, Union
 
 import requests
@@ -36,6 +37,34 @@ class ErrorLog(BaseModel):
     """Standard error."""
 
 
+class Status(str, Enum):
+    """Status of a run. Deprecated: use StatusV2."""
+
+    failed = "failed"
+    """Run failed."""
+    running = "running"
+    """Run is running."""
+    succeeded = "succeeded"
+    """Run succeeded."""
+
+
+class StatusV2(str, Enum):
+    """Status of a run."""
+
+    canceled = "canceled"
+    """Run was canceled."""
+    failed = "failed"
+    """Run failed."""
+    none = "none"
+    """Run has no status."""
+    queued = "queued"
+    """Run is queued."""
+    running = "running"
+    """Run is running."""
+    succeeded = "succeeded"
+    """Run succeeded."""
+
+
 class Metadata(BaseModel):
     """Metadata of a run, whether it was successful or not."""
 
@@ -55,7 +84,9 @@ class Metadata(BaseModel):
     """Size of the input in bytes."""
     output_size: float
     """Size of the output in bytes."""
-    status: str
+    status: Status
+    """Deprecated: use status_v2."""
+    status_v2: StatusV2
     """Status of the run."""
 
 
@@ -692,7 +723,11 @@ class Application:
         polling_ok = False
         for _ in range(polling_options.max_tries):
             run_information = self.run_metadata(run_id=run_id)
-            if run_information.metadata.status in ["succeeded", "failed"]:
+            if run_information.metadata.status_v2 in [
+                StatusV2.succeeded,
+                StatusV2.failed,
+                StatusV2.canceled,
+            ]:
                 polling_ok = True
                 break
 

--- a/nextmv/cloud/application.py
+++ b/nextmv/cloud/application.py
@@ -3,7 +3,6 @@
 import time
 from dataclasses import dataclass
 from datetime import datetime
-from enum import Enum
 from typing import Any, Dict, List, Optional, Union
 
 import requests
@@ -13,6 +12,7 @@ from nextmv.cloud.acceptance_test import AcceptanceTest, Metric
 from nextmv.cloud.batch_experiment import BatchExperiment, BatchExperimentMetadata, BatchExperimentRun
 from nextmv.cloud.client import Client, get_size
 from nextmv.cloud.input_set import InputSet
+from nextmv.cloud.status import Status, StatusV2
 
 _MAX_RUN_SIZE: int = 5 * 1024 * 1024
 """Maximum size of the run input/output. This value is used to determine
@@ -35,34 +35,6 @@ class ErrorLog(BaseModel):
     """Standard output."""
     stderr: Optional[str] = None
     """Standard error."""
-
-
-class Status(str, Enum):
-    """Status of a run. Deprecated: use StatusV2."""
-
-    failed = "failed"
-    """Run failed."""
-    running = "running"
-    """Run is running."""
-    succeeded = "succeeded"
-    """Run succeeded."""
-
-
-class StatusV2(str, Enum):
-    """Status of a run."""
-
-    canceled = "canceled"
-    """Run was canceled."""
-    failed = "failed"
-    """Run failed."""
-    none = "none"
-    """Run has no status."""
-    queued = "queued"
-    """Run is queued."""
-    running = "running"
-    """Run is running."""
-    succeeded = "succeeded"
-    """Run succeeded."""
 
 
 class Metadata(BaseModel):
@@ -218,6 +190,22 @@ class Application:
         )
 
         return BatchExperiment.from_dict(response.json())
+
+    def cancel_run(self, run_id: str) -> None:
+        """
+        Cancel a run.
+
+        Args:
+            run_id: ID of the run.
+
+        Raises:
+            requests.HTTPError: If the response status code is not 2xx.
+        """
+
+        _ = self.client.request(
+            method="PATCH",
+            endpoint=f"{self.endpoint}/runs/{run_id}/cancel",
+        )
 
     def input_set(self, input_set_id: str) -> InputSet:
         """

--- a/nextmv/cloud/status.py
+++ b/nextmv/cloud/status.py
@@ -1,0 +1,29 @@
+from enum import Enum
+
+
+class Status(str, Enum):
+    """Status of a run. Deprecated: use StatusV2."""
+
+    failed = "failed"
+    """Run failed."""
+    running = "running"
+    """Run is running."""
+    succeeded = "succeeded"
+    """Run succeeded."""
+
+
+class StatusV2(str, Enum):
+    """Status of a run."""
+
+    canceled = "canceled"
+    """Run was canceled."""
+    failed = "failed"
+    """Run failed."""
+    none = "none"
+    """Run has no status."""
+    queued = "queued"
+    """Run is queued."""
+    running = "running"
+    """Run is running."""
+    succeeded = "succeeded"
+    """Run succeeded."""


### PR DESCRIPTION
# Description

Adds support for `status_v2`. For the polling logic, uses the additional `canceled` state as criteria for stopping the polling action. Additionally, new methods are introduced to cancel runs and list the account queue, which potentially may be done programatically.