### PR TITLE
Allow writing pure Dicts

### DIFF
--- a/nextmv/output.py
+++ b/nextmv/output.py
@@ -364,7 +364,7 @@ class LocalOutputWriter(OutputWriter):
 
         Parameters
         ----------
-        output : Output
+        output: Output, Dict[str, Any]
             Output data to write.
         path : str
             Path to write the output data to.
@@ -383,12 +383,15 @@ class LocalOutputWriter(OutputWriter):
         if sys.stdout is not sys.__stdout__ and not skip_stdout_reset:
             reset_stdout()
 
-        statistics = self._extract_statistics(output)
-        options = self._extract_options(output)
-
-        output_format = OutputFormat.JSON
         if isinstance(output, Output):
             output_format = output.output_format
+        elif isinstance(output, Dict):
+            output_format = OutputFormat.JSON
+        else:
+            raise TypeError(f"unsupported output type: {type(output)}, supported types are `Output` or `Dict`")
+
+        statistics = self._extract_statistics(output)
+        options = self._extract_options(output)
 
         self.FILE_WRITERS[output_format](
             output=output,
@@ -416,7 +419,7 @@ class LocalOutputWriter(OutputWriter):
         elif isinstance(stats, Dict):
             statistics = stats
         else:
-            raise ValueError(f"unsupported statistics type: {type(stats)}, supported types are `Statistics` or `Dict`")
+            raise TypeError(f"unsupported statistics type: {type(stats)}, supported types are `Statistics` or `Dict`")
 
         return statistics
 
@@ -439,7 +442,7 @@ class LocalOutputWriter(OutputWriter):
         elif isinstance(opt, Dict):
             options = opt
         else:
-            raise ValueError(f"unsupported options type: {type(opt)}, supported types are `Options` or `Dict`")
+            raise TypeError(f"unsupported options type: {type(opt)}, supported types are `Options` or `Dict`")
 
         return options
 
@@ -470,7 +473,7 @@ def write_local(
 
     Parameters
     ----------
-    output : Output
+    output : Output, Dict[str, Any]
         Output data to write.
     path : str
         Path to write the output data to.

--- a/nextmv/output.py
+++ b/nextmv/output.py
@@ -230,15 +230,14 @@ class Output:
         if self.solution is None:
             return
 
-        if (
-            self.output_format == OutputFormat.JSON
-            and not isinstance(self.solution, dict)
-            and not isinstance(self.solution, list)
-        ):
-            raise ValueError(
-                f"unsupported Output.solution type: {type(self.solution)} with "
-                "output_format OutputFormat.JSON, supported type is `dict`, `list`"
-            )
+        if self.output_format == OutputFormat.JSON:
+            try:
+                _ = json.dumps(self.solution)
+            except (TypeError, OverflowError) as e:
+                raise ValueError(
+                    f"Output has output_format OutputFormat.JSON and "
+                    f"Output.solution is of type {type(self.solution)}, which is not JSON serializable"
+                ) from e
 
         elif self.output_format == OutputFormat.CSV_ARCHIVE and not isinstance(self.solution, dict):
             raise ValueError(

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -31,6 +31,25 @@ class TestOutput(unittest.TestCase):
 
             self.assertDictEqual(got, expected)
 
+    def test_local_writer_json_stdout_default_dict_output(self):
+        output = {
+            "solution": {"empanadas": "are_life"},
+            "statistics": {"foo": "bar"},
+        }
+        output_writer = nextmv.LocalOutputWriter()
+
+        with patch("sys.stdout", new=StringIO()) as mock_stdout:
+            output_writer.write(output, skip_stdout_reset=True)
+
+            got = json.loads(mock_stdout.getvalue())
+            expected = {
+                "solution": {"empanadas": "are_life"},
+                "statistics": {"foo": "bar"},
+                "options": {},
+            }
+
+            self.assertDictEqual(got, expected)
+
     def test_local_writer_json_stdout(self):
         output = nextmv.Output(
             output_format=nextmv.OutputFormat.JSON,
@@ -58,6 +77,30 @@ class TestOutput(unittest.TestCase):
 
         output = nextmv.Output(
             options=options,
+            output_format=nextmv.OutputFormat.JSON,
+            solution={"empanadas": "are_life"},
+            statistics={"foo": "bar"},
+        )
+        output_writer = nextmv.LocalOutputWriter()
+
+        with patch("sys.stdout", new=StringIO()) as mock_stdout:
+            output_writer.write(output, skip_stdout_reset=True)
+
+            got = json.loads(mock_stdout.getvalue())
+            expected = {
+                "options": {
+                    "duration": 5,
+                    "solver": "highs",
+                },
+                "solution": {"empanadas": "are_life"},
+                "statistics": {"foo": "bar"},
+            }
+
+            self.assertDictEqual(got, expected)
+
+    def test_local_writer_json_stdout_with_options_json(self):
+        output = nextmv.Output(
+            options={"duration": 5, "solver": "highs"},
             output_format=nextmv.OutputFormat.JSON,
             solution={"empanadas": "are_life"},
             statistics={"foo": "bar"},

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -261,3 +261,8 @@ class TestOutput(unittest.TestCase):
 
         # Removes the output directory after the test is executed.
         shutil.rmtree(write_path)
+
+    def test_local_write_bad_output_type(self):
+        output = "I am clearly not an output object."
+        with self.assertRaises(TypeError):
+            nextmv.write_local(output)


### PR DESCRIPTION
- When instantiating an `Output` object that has `JSON` as the output format, check that the solution is serializable and not enforce a `dict` or `list`.
- When using the `write_local` function (really that is a convenience for `LocalOutputWriter().write`), allow the `output` to be of type `Output` or a simple `dict`. The downstream functions handle the cases when it is one way or the other.