### PR TITLE
Adjust Pydantic serialization to fix `.push` command

### DIFF
--- a/nextmv/nextmv/__about__.py
+++ b/nextmv/nextmv/__about__.py
@@ -1,1 +1,1 @@
-__version__ = "v0.17.2"
+__version__ = "v0.18.0.dev0"

--- a/nextmv/nextmv/__about__.py
+++ b/nextmv/nextmv/__about__.py
@@ -1,1 +1,1 @@
-__version__ = "v0.18.0.dev0"
+__version__ = "v0.18.0.dev1"

--- a/nextmv/nextmv/cloud/manifest.py
+++ b/nextmv/nextmv/cloud/manifest.py
@@ -5,7 +5,7 @@ from enum import Enum
 from typing import Any, Optional
 
 import yaml
-from pydantic import Field
+from pydantic import AliasChoices, Field
 
 from nextmv.base_model import BaseModel
 from nextmv.model import _REQUIREMENTS_FILE, ModelConfiguration
@@ -97,7 +97,11 @@ class ManifestPythonModel(BaseModel):
 class ManifestPython(BaseModel):
     """Python-specific instructions."""
 
-    pip_requirements: Optional[str] = Field(serialization_alias="pip-requirements", default=None)
+    pip_requirements: Optional[str] = Field(
+        serialization_alias="pip-requirements",
+        validation_alias=AliasChoices("pip-requirements", "pip_requirements"),
+        default=None,
+    )
     """
     Path to a requirements.txt file containing (additional) Python
     dependencies that will be bundled with the app.
@@ -138,7 +142,11 @@ class Manifest(BaseModel):
     command. The build.environment is used to set environment variables when
     running the build command given as key-value pairs.
     """
-    pre_push: Optional[str] = Field(serialization_alias="pre-push", default=None)
+    pre_push: Optional[str] = Field(
+        serialization_alias="pre-push",
+        validation_alias=AliasChoices("pre-push", "pre_push"),
+        default=None,
+    )
     """
     Optional. A command to run before the app is pushed to the Nextmv Cloud.
     This command can be used to compile a binary, run tests or similar tasks.

--- a/nextmv/nextmv/model.py
+++ b/nextmv/nextmv/model.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import shutil
+import warnings
 from dataclasses import dataclass
 from typing import Any, Optional
 
@@ -8,6 +9,19 @@ from nextmv.input import Input
 from nextmv.logger import log
 from nextmv.options import Options
 from nextmv.output import Output
+
+# Disable warnings from mlflow that are not relevant to the user:
+# .../site-packages/mlflow/pyfunc/utils/data_validation.py:134: UserWarning: Add type hints to the `predict` method to enable data validation and automatic signature inference during model logging. Check https://mlflow.org/docs/latest/model/python_model.html#type-hint-usage-in-pythonmodel for more details.
+original_showwarning = warnings.showwarning
+
+
+def custom_showwarning(message, category, filename, lineno, file=None, line=None):
+    if "mlflow/pyfunc/utils/data_validation.py" in filename:
+        return
+    original_showwarning(message, category, filename, lineno, file, line)
+
+
+warnings.showwarning = custom_showwarning
 
 # When working with the `Model`, we expect to be working in a notebook
 # environment, and not interact with the local filesystem a lot. We use the
@@ -104,7 +118,7 @@ class Model:
 
         raise NotImplementedError
 
-    def save(self, model_dir: str, configuration: ModelConfiguration) -> None:
+    def save(model_self, model_dir: str, configuration: ModelConfiguration) -> None:
         """
         Save the model to the local filesystem, in the location given by `dir`.
         The model is saved according to the configuration provided, which is of
@@ -144,7 +158,12 @@ class Model:
             `DecisionModel`.
             """
 
-            def predict(mlflow_self, context, model_input, params=None) -> Any:
+            def predict(
+                self,
+                context,
+                model_input,
+                params: dict[str, Any] | None = None,
+            ) -> Any:
                 """
                 The predict method allows us to work with mlflow’s [python_function]
                 model flavor. Warning: This method should not be used or overridden
