### PR TITLE
Fixes making large input runs

### DIFF
--- a/nextmv/cloud/application.py
+++ b/nextmv/cloud/application.py
@@ -875,11 +875,9 @@ class Application:
         if isinstance(input, Dict):
             input = json.dumps(input)
 
-        _ = self.client.request(
-            method="PUT",
-            endpoint=upload_url.upload_url,
+        _ = self.client.upload_to_presigned_url(
+            url=upload_url.upload_url,
             data=input,
-            headers={"Content-Type": "application/json"},
         )
 
     def upload_url(self) -> UploadURL:


### PR DESCRIPTION
# Description

Fixes large input runs by splitting the functionality into its own implementation that won't do a size check. Furthermore, added `str` as supported type for size calculation.

## Changes
- Replaced use of generic request implementation with `upload_to_presigned_url` method in `Application` class.
- Added `upload_to_presigned_url` method in `Client` class to handle uploads to presigned URLs (as they differ in behavior compared to "normal" API requests; we had this discussion [here](https://github.com/nextmv-io/nextmv-py/pull/19/files/18685197b48bed673df46fbbd9c8daea47582492#diff-11f2bd9ff33e5c57229863583ff0e122d8f34d9038fb46d11f5d3e74834bf242) before).
- Extended `get_size` function to support string type objects.