### PR TITLE
Improves None default test case

### DIFF
--- a/tests/scripts/options5.py
+++ b/tests/scripts/options5.py
@@ -4,4 +4,4 @@ options = nextmv.Options(
     nextmv.Parameter("str_opt", str, default=None),
 )
 
-print(options.to_dict())
+print(f"str_opt: {options.str_opt}")

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -346,7 +346,7 @@ class TestOptions(unittest.TestCase):
             text=True,
         )
         self.assertEqual(result1.returncode, 0, result1.stderr)
-        self.assertEqual(result1.stdout, "{'str_opt': ''}\n")
+        self.assertEqual(result1.stdout, "str_opt: \n")
 
         result2 = subprocess.run(
             ["python3", file, "-str_opt", "empanadas"],
@@ -354,7 +354,7 @@ class TestOptions(unittest.TestCase):
             text=True,
         )
         self.assertEqual(result2.returncode, 0, result2.stderr)
-        self.assertEqual(result2.stdout, "{'str_opt': 'empanadas'}\n")
+        self.assertEqual(result2.stdout, "str_opt: empanadas\n")
 
         result3 = subprocess.run(
             ["python3", file],
@@ -362,7 +362,7 @@ class TestOptions(unittest.TestCase):
             text=True,
         )
         self.assertEqual(result3.returncode, 0, result3.stderr)
-        self.assertEqual(result3.stdout, "{'str_opt': None}\n")
+        self.assertEqual(result3.stdout, "str_opt: None\n")
 
     def test_name_handling(self):
         file = self._file_name("options6.py", "..")


### PR DESCRIPTION
# Description

Modified the `None` default test case to better display the issue it raises, if we don't support it.

## Changes

- Changed options display from dictionary to formatted string in `options5.py`.
  - This raises an exception that `argparse` wouldn't, as `None` was explicitly requested as the default by the user.
  - This behavior is in line with `argparse` even if not requesting a default **and** not requiring the arg, it will simply be `None`.
- Updated assertions in `test_options.py` to match the new display format.

## Example of the `argparse` behavior

Consider the following example with `argparse`. We add two arguments. The first has an explicit `None` default, the second is neither _required_ nor sets a _default_. Both allow accessing the named field without an exception and simply return `None`.

```python
parser = argparse.ArgumentParser()
parser.add_argument("--choice", choices=["a", "b", "c"], type=str, default=None)
parser.add_argument("--input", type=str)
args = parser.parse_args()

print(f"Choice: {args.choice}")
print(f"Input file: {args.input}")
```

The output:

```bash
Choice: None
Input file: None
```