@@ -153,7 +172,7 @@ class Model:
                 [python_function]: https://mlflow.org/docs/latest/python_api/mlflow.pyfunc.html
                 """
 
-                return self.solve(model_input)
+                return model_self.solve(model_input)
 
         # Some annoying logging from mlflow must be disabled.
         logging.disable(logging.CRITICAL)
@@ -176,8 +195,6 @@ class Model:
             python_model=MLFlowModel(),
             signature=signature,  # Allows us to work with our own `Options` class.
         )
-
-        logging.disable(logging.NOTSET)
 
         # Create an auxiliary requirements file with the model dependencies.
         requirements_file = os.path.join(model_dir, _REQUIREMENTS_FILE)

--- a/nextmv/nextmv/model.py
+++ b/nextmv/nextmv/model.py
@@ -11,7 +11,11 @@ from nextmv.options import Options
 from nextmv.output import Output
 
 # Disable warnings from mlflow that are not relevant to the user:
-# .../site-packages/mlflow/pyfunc/utils/data_validation.py:134: UserWarning: Add type hints to the `predict` method to enable data validation and automatic signature inference during model logging. Check https://mlflow.org/docs/latest/model/python_model.html#type-hint-usage-in-pythonmodel for more details.
+# .../site-packages/mlflow/pyfunc/utils/data_validation.py:134: UserWarning:Add
+# type hints to the `predict` method to enable data validation and automatic
+# signature inference during model logging. Check
+# https://mlflow.org/docs/latest/model/python_model.html#type-hint-usage-in-pythonmodel
+# for more details.
 original_showwarning = warnings.showwarning
 
 

--- a/nextmv/nextmv/model.py
+++ b/nextmv/nextmv/model.py
@@ -10,18 +10,29 @@ from nextmv.logger import log
 from nextmv.options import Options
 from nextmv.output import Output
 
-# Disable warnings from mlflow that are not relevant to the user:
-# .../site-packages/mlflow/pyfunc/utils/data_validation.py:134: UserWarning:Add
-# type hints to the `predict` method to enable data validation and automatic
-# signature inference during model logging. Check
-# https://mlflow.org/docs/latest/model/python_model.html#type-hint-usage-in-pythonmodel
-# for more details.
+# The following block of code is used to suppress warnings from mlflow. We
+# suppress these warnings because they are not relevant to the user, and they
+# are not actionable.
 original_showwarning = warnings.showwarning
 
 
 def custom_showwarning(message, category, filename, lineno, file=None, line=None):
+    # .../site-packages/mlflow/pyfunc/utils/data_validation.py:134: UserWarning:Add
+    # type hints to the `predict` method to enable data validation and automatic
+    # signature inference during model logging. Check
+    # https://mlflow.org/docs/latest/model/python_model.html#type-hint-usage-in-pythonmodel
+    # for more details.
     if "mlflow/pyfunc/utils/data_validation.py" in filename:
         return
+
+    # .../site-packages/mlflow/pyfunc/__init__.py:3212: UserWarning: An input
+    # example was not provided when logging the model. To ensure the model
+    # signature functions correctly, specify the `input_example` parameter. See
+    # https://mlflow.org/docs/latest/model/signatures.html#model-input-example
+    # for more details about the benefits of using input_example.
+    if "mlflow/pyfunc/__init__.py" in filename:
+        return
+
     original_showwarning(message, category, filename, lineno, file, line)
 
 

--- a/nextmv/nextmv/model.py
+++ b/nextmv/nextmv/model.py
@@ -166,7 +166,7 @@ class Model:
                 self,
                 context,
                 model_input,
-                params: dict[str, Any] | None = None,
+                params: Optional[dict[str, Any]] = None,
             ) -> Any:
                 """
                 The predict method allows us to work with mlflow’s [python_function]

--- a/nextmv/nextmv/output.py
+++ b/nextmv/nextmv/output.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Optional, Union
 
-from pydantic import Field
+from pydantic import AliasChoices, Field
 
 from nextmv.base_model import BaseModel
 from nextmv.logger import reset_stdout
@@ -151,7 +151,11 @@ class Statistics(BaseModel):
     """Statistics about the last result."""
     series_data: Optional[SeriesData] = None
     """Data of the series."""
-    statistics_schema: Optional[str] = Field(serialization_alias="schema", default="v1")
+    statistics_schema: Optional[str] = Field(
+        serialization_alias="schema",
+        validation_alias=AliasChoices("schema", "statistics_schema"),
+        default="v1",
+    )
     """Schema (version). This class only supports `v1`."""
 
 
