### PR TITLE
ENG-5405 Adds support for logging

### DIFF
--- a/nextmv/__init__.py
+++ b/nextmv/__init__.py
@@ -1,1 +1,4 @@
 """Nextmv Python SDK."""
+
+from .logger import Logger as Logger
+from .logger import log as log

--- a/nextmv/__init__.py
+++ b/nextmv/__init__.py
@@ -1,4 +1,9 @@
 """Nextmv Python SDK."""
 
-from .logger import Logger as Logger
+from .__about__ import __version__
 from .logger import log as log
+from .logger import redirect_stdout as redirect_stdout
+from .logger import reset_stdout as reset_stdout
+
+version = __version__
+"""The version of the Nextmv Python SDK."""

--- a/nextmv/logger.py
+++ b/nextmv/logger.py
@@ -2,87 +2,31 @@
 
 import sys
 
+__original_stdout = None
 
-class Logger:
-    """
-    Logger is a special class that logs _all_ messages to stderr. After it is
-    instantiated, it will redirect _all_ messages streamed to both stdout and
-    stderr to a buffer. To flush the buffer to stderr, call the `flush` method.
-    Once the `flush` method is called, the buffer will be cleared, by streaming
-    all the logs stored to stderr, and the behavior of stdout and stderr will
-    be restored to their original state.
 
-    If you only want to log messages to stderr, without buffering them, and not
-    redirect the stdout stream to stderr, you can instead use the `log`
-    function from this same module.
+def redirect_stdout() -> None:
+    """Redirect all messages written to stdout to stderr. When you do not want
+    to redirect stdout anymore, call `reset_stdout`."""
 
-    Examples:
+    global __original_stdout
+    __original_stdout = sys.stdout
+    sys.stdout = sys.stderr
 
-        - Print message "0" to stdout, messages "1" and "2" to stderr, and then "3" to stdout:
 
-        ```python
-        import nextmv
+def reset_stdout() -> None:
+    """Reset stdout to its original value. This function should always be
+    called after `redirect_stdout` to avoid unexpected behavior."""
 
-        print("0. I do nothing")
-        logger = nextmv.Logger()
-        logger.log("1. I log a message to stderr")
-        print("2. I print a message to stdout, but gets redirected to stderr")
-        logger.flush()
-        print("3. I print another message to stdout")
-        ```
-    """
+    if __original_stdout is None:
+        return
 
