### PR TITLE
Increases default maximum polling duration

### DIFF
--- a/nextmv/cloud/application.py
+++ b/nextmv/cloud/application.py
@@ -82,7 +82,7 @@ class PollingOptions(BaseModel):
     """Maximum delay to use between polls, in seconds. This parameter is
     activated when the backoff parameter is greater than 1, such that the delay
     is increasing after each poll."""
-    max_duration: float = 60
+    max_duration: float = 300
     """Maximum duration of the polling strategy, in seconds."""
     max_tries: int = 20
     """Maximum number of tries to use."""


### PR DESCRIPTION
# Description

Extends the default polling timeout to account for non-default execution class runs (including queuing) and somewhat longer runs.

## Changes

- Increased `max_duration` from 60 to 300 seconds in `PollingOptions` class.