### PR TITLE
Allow dict solution to pass through and add support for assets in Output

### DIFF
--- a/nextmv/nextmv/__init__.py
+++ b/nextmv/nextmv/__init__.py
@@ -13,6 +13,7 @@ from .model import Model as Model
 from .model import ModelConfiguration as ModelConfiguration
 from .options import Options as Options
 from .options import Parameter as Parameter
+from .output import Asset as Asset
 from .output import DataPoint as DataPoint
 from .output import LocalOutputWriter as LocalOutputWriter
 from .output import Output as Output
@@ -23,6 +24,8 @@ from .output import RunStatistics as RunStatistics
 from .output import Series as Series
 from .output import SeriesData as SeriesData
 from .output import Statistics as Statistics
+from .output import Visual as Visual
+from .output import VisualSchema as VisualSchema
 from .output import write_local as write_local
 
 VERSION = __version__

--- a/nextmv/nextmv/output.py
+++ b/nextmv/nextmv/output.py
@@ -281,6 +281,7 @@ class Output:
     `output_format` is OutputFormat.CSV_ARCHIVE. These configurations are
     passed as kwargs to the `DictWriter` class from the `csv` module."""
     assets: Optional[list[Asset]] = None
+    """Optional list of assets to be included in the output."""
 
     def __post_init__(self):
         """Check that the solution matches the format given to initialize the

--- a/nextmv/nextmv/output.py
+++ b/nextmv/nextmv/output.py
@@ -273,21 +273,18 @@ class LocalOutputWriter(OutputWriter):
         statistics: dict[str, Any],
         path: Optional[str] = None,
     ) -> None:
-        solution = {}
-        if isinstance(output, Output):
-            sol = output.solution
-        elif isinstance(output, dict):
-            sol = output.get("solution")
-
-        if sol is not None:
-            solution = sol
-
-        serialized = json.dumps(
-            {
+        if isinstance(output, dict):
+            final_output = output
+        else:
+            solution = output.solution if output.solution is not None else {}
+            final_output = {
                 "options": options,
                 "solution": solution,
                 "statistics": statistics,
-            },
+            }
+
+        serialized = json.dumps(
+            final_output,
             indent=2,
             default=_custom_serial,
         )
@@ -370,6 +367,11 @@ class LocalOutputWriter(OutputWriter):
         unexpected behavior. If you want to skip this behavior, set the
         `skip_stdout_reset` parameter to `True`.
 
+        If the `output` is a `dict`, it will be simply written to the specified
+        `path`, as a passthrough. On the other hand, if the `output` is of type
+        `Output`, a more structured object will be written, which adheres to
+        the schema specified by the corresponding `Output` class.
+
         Parameters
         ----------
         output: Output, dict[str, Any]
@@ -414,10 +416,10 @@ class LocalOutputWriter(OutputWriter):
 
         statistics = {}
 
-        if isinstance(output, Output):
-            stats = output.statistics
-        elif isinstance(output, dict):
-            stats = output.get("statistics")
+        if not isinstance(output, Output):
+            return statistics
+
+        stats = output.statistics
 
         if stats is None:
             return statistics
@@ -437,10 +439,10 @@ class LocalOutputWriter(OutputWriter):
 
         options = {}
 
-        if isinstance(output, Output):
-            opt = output.options
-        elif isinstance(output, dict):
-            opt = output.get("options")
+        if not isinstance(output, Output):
+            return options
+
+        opt = output.options
 
         if opt is None:
             return options

--- a/nextmv/nextmv/output.py
+++ b/nextmv/nextmv/output.py
@@ -164,6 +164,66 @@ class OutputFormat(str, Enum):
     """CSV archive format: multiple CSV files."""
 
 
+class VisualSchema(str, Enum):
+    """Schema of a visual asset."""
+
+    CHARTJS = "chartjs"
+    """Tells Nextmv Console to render the custom asset data with the Chart.js
+    library."""
+    GEOJSON = "geojson"
+    """Tells Nextmv Console to render the custom asset data as GeoJSON on a
+    map."""
+    PLOTLY = "plotly"
+    """Tells Nextmv Console to render the custom asset data with the Plotly
+    library."""
+
+
+class Visual(BaseModel):
+    """
+    Visual schema of an asset that defines how it is plotted in the Nextmv
+    Console.
+    """
+
+    schema: VisualSchema
+    """Schema of the visual asset."""
+    label: str
+    """Label for the custom tab of the visual asset in the Nextmv Console."""
+
+    visual_type: Optional[str] = Field(alias="type", default="custom-tab")
+    """Defines the type of custom visual, currently there is only one type:
+    `custom-tab`. This renders the visual in its own tab view of the run
+    details."""
+
+    def __post_init__(self):
+        if self.schema not in VisualSchema:
+            raise ValueError(f"unsupported schema: {self.schema}, supported schemas are {VisualSchema}")
+
+        if self.visual_type != "custom-tab":
+            raise ValueError(f"unsupported visual_type: {self.visual_type}, supported types are `custom-tab`")
+
+
+class Asset(BaseModel):
+    """
+    An asset represents downloadable information that is part of the `Output`.
+    """
+
+    name: str
+    """Name of the asset."""
+    content: dict[str, Any]
+    """Content of the asset."""
+
+    content_type: Optional[str] = "json"
+    """Content type of the asset. Only `json` is allowed"""
+    description: Optional[str] = None
+    """Description of the asset."""
+    visual: Optional[Visual] = None
+    """Visual schema of the asset."""
+
+    def __post_init__(self):
+        if self.content_type != "json":
+            raise ValueError(f"unsupported content_type: {self.content_type}, supported types are `json`")
+
+
 @dataclass
 class Output:
     """
@@ -220,6 +280,7 @@ class Output:
     """Optional configuration for writing CSV files, to be used when the
     `output_format` is OutputFormat.CSV_ARCHIVE. These configurations are
     passed as kwargs to the `DictWriter` class from the `csv` module."""
+    assets: Optional[list[Asset]] = None
 
     def __post_init__(self):
         """Check that the solution matches the format given to initialize the
@@ -271,6 +332,7 @@ class LocalOutputWriter(OutputWriter):
         output: Union[Output, dict[str, Any]],
         options: dict[str, Any],
         statistics: dict[str, Any],
+        assets: list[dict[str, Any]],
         path: Optional[str] = None,
     ) -> None:
         if isinstance(output, dict):