-    def __init__(self):
-        self._logs = []
-        self._original_stdout = sys.stdout
-        self._original_stderr = sys.stderr
-        sys.stdout = self._FileCapture(self)
-        sys.stderr = self._FileCapture(self)
-
-    class _FileCapture:
-        """This custom writer is written to capture anything written to
-        stdout. It needs to implement the `write` and `flush` methods."""
-
-        def __init__(self, logger):
-            self.logger = logger
-
-        def write(self, message):
-            if message.strip():  # Avoid capturing empty messages.
-                self.logger._logs.append(message)
-
-        def flush(self):
-            pass  # No need to implement flush for this use case.
-
-    def log(self, message: str) -> None:
-        """
-        Log a message that will be later redirected to stderr.
-
-        Args:
-            message: The message to log.
-        """
-
-        self._logs.append(message)
-
-    def flush(self) -> None:
-        """
-        Flush the buffer to stderr and clear the buffer.
-        """
-
-        for log in self._logs:
-            self._original_stderr.write(log + "\n")
-
-        self._logs = []
-        sys.stdout = self._original_stdout
-        sys.stderr = self._original_stderr
+    sys.stdout = __original_stdout
 
 
 def log(message: str) -> None:
     """
     Log a message to stderr.
-
-    If you want a special logger that buffers stdout and stderr messages and
-    flushes them to stderr, you can instead use the `Logger` class from the
-    same module.
 
     Args:
         message: The message to log.

--- a/nextmv/logger.py
+++ b/nextmv/logger.py
@@ -1,0 +1,80 @@
+"""Logger that writes to stderr."""
+
+import sys
+
+
+class Logger:
+    """
+    Logger is a special class that logs _all_ messages to stderr. After it is
+    instantiated, it will redirect _all_ messages streamed to both stdout and
+    stderr to a buffer. To flush the buffer to stderr, call the `flush` method.
+    Once the `flush` method is called, the buffer will be cleared, by streaming
+    all the logs stored to stderr, and the behavior of stdout and stderr will
+    be restored to their original state.
+
+    If you only want to log messages to stderr, and not redirect the stdout
+    stream to stderr, you can instead use the `log` function from this same
+    module.
+    """
+
+    def __init__(self):
+        self._logs = []
+        self._stdout_set = False
+
+    class _StdoutCapture:
+        """This custom writer is written to capture anything written to
+        stdout. It needs to implement the `write` and `flush` methods."""
+
+        def __init__(self, logger):
+            self.logger = logger
+
+        def write(self, message):
+            if message.strip():  # Avoid capturing empty messages.
+                self.logger._logs.append(message)
+
+        def flush(self):
+            pass  # No need to implement flush for this use case.
+
+    def log(self, message: str) -> None:
+        """
+        Log a message that will be later redirected to stderr.
+
+        Args:
+            message: The message to log.
+        """
+
+        if not self._stdout_set:
+            sys.stdout = self._StdoutCapture(self)
+            self._stdout_set = True
+
+        self._logs.append(message)
+
+    def flush(self) -> None:
+        """
+        Flush the logs to stderr and reset the behavior of the stdout and
+        stderr streams.
+        """
+
+        for log in self._logs:
+            print(log, file=sys.stderr)
+
+        self._logs = []
+        sys.stdout = sys.__stdout__
+        self._stdout_set = False
+
+
+def log(message: str) -> None:
+    """
+    Log a message to stderr.
+
+    If you want a special logger that captures all messages and redirects both
+    stdout and stderr to stderr, you can instead use the `Logger` class from
+    the same module.
+
+    Args:
+        message: The message to log.
+    """
+
+    logger = Logger()
+    logger.log(message)
+    logger.flush()

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,0 +1,59 @@
+import sys
+import unittest
+from io import StringIO
+from unittest.mock import patch
+
+import nextmv
+
+
+class TestLogger(unittest.TestCase):
+    @patch("sys.stderr", new_callable=StringIO)
+    @patch("sys.stdout", new_callable=StringIO)
+    def test_log(self, mock_stdout, mock_stderr):
+        # Make sure that stdout is not redirected to stderr, this is, it is not
+        # affected by the log function.
+        print("I print a message to stdout")
+        self.assertEqual(
+            mock_stdout.getvalue(),
+            "I print a message to stdout\n",
+        )
+
+        # Test that calling the simple log function is equivalent to printing
+        # to stderr.
+        nextmv.log("doing this")
+        print("is the same as doing this", file=sys.stderr)
+        self.assertEqual(
+            mock_stderr.getvalue(),
+            "doing this\nis the same as doing this\n",
+        )
+
+    @patch("sys.stderr", new_callable=StringIO)
+    def test_logger(self, mock_stderr):
+        logger = nextmv.Logger()
+
+        # I can log to stderr.
+        logger.log("0. log directly to stderr")
+
+        # And if I print to stdout, it will actually be redirected to stderr.
+        print("1. stdout redirected to stderr")
+
+        # I have to remember to flush the logger to see the messages.
+        logger.flush()
+
+        self.assertEqual(
+            mock_stderr.getvalue(),
+            "0. log directly to stderr\n1. stdout redirected to stderr\n",
+        )
+
+    @patch("sys.stderr", new_callable=StringIO)
+    def test_logger_no_flush(self, mock_stderr):
+        logger = nextmv.Logger()
+
+        # I can log to stderr.
+        logger.log("0. log directly to stderr")
+
+        # And if I print to stdout, it will actually be redirected to stderr.
+        print("1. stdout redirected to stderr")
+
+        # Note that I didn't flush the logger, so the messages are not shown.
+        self.assertEqual(mock_stderr.getvalue(), "")

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -28,32 +28,28 @@ class TestLogger(unittest.TestCase):
         )
 
     @patch("sys.stderr", new_callable=StringIO)
-    def test_logger(self, mock_stderr):
-        logger = nextmv.Logger()
+    @patch("sys.stdout", new_callable=StringIO)
+    def test_redirect_stdout(self, mock_stdout, mock_stderr):
+        nextmv.redirect_stdout()
 
         # I can log to stderr.
-        logger.log("0. log directly to stderr")
+        nextmv.log("0. log directly to stderr")
 
         # And if I print to stdout, it will actually be redirected to stderr.
         print("1. stdout redirected to stderr")
 
-        # I have to remember to flush the logger to see the messages.
-        logger.flush()
+        # I reset stdout to its original value.
+        nextmv.reset_stdout()
+
+        # Now I can print to stdout again.
+        print("2. back to stdout")
 
         self.assertEqual(
             mock_stderr.getvalue(),
             "0. log directly to stderr\n1. stdout redirected to stderr\n",
         )
 
-    @patch("sys.stderr", new_callable=StringIO)
-    def test_logger_no_flush(self, mock_stderr):
-        logger = nextmv.Logger()
-
-        # I can log to stderr.
-        logger.log("0. log directly to stderr")
-
-        # And if I print to stdout, it will actually be redirected to stderr.
-        print("1. stdout redirected to stderr")
-
-        # Note that I didn't flush the logger, so the messages are not shown.
-        self.assertEqual(mock_stderr.getvalue(), "")
+        self.assertEqual(
+            mock_stdout.getvalue(),
+            "2. back to stdout\n",
+        )

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,10 @@
+import unittest
+
+import nextmv
+
+
+class TestLogger(unittest.TestCase):
+    def test_version(self):
+        exported_version = nextmv.version
+        expected_version = nextmv.__about__.__version__
+        self.assertEqual(exported_version, expected_version)


### PR DESCRIPTION
# Description

Adds functionality for logging. For the Nextmv platform, logging implies streaming to `stderr`.

Two new features are introduced:
- `log`: it is a function to simply print to `stderr`.
- `redirect_stdout`: to redirect stdout to stderr. This is needed for solvers that only log to stdout.
- `reset_stdout`: reset the behavior of stdout.

## Usage

Consider the following Python script:

```python
import sys

import nextmv

print("0. I do nothing")

nextmv.redirect_stdout()

nextmv.log("1. I log a message to stderr")

print("2. I print a message to stdout")

nextmv.reset_stdout()

print("3. I print another message to stdout")

print("4. I print yet another message to stderr without the logger", file=sys.stderr)

nextmv.log("5. I log a message to stderr using the nextmv module directly")

print("6. I print a message to stdout, again")

```

After executing it, here are the messages printed to the different streams.

- `stdout`

```txt
0. I do nothing
3. I print another message to stdout
6. I print a message to stdout, again
```

- `stderr`

```txt
1. I log a message to stderr
2. I print a message to stdout
4. I print yet another message to stderr without the logger
5. I log a message to stderr using the nextmv module directly
```