### PR TITLE
Change publish for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,5 @@
-name: publish
-run-name: Publish ${{ inputs.VERSION }} (pre-release - ${{ inputs.IS_PRE_RELEASE }}) by @${{ github.actor }} from ${{ github.ref_name }}
+name: release
+run-name: Release ${{ inputs.VERSION }} (pre-release - ${{ inputs.IS_PRE_RELEASE }}) by @${{ github.actor }} from ${{ github.ref_name }}
 
 on:
   workflow_dispatch:
@@ -82,7 +82,7 @@ jobs:
         run: python -m build
         working-directory: ./nextmv-py
 
-  publish: # This job is used to publish the release to PyPI/TestPyPI
+  release: # This job is used to publish the release to PyPI/TestPyPI
     runs-on: ubuntu-latest
     needs: bump
     strategy:
@@ -132,8 +132,8 @@ jobs:
 
   notify:
     runs-on: ubuntu-latest
-    needs: publish
-    if: ${{ needs.publish.result == 'success' && inputs.IS_PRE_RELEASE == false }}
+    needs: release
+    if: ${{ needs.release.result == 'success' && inputs.IS_PRE_RELEASE == false }}
     steps:
       - name: notify slack
         run: |


### PR DESCRIPTION
# Description

In all of Nextmv’s repos, we use the name `release` for the workflow that publishes the "thing". This is the only place where it is called `publish`, so might as well change it for `release`. `nextroute` already uses the name `release`. We should update `nextplot` as well.