@@ -281,6 +343,7 @@ class LocalOutputWriter(OutputWriter):
                 "options": options,
                 "solution": solution,
                 "statistics": statistics,
+                "assets": assets,
             }
 
         serialized = json.dumps(
@@ -300,6 +363,7 @@ class LocalOutputWriter(OutputWriter):
         output: Output,
         options: dict[str, Any],
         statistics: dict[str, Any],
+        assets: list[dict[str, Any]],
         path: Optional[str] = None,
     ) -> None:
         dir_path = "output"
@@ -316,6 +380,7 @@ class LocalOutputWriter(OutputWriter):
             {
                 "options": options,
                 "statistics": statistics,
+                "assets": assets,
             },
             indent=2,
         )
@@ -402,11 +467,13 @@ class LocalOutputWriter(OutputWriter):
 
         statistics = self._extract_statistics(output)
         options = self._extract_options(output)
+        assets = self._extract_assets(output)
 
         self.FILE_WRITERS[output_format](
             output=output,
             options=options,
             statistics=statistics,
+            assets=assets,
             path=path,
         )
 
@@ -455,6 +522,30 @@ class LocalOutputWriter(OutputWriter):
             raise TypeError(f"unsupported options type: {type(opt)}, supported types are `Options` or `dict`")
 
         return options
+
+    @staticmethod
+    def _extract_assets(output: Union[Output, dict[str, Any]]) -> list[dict[str, Any]]:
+        """Extract JSON-serializable assets."""
+
+        assets = []
+
+        if not isinstance(output, Output):
+            return assets
+
+        assts = output.assets
+
+        if assts is None:
+            return assets
+
+        for ix, asset in enumerate(assts):
+            if isinstance(asset, Asset):
+                assets.append(asset.to_dict())
+            elif isinstance(asset, dict):
+                assets.append(asset)
+            else:
+                raise TypeError(f"unsupported asset {ix}, type: {type(asset)}; supported types are `Asset` or `dict`")
+
+        return assets
 
 
 def write_local(

--- a/nextmv/tests/test_output.py
+++ b/nextmv/tests/test_output.py
@@ -46,7 +46,6 @@ class TestOutput(unittest.TestCase):
             expected = {
                 "solution": {"empanadas": "are_life"},
                 "statistics": {"foo": "bar"},
-                "options": {},
             }
 
             self.assertDictEqual(got, expected)
@@ -269,3 +268,39 @@ class TestOutput(unittest.TestCase):
         output = "I am clearly not an output object."
         with self.assertRaises(TypeError):
             nextmv.write_local(output)
+
+    def test_local_write_passthrough_output(self):
+        output = {
+            "i_am": "a_crazy_object",
+            "with": [
+                {"nested": "values"},
+                {"and": "more_craziness"},
+            ],
+        }
+
+        output_writer = nextmv.LocalOutputWriter()
+
+        with patch("sys.stdout", new=StringIO()) as mock_stdout:
+            output_writer.write(output, skip_stdout_reset=True)
+
+            got = json.loads(mock_stdout.getvalue())
+            expected = output
+
+            self.assertDictEqual(got, expected)
+
+    def test_local_write_empty_output(self):
+        output = nextmv.Output()
+
+        output_writer = nextmv.LocalOutputWriter()
+
+        with patch("sys.stdout", new=StringIO()) as mock_stdout:
+            output_writer.write(output, skip_stdout_reset=True)
+
+            got = json.loads(mock_stdout.getvalue())
+            expected = expected = {
+                "options": {},
+                "solution": {},
+                "statistics": {},
+            }
+
+            self.assertDictEqual(got, expected)

--- a/nextmv/tests/test_output.py
+++ b/nextmv/tests/test_output.py
@@ -28,6 +28,7 @@ class TestOutput(unittest.TestCase):
                 "solution": {"empanadas": "are_life"},
                 "statistics": {"foo": "bar"},
                 "options": {},
+                "assets": [],
             }
 
             self.assertDictEqual(got, expected)
