### PR TITLE
Fix Dependency Installation Issue for Windows Store Python

### DIFF
--- a/nextmv/cloud/package.py
+++ b/nextmv/cloud/package.py
@@ -259,6 +259,7 @@ def __install_dependencies(
         "--no-warn-conflicts",
         "--target",
         os.path.join(temp_dir, dep_dir),
+        "--no-user",  # We explicitly avoid user mode (mainly to fix issues with Windows store Python installations)
         "--no-input",
         "--quiet",
     ]


### PR DESCRIPTION
# Description

This update addresses a problem with dependency installation on Python versions installed via the Windows Store by explicitly avoiding user mode.

## Changes

- Added `--no-user` flag to dependency installation command to fix issues with Windows store Python installations.