### PR TITLE
Fixes None default and dash option handling

### DIFF
--- a/nextmv/options.py
+++ b/nextmv/options.py
@@ -116,11 +116,14 @@ class Options:
             description="Options for %(prog)s. Use command-line arguments (highest precedence) "
             + "or environment variables.",
         )
-        params_by_name: Dict[str, Parameter] = {}
+        params_by_field_name: Dict[str, Parameter] = {}
 
         for p, param in enumerate(parameters):
             if not isinstance(param, Parameter):
                 raise TypeError(f"expected a <Parameter> object, but got {type(param)} in index {p}")
+
+            # Remove any leading '-'. This is in line with argparse's behavior.
+            param.name = param.name.lstrip("-")
 
             parser.add_argument(
                 f"-{param.name}",
@@ -128,12 +131,15 @@ class Options:
                 type=param.param_type if param.param_type is not bool else str,
                 help=self._description(param),
             )
-            params_by_name[param.name] = param
+
+            # Store the parameter by its field name for easy access later. argparse
+            # replaces '-' with '_', so we do the same here.
+            params_by_field_name[param.name.replace("-", "_")] = param
 
         args = parser.parse_args()
 
         for arg in vars(args):
-            param = params_by_name[arg]
+            param = params_by_field_name[arg]
 
             # First, attempt to set the value of a parameter from the
             # command-line args.

--- a/nextmv/options.py
+++ b/nextmv/options.py
@@ -157,13 +157,10 @@ class Options:
                 setattr(self, arg, value)
                 continue
 
-            # Finally, attempt to set the value of a parameter from the default
-            # value.
-            if param.default is not None:
-                setattr(self, arg, param.default)
-                continue
-
+            # Finally, attempt to set a default value. This is only allowed
+            # for non-required parameters.
             if not param.required:
+                setattr(self, arg, param.default)
                 continue
 
             # At this point, the parameter is required and no value was

--- a/tests/scripts/options1.py
+++ b/tests/scripts/options1.py
@@ -1,8 +1,8 @@
 import nextmv
 
 options = nextmv.Options(
-    nextmv.Parameter("duration", str, "30s", description="solver duration", required=True),
-    nextmv.Parameter("threads", int, 4, description="computer threads", required=True),
+    nextmv.Parameter("duration", str, "30s", description="solver duration"),
+    nextmv.Parameter("threads", int, 4, description="computer threads"),
 )
 
 print(options.to_dict())

--- a/tests/scripts/options5.py
+++ b/tests/scripts/options5.py
@@ -1,7 +1,7 @@
 import nextmv
 
 options = nextmv.Options(
-    nextmv.Parameter("bool_opt", bool, default=True),
+    nextmv.Parameter("str_opt", str, default=None),
 )
 
 print(options.to_dict())

--- a/tests/scripts/options6.py
+++ b/tests/scripts/options6.py
@@ -1,0 +1,9 @@
+import nextmv
+
+options = nextmv.Options(
+    nextmv.Parameter("-dash-opt", str, default="dash"),
+    nextmv.Parameter("underscore_opt", str, default="underscore"),
+    nextmv.Parameter("camelCaseOpt", str, default="camel"),
+)
+
+print(options.to_dict())

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -23,7 +23,7 @@ class TestOptions(unittest.TestCase):
     assume that the script is one level up.
     """
 
-    test_scripts = [1, 2, 3, 4, 5]
+    test_scripts = [1, 2, 3, 4, 5, 6]
     """These are auxiliary scripts that are used to test different scenarios of
     instantiating an `Options` object."""
 
@@ -363,6 +363,26 @@ class TestOptions(unittest.TestCase):
         )
         self.assertEqual(result3.returncode, 0, result3.stderr)
         self.assertEqual(result3.stdout, "{'str_opt': None}\n")
+
+    def test_name_handling(self):
+        file = self._file_name("options6.py", "..")
+
+        result1 = subprocess.run(
+            [
+                "python3",
+                file,
+                "-dash-opt",
+                "empanadas",
+                "-underscore_opt",
+                "is",
+                "-camelCaseOpt",
+                "life",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result1.returncode, 0, result1.stderr)
+        self.assertEqual(result1.stdout, "{'dash_opt': 'empanadas', 'underscore_opt': 'is', 'camelCaseOpt': 'life'}\n")
 
     @staticmethod
     def _file_name(name: str, relative_location: str = ".") -> str:

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -23,7 +23,7 @@ class TestOptions(unittest.TestCase):
     assume that the script is one level up.
     """
 
-    test_scripts = [1, 2, 3, 4]
+    test_scripts = [1, 2, 3, 4, 5]
     """These are auxiliary scripts that are used to test different scenarios of
     instantiating an `Options` object."""
 
@@ -156,7 +156,7 @@ class TestOptions(unittest.TestCase):
 
         self.maxDiff = None
         self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertIn("[env var: DURATION] (required) (default: 30s)", result.stdout)
+        self.assertIn("[env var: DURATION] (default: 30s)", result.stdout)
 
     def test_minimal_help_message(self):
         file = self._file_name("options3.py", "..")
@@ -168,7 +168,7 @@ class TestOptions(unittest.TestCase):
 
         self.maxDiff = None
         self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertNotIn("[env var: DURATION] (required) (default: 30s)", result.stdout)
+        self.assertNotIn("[env var: DURATION] (default: 30s)", result.stdout)
 
     def test_bool_option(self):
         file = self._file_name("options4.py", "..")
@@ -316,7 +316,7 @@ class TestOptions(unittest.TestCase):
             text=True,
         )
         self.assertEqual(result15.returncode, 0, result15.stderr)
-        self.assertEqual(result15.stdout, "{'bool_opt': False}\n")
+        self.assertEqual(result15.stdout, "{'bool_opt': True}\n")
 
         # Bad arg.
         result16 = subprocess.run(
@@ -336,6 +336,33 @@ class TestOptions(unittest.TestCase):
         )
         self.assertEqual(result16.returncode, 1, result16.stderr)
         self.assertEqual(result16.stdout, "")
+
+    def test_none_default(self):
+        file = self._file_name("options5.py", "..")
+
+        result1 = subprocess.run(
+            ["python3", file, "-str_opt", ""],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result1.returncode, 0, result1.stderr)
+        self.assertEqual(result1.stdout, "{'str_opt': ''}\n")
+
+        result2 = subprocess.run(
+            ["python3", file, "-str_opt", "empanadas"],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result2.returncode, 0, result2.stderr)
+        self.assertEqual(result2.stdout, "{'str_opt': 'empanadas'}\n")
+
+        result3 = subprocess.run(
+            ["python3", file],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result3.returncode, 0, result3.stderr)
+        self.assertEqual(result3.stdout, "{'str_opt': None}\n")
 
     @staticmethod
     def _file_name(name: str, relative_location: str = ".") -> str:


### PR DESCRIPTION
# Description

Fixes `None`-default-option and dashed-option (`-`) handling.

## Changes

- Added stripping of leading '-' from parameter names to align with argparse behavior.
- Replaced '-' with '_' in parameter names for consistency with argparse and fixing bug when facing `-` options.
- Simplified default value assignment logic for non-required parameters.
- Updated tests to reflect changes in parameter requirements and default values.
- Added new tests for handling parameters with none default values and different naming conventions.