@@ -66,6 +67,7 @@ class TestOutput(unittest.TestCase):
                 "solution": {"empanadas": "are_life"},
                 "statistics": {"foo": "bar"},
                 "options": {},
+                "assets": [],
             }
 
             self.assertDictEqual(got, expected)
@@ -94,6 +96,7 @@ class TestOutput(unittest.TestCase):
                 },
                 "solution": {"empanadas": "are_life"},
                 "statistics": {"foo": "bar"},
+                "assets": [],
             }
 
             self.assertDictEqual(got, expected)
@@ -118,6 +121,7 @@ class TestOutput(unittest.TestCase):
                 },
                 "solution": {"empanadas": "are_life"},
                 "statistics": {"foo": "bar"},
+                "assets": [],
             }
 
             self.assertDictEqual(got, expected)
@@ -140,6 +144,7 @@ class TestOutput(unittest.TestCase):
                 "options": {},
                 "solution": {"empanadas": "are_life"},
                 "statistics": {"foo": "bar"},
+                "assets": [],
             }
 
             self.assertDictEqual(got, expected)
@@ -248,6 +253,7 @@ class TestOutput(unittest.TestCase):
                     "solver": "highs",
                 },
                 "statistics": {"foo": "bar"},
+                "assets": [],
             }
 
             self.assertDictEqual(stdout_got, stdout_expected)
@@ -301,6 +307,100 @@ class TestOutput(unittest.TestCase):
                 "options": {},
                 "solution": {},
                 "statistics": {},
+                "assets": [],
+            }
+
+            self.assertDictEqual(got, expected)
+
+    def test_local_write_valid_assets_from_class(self):
+        output = nextmv.Output(
+            assets=[
+                nextmv.Asset(
+                    name="foo",
+                    content={"foo": "bar"},
+                    content_type="json",
+                    description="A foo asset.",
+                    visual=nextmv.Visual(
+                        schema=nextmv.VisualSchema.CHARTJS,
+                        label="A chart",
+                        visual_type="custom-tab",
+                    ),
+                ),
+                nextmv.Asset(
+                    name="bar",
+                    content={"bar": "baz"},
+                    content_type="json",
+                    description="A bar asset.",
+                ),
+            ],
+        )
+
+        output_writer = nextmv.LocalOutputWriter()
+
+        with patch("sys.stdout", new=StringIO()) as mock_stdout:
+            output_writer.write(output, skip_stdout_reset=True)
+
+            got = json.loads(mock_stdout.getvalue())
+            expected = {
+                "options": {},
+                "solution": {},
+                "statistics": {},
+                "assets": [
+                    {
+                        "content": {"foo": "bar"},
+                        "content_type": "json",
+                        "description": "A foo asset.",
+                        "name": "foo",
+                        "visual": {
+                            "label": "A chart",
+                            "schema": "chartjs",
+                            "type": "custom-tab",
+                        },
+                    },
+                    {
+                        "content": {"bar": "baz"},
+                        "content_type": "json",
+                        "description": "A bar asset.",
+                        "name": "bar",
+                    },
+                ],
+            }
+
+            self.assertDictEqual(got, expected)
+
+    def test_local_write_valid_assets_from_dict(self):
+        assets = [
+            {
+                "name": "foo",
+                "content": {"foo": "bar"},
+                "content_type": "json",
+                "description": "A foo asset.",
+                "visual": {
+                    "schema": "chartjs",
+                    "label": "A chart",
+                    "visual_type": "custom-tab",
+                },
+            },
+            {
+                "name": "bar",
+                "content": {"bar": "baz"},
+                "content_type": "json",
+                "description": "A bar asset.",
+            },
+        ]
+        output = nextmv.Output(assets=assets)
+
+        output_writer = nextmv.LocalOutputWriter()
+
+        with patch("sys.stdout", new=StringIO()) as mock_stdout:
+            output_writer.write(output, skip_stdout_reset=True)
+
+            got = json.loads(mock_stdout.getvalue())
+            expected = {
+                "options": {},
+                "solution": {},
+                "statistics": {},
+                "assets": assets,
             }
 
             self.assertDictEqual(got, expected)


### PR DESCRIPTION
# Description

- This PR introduces a fix where, if the output is a `dict`, then it is simply piped through and written as `JSON`. When writing an output, if it is of type `Output`, then the schema will be enforced (which guarantees that `options`, `solution`, `statistics`, and `assets` are being written). 
- Support for `assets` in the output schema is introduced as well.

