### PR TITLE
Fix parsing of bool options

### DIFF
--- a/nextmv/options.py
+++ b/nextmv/options.py
@@ -125,7 +125,7 @@ class Options:
             parser.add_argument(
                 f"-{param.name}",
                 f"--{param.name}",
-                type=param.param_type if param.param_type != bool else str,  # noqa E721
+                type=param.param_type if param.param_type is not bool else str,
                 help=self._description(param),
             )
             params_by_name[param.name] = param
@@ -149,7 +149,7 @@ class Options:
             env_value = os.getenv(upper_name)
             if env_value is not None:
                 try:
-                    typed_env_value = param.param_type(env_value) if param.param_type != bool else env_value  # noqa E721
+                    typed_env_value = param.param_type(env_value) if param.param_type is not bool else env_value
                 except ValueError:
                     raise ValueError(f'environment variable "{upper_name}" is not of type {param.param_type}') from None
 
@@ -213,7 +213,7 @@ class Options:
         """Handles how the value of a parameter is extracted."""
 
         param_type = parameter.param_type
-        if param_type != bool:  # noqa E721
+        if param_type is not bool:
             return value
 
         value = str(value).lower()

--- a/nextmv/options.py
+++ b/nextmv/options.py
@@ -125,7 +125,7 @@ class Options:
             parser.add_argument(
                 f"-{param.name}",
                 f"--{param.name}",
-                type=param.param_type,
+                type=param.param_type if param.param_type != bool else str,  # noqa E721
                 help=self._description(param),
             )
             params_by_name[param.name] = param
@@ -133,25 +133,28 @@ class Options:
         args = parser.parse_args()
 
         for arg in vars(args):
+            param = params_by_name[arg]
+
             # First, attempt to set the value of a parameter from the
             # command-line args.
-            value = getattr(args, arg)
-            if value is not None:
+            arg_value = getattr(args, arg)
+            if arg_value is not None:
+                value = self._parameter_value(param, arg_value)
                 setattr(self, arg, value)
                 continue
 
             # Second, attempt to set the value of a parameter from the
             # environment variables.
-            param = params_by_name[arg]
             upper_name = arg.upper()
             env_value = os.getenv(upper_name)
             if env_value is not None:
                 try:
-                    typed_env_value = param.param_type(env_value)
+                    typed_env_value = param.param_type(env_value) if param.param_type != bool else env_value  # noqa E721
                 except ValueError:
                     raise ValueError(f'environment variable "{upper_name}" is not of type {param.param_type}') from None
 
-                setattr(self, arg, typed_env_value)
+                value = self._parameter_value(param, typed_env_value)
+                setattr(self, arg, value)
                 continue
 
             # Finally, attempt to set the value of a parameter from the default
@@ -204,3 +207,20 @@ class Options:
             description += f": {param.description}"
 
         return description
+
+    @staticmethod
+    def _parameter_value(parameter: Parameter, value: Any) -> Any:
+        """Handles how the value of a parameter is extracted."""
+
+        param_type = parameter.param_type
+        if param_type != bool:  # noqa E721
+            return value
+
+        value = str(value).lower()
+
+        if value in ("true", "1", "t", "y", "yes"):
+            return True
+        if value in ("false", "0", "f", "n", "no"):
+            return False
+
+        raise argparse.ArgumentTypeError(f"invalid value for bool parameter '{parameter.name}': {value}")

