### PR TITLE
Add options to Parameter type

### DIFF
--- a/nextmv/options.py
+++ b/nextmv/options.py
@@ -52,7 +52,7 @@ class Parameter:
     """Whether the parameter is required. If a parameter is required, it will
     be an error to not provide a value for it, either trough a command-line
     argument, an environment variable or a default value."""
-    choices: List[Optional[Any]] = None
+    choices: Optional[List[Any]] = None
     """Limits values to a specific set of choices."""
 
 

--- a/nextmv/options.py
+++ b/nextmv/options.py
@@ -3,7 +3,7 @@
 import argparse
 import os
 from dataclasses import dataclass
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 from nextmv.base_model import BaseModel
 
@@ -23,6 +23,8 @@ class Parameter:
         The name of the parameter.
     param_type : type
         The type of the parameter.
+    choices : List[Any], optional
+        Limits values to a specific set of choices.
     default : Any, optional
         The default value of the parameter. Even though this is optional, it is
         recommended to provide a default value for all parameters.
@@ -50,6 +52,8 @@ class Parameter:
     """Whether the parameter is required. If a parameter is required, it will
     be an error to not provide a value for it, either trough a command-line
     argument, an environment variable or a default value."""
+    choices: List[Optional[Any]] = None
+    """Limits values to a specific set of choices."""
 
 
 class Options:
@@ -125,11 +129,15 @@ class Options:
             # Remove any leading '-'. This is in line with argparse's behavior.
             param.name = param.name.lstrip("-")
 
+            kwds = {}
+            if param.choices is not None:
+                kwds["choices"] = param.choices
             parser.add_argument(
                 f"-{param.name}",
                 f"--{param.name}",
                 type=param.param_type if param.param_type is not bool else str,
                 help=self._description(param),
+                **kwds,
             )
 
             # Store the parameter by its field name for easy access later. argparse
@@ -137,7 +145,9 @@ class Options:
             params_by_field_name[param.name.replace("-", "_")] = param
 
         args = parser.parse_args()
+        self._set_arg_attrs(args, params_by_field_name)
 
+    def _set_arg_attrs(self, args: argparse.Namespace, params_by_field_name: Dict[str, Parameter]):
         for arg in vars(args):
             param = params_by_field_name[arg]
 
@@ -163,10 +173,13 @@ class Options:
                 setattr(self, arg, value)
                 continue
 
-            # Finally, attempt to set a default value. This is only allowed
-            # for non-required parameters.
-            if not param.required:
+            # Finally, attempt to set the value of a parameter from the default
+            # value.
+            if param.default is not None:
                 setattr(self, arg, param.default)
+                continue
+
+            if not param.required:
                 continue
 
             # At this point, the parameter is required and no value was

--- a/tests/scripts/options7.py
+++ b/tests/scripts/options7.py
@@ -1,0 +1,9 @@
+import nextmv
+
+options = nextmv.Options(
+    nextmv.Parameter("foo", str, choices=["bar", "baz"]),
+    nextmv.Parameter("prime", int, choices=[11, 13, 17], required=True),
+    nextmv.Parameter("xyzzy", str, choices=["xyzzy", "plugh"], default="xyzzy"),
+)
+
+print(options.to_dict())

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -23,7 +23,7 @@ class TestOptions(unittest.TestCase):
     assume that the script is one level up.
     """
 
-    test_scripts = [1, 2, 3, 4, 5, 6]
+    test_scripts = [1, 2, 3, 4, 5, 6, 7]
     """These are auxiliary scripts that are used to test different scenarios of
     instantiating an `Options` object."""
 
@@ -362,7 +362,7 @@ class TestOptions(unittest.TestCase):
             text=True,
         )
         self.assertEqual(result3.returncode, 0, result3.stderr)
-        self.assertEqual(result3.stdout, "{'str_opt': None}\n")
+        self.assertEqual(result3.stdout, "{}\n")
 
     def test_name_handling(self):
         file = self._file_name("options6.py", "..")
@@ -383,6 +383,41 @@ class TestOptions(unittest.TestCase):
         )
         self.assertEqual(result1.returncode, 0, result1.stderr)
         self.assertEqual(result1.stdout, "{'dash_opt': 'empanadas', 'underscore_opt': 'is', 'camelCaseOpt': 'life'}\n")
+
+    def test_choices_option(self):
+        file = self._file_name("options7.py", "..")
+
+        result1 = subprocess.run(
+            ["python3", file],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result1.returncode, 1, result1.stderr)
+        self.assertEqual(result1.stdout, "")
+
+        result2 = subprocess.run(
+            ["python3", file, "-prime", "3"],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result2.returncode, 2, result2.stderr)
+        self.assertEqual(result2.stdout, "")
+
+        result3 = subprocess.run(
+            ["python3", file, "-prime", "11"],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result3.returncode, 0, result3.stderr)
+        self.assertEqual(result3.stdout, "{'prime': 11, 'xyzzy': 'xyzzy'}\n")
+
+        result4 = subprocess.run(
+            ["python3", file, "-prime", "17", "-foo", "baz"],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result4.returncode, 0, result4.stderr)
+        self.assertEqual(result4.stdout, "{'foo': 'baz', 'prime': 17, 'xyzzy': 'xyzzy'}\n")
 
     @staticmethod
     def _file_name(name: str, relative_location: str = ".") -> str:


### PR DESCRIPTION
For scikit-learn and other integrations, I need to be able to do this:

```python
    nextmv.Parameter(
        "criterion",
        str,
        choices=["squared_error", "friedman_mse", "absolute_error", "poisson"],
        description="The function to measure the quality of a split.",
    )
```

This PR adds that field to the `Parameter` type. It also corrects what I believe is an error in default handling.