### PR TITLE
Make CSV reading/writing configurable

### DIFF
--- a/nextmv/output.py
+++ b/nextmv/output.py
@@ -216,6 +216,10 @@ class Output:
     """The solution to the decision problem."""
     statistics: Optional[Union[Statistics, Dict[str, Any]]] = None
     """Statistics of the solution."""
+    csv_configurations: Optional[Dict[str, Any]] = None
+    """Optional configuration for writing CSV files, to be used when the
+    `output_format` is OutputFormat.CSV_ARCHIVE. These configurations are
+    passed as kwargs to the `DictWriter` class from the `csv` module."""
 
     def __post_init__(self):
         """Check that the solution matches the format given to initialize the
@@ -323,13 +327,17 @@ class LocalOutputWriter(OutputWriter):
         if output.solution is None:
             return
 
+        csv_configurations = output.csv_configurations
+        if csv_configurations is None:
+            csv_configurations = {}
+
         for file_name, data in output.solution.items():
             file_path = os.path.join(dir_path, f"{file_name}.csv")
             with open(file_path, "w", encoding="utf-8", newline="") as file:
                 writer = csv.DictWriter(
                     file,
                     fieldnames=data[0].keys(),
-                    quoting=csv.QUOTE_NONNUMERIC,
+                    **csv_configurations,
                 )
                 writer.writeheader()
                 writer.writerows(data)

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -1,3 +1,4 @@
+import csv
 import os
 import shutil
 import unittest
@@ -42,7 +43,12 @@ class TestInput(unittest.TestCase):
         input_loader = nextmv.LocalInputLoader()
 
         with patch("sys.stdin", new=StringIO(sample_input)):
-            input_data = input_loader.load(input_format=nextmv.InputFormat.CSV)
+            input_data = input_loader.load(
+                input_format=nextmv.InputFormat.CSV,
+                csv_configurations={
+                    "quoting": csv.QUOTE_NONNUMERIC,
+                },
+            )
 
         self.assertIsInstance(input_data, nextmv.Input)
         self.assertEqual(input_data.input_format, nextmv.InputFormat.CSV)
@@ -98,7 +104,13 @@ class TestInput(unittest.TestCase):
         input_loader = nextmv.LocalInputLoader()
 
         with patch("builtins.open", return_value=StringIO(sample_input)):
-            input_data = input_loader.load(input_format=nextmv.InputFormat.CSV, path="input.csv")
+            input_data = input_loader.load(
+                input_format=nextmv.InputFormat.CSV,
+                path="input.csv",
+                csv_configurations={
+                    "quoting": csv.QUOTE_NONNUMERIC,
+                },
+            )
 
         self.assertIsInstance(input_data, nextmv.Input)
         self.assertEqual(input_data.input_format, nextmv.InputFormat.CSV)
@@ -146,7 +158,13 @@ class TestInput(unittest.TestCase):
             file_2.write(sample_input_2)
 
         # Load the CSV archive input
-        input_data = input_loader.load(nextmv.InputFormat.CSV_ARCHIVE, path=load_path)
+        input_data = input_loader.load(
+            nextmv.InputFormat.CSV_ARCHIVE,
+            path=load_path,
+            csv_configurations={
+                "quoting": csv.QUOTE_NONNUMERIC,
+            },
+        )
 
         # Do the checks
         self.assertIsInstance(input_data, nextmv.Input)

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1,3 +1,4 @@
+import csv
 import json
 import os
 import shutil
@@ -233,6 +234,7 @@ class TestOutput(unittest.TestCase):
             output_format=nextmv.OutputFormat.CSV_ARCHIVE,
             solution=solution,
             statistics={"foo": "bar"},
+            csv_configurations={"quoting": csv.QUOTE_NONNUMERIC},
         )
         output_writer = nextmv.LocalOutputWriter()
 


### PR DESCRIPTION
# Description

Makes working with CSV formats configurable.

- When reading an input, you can pass in an optional `csv_configuration` `dict` in the `load_local` and `load` functions. That configuration will be passed as kwargs to the `csv.DictReader` class to apply them when loading `CSV`and `CSV_ARCHIVE` inputs.
- When writing an output, you can give the `Output` object the same, optional, `csv_configuration` `dict`. That dict will be passes as kwargs to the `csv.DictWriter` class when working with `CSV_ARCHIVE`.