--- a/tests/scripts/options4.py
+++ b/tests/scripts/options4.py
@@ -1,0 +1,7 @@
+import nextmv
+
+options = nextmv.Options(
+    nextmv.Parameter("bool_opt", bool, required=True, default=False),
+)
+
+print(options.to_dict())

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -23,7 +23,7 @@ class TestOptions(unittest.TestCase):
     assume that the script is one level up.
     """
 
-    test_scripts = [1, 2, 3]
+    test_scripts = [1, 2, 3, 4]
     """These are auxiliary scripts that are used to test different scenarios of
     instantiating an `Options` object."""
 
@@ -169,6 +169,154 @@ class TestOptions(unittest.TestCase):
         self.maxDiff = None
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertNotIn("[env var: DURATION] (required) (default: 30s)", result.stdout)
+
+    def test_bool_option(self):
+        file = self._file_name("options4.py", "..")
+
+        result1 = subprocess.run(
+            ["python3", file, "-bool_opt", "false"],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result1.returncode, 0, result1.stderr)
+        self.assertEqual(result1.stdout, "{'bool_opt': False}\n")
+
+        result2 = subprocess.run(
+            ["python3", file, "-bool_opt", "f"],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result2.returncode, 0, result2.stderr)
+        self.assertEqual(result2.stdout, "{'bool_opt': False}\n")
+
+        result3 = subprocess.run(
+            ["python3", file, "-bool_opt", "False"],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result3.returncode, 0, result3.stderr)
+        self.assertEqual(result3.stdout, "{'bool_opt': False}\n")
+
+        result4 = subprocess.run(
+            ["python3", file, "-bool_opt", "0"],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result4.returncode, 0, result4.stderr)
+        self.assertEqual(result4.stdout, "{'bool_opt': False}\n")
+
+        result5 = subprocess.run(
+            ["python3", file, "-bool_opt", "true"],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result5.returncode, 0, result5.stderr)
+        self.assertEqual(result5.stdout, "{'bool_opt': True}\n")
+
+        result6 = subprocess.run(
+            ["python3", file, "-bool_opt", "t"],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result6.returncode, 0, result6.stderr)
+        self.assertEqual(result6.stdout, "{'bool_opt': True}\n")
+
+        result7 = subprocess.run(
+            ["python3", file, "-bool_opt", "True"],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result7.returncode, 0, result7.stderr)
+        self.assertEqual(result7.stdout, "{'bool_opt': True}\n")
+
+        result8 = subprocess.run(
+            ["python3", file, "-bool_opt", "1"],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result8.returncode, 0, result8.stderr)
+        self.assertEqual(result8.stdout, "{'bool_opt': True}\n")
+
+        result9 = subprocess.run(
+            ["python3", file],
+            capture_output=True,
+            text=True,
+            env={**os.environ, "BOOL_OPT": "f"},
+        )
+        self.assertEqual(result9.returncode, 0, result9.stderr)
+        self.assertEqual(result9.stdout, "{'bool_opt': False}\n")
+
+        result10 = subprocess.run(
+            ["python3", file],
+            capture_output=True,
+            text=True,
+            env={**os.environ, "BOOL_OPT": "false"},
+        )
+        self.assertEqual(result10.returncode, 0, result10.stderr)
+        self.assertEqual(result10.stdout, "{'bool_opt': False}\n")
+
+        result11 = subprocess.run(
+            ["python3", file],
+            capture_output=True,
+            text=True,
+            env={**os.environ, "BOOL_OPT": "False"},
+        )
+        self.assertEqual(result11.returncode, 0, result11.stderr)
+        self.assertEqual(result11.stdout, "{'bool_opt': False}\n")
+
+        result12 = subprocess.run(
+            ["python3", file],
+            capture_output=True,
+            text=True,
+            env={**os.environ, "BOOL_OPT": "0"},
+        )
+        self.assertEqual(result12.returncode, 0, result12.stderr)
+        self.assertEqual(result12.stdout, "{'bool_opt': False}\n")
+
+        result13 = subprocess.run(
+            ["python3", file],
+            capture_output=True,
+            text=True,
+            env={**os.environ, "BOOL_OPT": "t"},
+        )
+        self.assertEqual(result13.returncode, 0, result13.stderr)
+        self.assertEqual(result13.stdout, "{'bool_opt': True}\n")
+
+        result14 = subprocess.run(
+            ["python3", file],
+            capture_output=True,
+            text=True,
+            env={**os.environ, "BOOL_OPT": "true"},
+        )
+        self.assertEqual(result14.returncode, 0, result14.stderr)
+        self.assertEqual(result14.stdout, "{'bool_opt': True}\n")
+
+        result14 = subprocess.run(
+            ["python3", file],
+            capture_output=True,
+            text=True,
+            env={**os.environ, "BOOL_OPT": "True"},
+        )
+        self.assertEqual(result14.returncode, 0, result14.stderr)
+        self.assertEqual(result14.stdout, "{'bool_opt': True}\n")
+
+        result14 = subprocess.run(
+            ["python3", file],
+            capture_output=True,
+            text=True,
+            env={**os.environ, "BOOL_OPT": "1"},
+        )
+        self.assertEqual(result14.returncode, 0, result14.stderr)
+        self.assertEqual(result14.stdout, "{'bool_opt': True}\n")
+
+        # Default case: nothing is specified.
+        result15 = subprocess.run(
+            ["python3", file],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result15.returncode, 0, result15.stderr)
+        self.assertEqual(result15.stdout, "{'bool_opt': False}\n")
 
     @staticmethod
     def _file_name(name: str, relative_location: str = ".") -> str:

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -318,6 +318,25 @@ class TestOptions(unittest.TestCase):
         self.assertEqual(result15.returncode, 0, result15.stderr)
         self.assertEqual(result15.stdout, "{'bool_opt': False}\n")
 
+        # Bad arg.
+        result16 = subprocess.run(
+            ["python3", file, "-bool_opt", "Frue"],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result16.returncode, 1, result16.stderr)
+        self.assertEqual(result16.stdout, "")
+
+        # Bad env var.
+        result16 = subprocess.run(
+            ["python3", file],
+            capture_output=True,
+            text=True,
+            env={**os.environ, "BOOL_OPT": "Frue"},
+        )
+        self.assertEqual(result16.returncode, 1, result16.stderr)
+        self.assertEqual(result16.stdout, "")
+
     @staticmethod
     def _file_name(name: str, relative_location: str = ".") -> str:
         """


### PR DESCRIPTION
# Description

Fixes a bug where there was no possibility to obtain `False` for a bool option. Now, when a `bool` option is encountered, it is treated as a string and translated to the appropriate `bool` value.