### PR TITLE
Adds choices / enum test for options handling

### DIFF
--- a/tests/scripts/options7.py
+++ b/tests/scripts/options7.py
@@ -1,0 +1,16 @@
+from enum import Enum
+
+import nextmv
+
+
+# Define choice enum
+class ChoiceEnum(Enum):
+    choice1 = "choice1"
+    choice2 = "choice2"
+
+
+options = nextmv.Options(
+    nextmv.Parameter("choice_opt", ChoiceEnum, default=ChoiceEnum.choice1),
+)
+
+print(options.to_dict())

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -23,7 +23,7 @@ class TestOptions(unittest.TestCase):
     assume that the script is one level up.
     """
 
-    test_scripts = [1, 2, 3, 4, 5, 6]
+    test_scripts = [1, 2, 3, 4, 5, 6, 7]
     """These are auxiliary scripts that are used to test different scenarios of
     instantiating an `Options` object."""
 

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -384,6 +384,25 @@ class TestOptions(unittest.TestCase):
         self.assertEqual(result1.returncode, 0, result1.stderr)
         self.assertEqual(result1.stdout, "{'dash_opt': 'empanadas', 'underscore_opt': 'is', 'camelCaseOpt': 'life'}\n")
 
+    def test_choices(self):
+        file = self._file_name("options7.py", "..")
+
+        result1 = subprocess.run(
+            ["python3", file, "-choice_opt", "choice2"],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result1.returncode, 0, result1.stderr)
+        self.assertEqual(result1.stdout, "{'choice_opt': 'choice2'}\n")
+
+        result2 = subprocess.run(
+            ["python3", file],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result2.returncode, 0, result2.stderr)
+        self.assertEqual(result2.stdout, "{'choice_opt': 'choice1'}\n")
+
     @staticmethod
     def _file_name(name: str, relative_location: str = ".") -> str:
         """


### PR DESCRIPTION
# Description

Introduces a new test script for testing choices / enums for option handling.

## Changes

- Added a new test script `options7.py` with an enum parameter example.
- Updated `test_options.py` to include the new `options7.py` in the test scripts list.

Resolves ENG-5539