@@ -184,12 +188,19 @@ class Visual(BaseModel):
     Console.
     """
 
-    visual_schema: VisualSchema = Field(serialization_alias="schema")
+    visual_schema: VisualSchema = Field(
+        serialization_alias="schema",
+        validation_alias=AliasChoices("schema", "visual_schema"),
+    )
     """Schema of the visual asset."""
     label: str
     """Label for the custom tab of the visual asset in the Nextmv Console."""
 
-    visual_type: Optional[str] = Field(serialization_alias="type", default="custom-tab")
+    visual_type: Optional[str] = Field(
+        serialization_alias="type",
+        validation_alias=AliasChoices("type", "visual_type"),
+        default="custom-tab",
+    )
     """Defines the type of custom visual, currently there is only one type:
     `custom-tab`. This renders the visual in its own tab view of the run
     details."""

--- a/nextmv/tests/cloud/app.yaml
+++ b/nextmv/tests/cloud/app.yaml
@@ -1,0 +1,22 @@
+files:
+  - main.py
+  - super_cool_model/**
+python:
+  model:
+    name: super_cool_model
+    options:
+      - choices: null
+        default: 30
+        description: Max runtime duration (in seconds).
+        name: duration
+        param_type: <class 'int'>
+        required: false
+  pip-requirements: model_requirements.txt
+runtime: ghcr.io/nextmv-io/runtime/python:3.11
+type: python
+pre-push: echo 'hello world - pre-push'
+build:
+  command: echo 'hello world - build'
+  environment:
+    SUPER: COOL
+    EXTRA: AWESOME

--- a/nextmv/tests/cloud/test_manifest.py
+++ b/nextmv/tests/cloud/test_manifest.py
@@ -38,3 +38,65 @@ class TestManifest(unittest.TestCase):
             }
         )
         self.assertEqual(manifest.python, manifest_python)
+        self.assertEqual(manifest_python.pip_requirements, "model_requirements.txt")
+
+    def test_manifest_python_from_dict(self):
+        manifest_python_dict = {
+            "pip-requirements": "foo_requirements.txt",
+            "model": {
+                "name": "foo_model",
+            },
+        }
+
+        manifest_python = ManifestPython.from_dict(manifest_python_dict)
+
+        self.assertEqual(manifest_python.pip_requirements, "foo_requirements.txt")
+        self.assertEqual(manifest_python.model.name, "foo_model")
+
+    def test_manifest_python_direct_instantiation(self):
+        manifest_python = ManifestPython(
+            pip_requirements="foo_requirements.txt",
+            model={"name": "foo_model"},
+        )
+
+        self.assertEqual(manifest_python.pip_requirements, "foo_requirements.txt")
+        self.assertEqual(manifest_python.model.name, "foo_model")
+
+    def test_manifest_from_yaml(self):
+        manifest = Manifest.from_yaml("tests/cloud")
+
+        self.assertListEqual(
+            manifest.files,
+            ["main.py", "super_cool_model/**"],
+        )
+
+        self.assertEqual(manifest.runtime, ManifestRuntime.PYTHON)
+
+        self.assertEqual(manifest.type, ManifestType.PYTHON)
+
+        self.assertEqual(manifest.python.pip_requirements, "model_requirements.txt")
+        self.assertEqual(manifest.python.model.name, "super_cool_model")
+        self.assertListEqual(
+            manifest.python.model.options,
+            [
+                {
+                    "choices": None,
+                    "default": 30,
+                    "description": "Max runtime duration (in seconds).",
+                    "name": "duration",
+                    "param_type": "<class 'int'>",
+                    "required": False,
+                },
+            ],
+        )
+
+        self.assertEqual(manifest.pre_push, "echo 'hello world - pre-push'")
+
+        self.assertEqual(manifest.build.command, "echo 'hello world - build'")
+        self.assertDictEqual(
+            manifest.build.environment,
+            {
+                "SUPER": "COOL",
+                "EXTRA": "AWESOME",
+            },
+        )

--- a/nextmv/tests/test_output.py
+++ b/nextmv/tests/test_output.py
@@ -404,3 +404,69 @@ class TestOutput(unittest.TestCase):
             }
 
             self.assertDictEqual(got, expected)
+
+    def test_visual_from_dict(self):
+        visual_dict = {
+            "schema": "chartjs",
+            "label": "A chart",
+            "type": "custom-tab",
+        }
+
+        visual = nextmv.Visual.from_dict(visual_dict)
+
+        self.assertEqual(visual.visual_schema, nextmv.VisualSchema.CHARTJS)
+        self.assertEqual(visual.label, "A chart")
+        self.assertEqual(visual.visual_type, "custom-tab")
+
+    def test_visual_from_dict_2(self):
+        visual_dict = {
+            "visual_schema": "chartjs",
+            "label": "A chart",
+            "visual_type": "custom-tab",
+        }
+
+        visual = nextmv.Visual.from_dict(visual_dict)
+
+        self.assertEqual(visual.visual_schema, nextmv.VisualSchema.CHARTJS)
+        self.assertEqual(visual.label, "A chart")
+        self.assertEqual(visual.visual_type, "custom-tab")
+
+    def test_visual_direct_instantiation(self):
+        visual = nextmv.Visual(
+            visual_schema=nextmv.VisualSchema.CHARTJS,
+            label="A chart",
+            visual_type="custom-tab",
+        )
+
+        self.assertEqual(visual.visual_schema, nextmv.VisualSchema.CHARTJS)
+        self.assertEqual(visual.label, "A chart")
+        self.assertEqual(visual.visual_type, "custom-tab")
+
+    def test_visual_direct_instantiation_2(self):
+        visual = nextmv.Visual(
+            schema=nextmv.VisualSchema.CHARTJS,
+            label="A chart",
+            type="custom-tab",
+        )
+
+        self.assertEqual(visual.visual_schema, nextmv.VisualSchema.CHARTJS)
+        self.assertEqual(visual.label, "A chart")
+        self.assertEqual(visual.visual_type, "custom-tab")
+
+    def test_visual_to_dict(self):
+        visual = nextmv.Visual(
+            visual_schema=nextmv.VisualSchema.CHARTJS,
+            label="A chart",
+            visual_type="custom-tab",
+        )
+
+        visual_dict = visual.to_dict()
+
+        self.assertDictEqual(
+            visual_dict,
+            {
+                "schema": "chartjs",
+                "label": "A chart",
+                "type": "custom-tab",
+            },
+        )


### PR DESCRIPTION
# Description

Fixes the use of `application.push` as there was a bug with the manifest. It had to do with Pydantic, and the way it handles field aliases. The bug is that we didn’t use `AliasChoice`.

Suppress some warnings coming out of `mlflow` that we don’t need the user to understand.