### PR TITLE
Add functionality to track a run (use external runs)

### DIFF
--- a/nextmv/nextmv/cloud/__init__.py
+++ b/nextmv/nextmv/cloud/__init__.py
@@ -48,6 +48,8 @@ from .run import RunLog as RunLog
 from .run import RunResult as RunResult
 from .run import RunType as RunType
 from .run import RunTypeConfiguration as RunTypeConfiguration
+from .run import TrackedRun as TrackedRun
+from .run import TrackedRunStatus as TrackedRunStatus
 from .secrets import Secret as Secret
 from .secrets import SecretsCollection as SecretsCollection
 from .secrets import SecretsCollectionSummary as SecretsCollectionSummary

--- a/nextmv/nextmv/cloud/application.py
+++ b/nextmv/nextmv/cloud/application.py
@@ -18,12 +18,14 @@ from nextmv.cloud.client import Client, get_size
 from nextmv.cloud.input_set import InputSet
 from nextmv.cloud.instance import Instance, InstanceConfiguration
 from nextmv.cloud.manifest import Manifest
-from nextmv.cloud.run import ExternalRunResult, RunConfiguration, RunInformation, RunLog, RunResult
+from nextmv.cloud.run import ExternalRunResult, RunConfiguration, RunInformation, RunLog, RunResult, TrackedRun
 from nextmv.cloud.secrets import Secret, SecretsCollection, SecretsCollectionSummary
 from nextmv.cloud.status import StatusV2
 from nextmv.cloud.version import Version
+from nextmv.input import Input
 from nextmv.logger import log
 from nextmv.model import Model, ModelConfiguration
+from nextmv.output import Output
 
 _MAX_RUN_SIZE: int = 5 * 1024 * 1024
 """Maximum size of the run input/output. This value is used to determine
@@ -1283,6 +1285,107 @@ class Application:
         run_information = poll(polling_options=polling_options, polling_func=polling_func)
 
         return self.__run_result(run_id=run_id, run_information=run_information)
+
+    def track_run(self, tracked_run: TrackedRun) -> str:
+        """
+        Track an external run.
+
+        This method allows you to register in Nextmv a run that happened
+        elsewhere, as though it were executed in the Nextmv platform. Having
+        information about a run in Nextmv is useful for things like
+        experimenting and testing.
+
+        Parameters
+        ----------
+        tracked_run : TrackedRun
+            The run to track.
+
+        Returns
+        -------
+        str
+            The ID of the run that was tracked.
+
+        Raises
+        ------
+        requests.HTTPError
+            If the response status code is not 2xx.
+        ValueError
+            If the tracked run does not have an input or output.
+        """
+        url_input = self.upload_url()
+
+        upload_input = tracked_run.input
+        if isinstance(tracked_run.input, Input):
+            upload_input = tracked_run.input.to_dict()
+
+        self.upload_large_input(input=upload_input, upload_url=url_input)
+
+        url_output = self.upload_url()
+
+        upload_output = tracked_run.output
+        if isinstance(tracked_run.output, Output):
+            upload_output = tracked_run.output.to_dict()
+
+        self.upload_large_input(input=upload_output, upload_url=url_output)
+
+        external_result = ExternalRunResult(
+            output_upload_id=url_output.upload_id,
+            status=tracked_run.status.value,
+            execution_duration=tracked_run.duration,
+        )
+
+        if tracked_run.logs is not None:
+            url_stderr = self.upload_url()
+            self.upload_large_input(input=tracked_run.logs_text(), upload_url=url_stderr)
+            external_result.error_upload_id = url_stderr.upload_id
+
+        if tracked_run.error is not None and tracked_run.error != "":
+            external_result.error_message = tracked_run.error
+
+        return self.new_run(upload_id=url_input.upload_id, external_result=external_result)
+
+    def track_run_with_result(
+        self,
+        tracked_run: TrackedRun,
+        polling_options: PollingOptions = _DEFAULT_POLLING_OPTIONS,
+    ) -> RunResult:
+        """
+        Track an external run and poll for the result. This is a convenience
+        method that combines the `track_run` and `run_result_with_polling`
+        methods. It applies polling logic to check when the run was
+        successfully registered.
+
+        Parameters
+        ----------
+        tracked_run : TrackedRun
+            The run to track.
+        polling_options : PollingOptions
+            Options to use when polling for the run result.
+
+        Returns
+        -------
+        RunResult
+            Result of the run.
+
+        Raises
+        ------
+        requests.HTTPError
+            If the response status code is not 2xx.
+        ValueError
+            If the tracked run does not have an input or output.
+        TimeoutError
+            If the run does not succeed after the polling strategy is
+            exhausted based on time duration.
+        RuntimeError
+            If the run does not succeed after the polling strategy is
+            exhausted based on number of tries.
+        """
+        run_id = self.track_run(tracked_run=tracked_run)
+
+        return self.run_result_with_polling(
+            run_id=run_id,
+            polling_options=polling_options,
+        )
 
     def update_instance(
         self,

--- a/nextmv/nextmv/cloud/application.py
+++ b/nextmv/nextmv/cloud/application.py
@@ -737,8 +737,8 @@ class Application:
     def new_instance(
         self,
         version_id: str,
-        id: Optional[str] = None,
-        name: Optional[str] = None,
+        id: str,
+        name: str,
         description: Optional[str] = None,
         configuration: Optional[InstanceConfiguration] = None,
     ) -> Instance:
@@ -936,8 +936,8 @@ class Application:
     def new_secrets_collection(
         self,
         secrets: list[Secret],
-        id: Optional[str] = None,
-        name: Optional[str] = None,
+        id: str,
+        name: str,
         description: Optional[str] = None,
     ) -> SecretsCollectionSummary:
         """
@@ -1437,7 +1437,7 @@ class Application:
         name: str,
         description: str,
         secrets: list[Secret],
-    ) -> SecretsCollection:
+    ) -> SecretsCollectionSummary:
         """
         Update a secrets collection.
 

--- a/nextmv/nextmv/cloud/run.py
+++ b/nextmv/nextmv/cloud/run.py
@@ -1,14 +1,17 @@
 """This module contains definitions for an app run."""
 
+import json
+from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
-from typing import Any, Optional
+from typing import Any, Optional, Union
 
 from pydantic import AliasChoices, Field
 
 from nextmv.base_model import BaseModel
 from nextmv.cloud.status import Status, StatusV2
-from nextmv.input import InputFormat
+from nextmv.input import Input, InputFormat
+from nextmv.output import Output, OutputFormat
 
 
 class Metadata(BaseModel):
@@ -159,3 +162,114 @@ class ExternalRunResult(BaseModel):
         valid_statuses = {"succeeded", "failed"}
         if self.status is not None and self.status not in valid_statuses:
             raise ValueError("Invalid status value, must be one of: " + ", ".join(valid_statuses))
+
+
+class TrackedRunStatus(str, Enum):
+    """
+    The status of a tracked run.
+
+    Attributes
+    ----------
+    SUCCEEDED : str
+        The run succeeded.
+    FAILED : str
+        The run failed.
+    """
+
+    SUCCEEDED = "succeeded"
+    """The run succeeded."""
+    FAILED = "failed"
+    """The run failed."""
+
+
+@dataclass
+class TrackedRun:
+    """
+    An external run that is tracked in the Nextmv platform.
+
+    Attributes
+    ----------
+    input : Union[Input, dict[str, any], str]
+        The input of the run being tracked. Please note that if the input
+        format is JSON, then the input data must be JSON serializable. This
+        field is required.
+    output : Union[Output, dict[str, any], str]
+        The output of the run being tracked. Please note that if the output
+        format is JSON, then the output data must be JSON serializable. This
+        field is required.
+    status : TrackedRunStatus
+        The status of the run being tracked. This field is required.
+    duration : Optional[int]
+        The duration of the run being tracked, in seconds. This field is
+        optional.
+    error : Optional[str]
+        An error message if the run failed. You should only specify this if the
+        run failed (the `status` is `TrackedRunStatus.FAILED`), otherwise an
+        exception will be raised. This field is optional.
+    logs : Optional[list[str]]
+        The logs of the run being tracked. Each element of the list is a line in
+        the log. This field is optional.
+    """
+
+    input: Union[Input, dict[str, any], str]
+    """The input of the run being tracked."""
+    output: Union[Output, dict[str, any], str]
+    """The output of the run being tracked. Only JSON output_format is supported."""
+    status: TrackedRunStatus
+    """The status of the run being tracked"""
+
+    duration: Optional[int] = None
+    """The duration of the run being tracked, in seconds."""
+    error: Optional[str] = None
+    """An error message if the run failed. You should only specify this if the
+    run failed, otherwise an exception will be raised."""
+    logs: Optional[list[str]] = None
+    """The logs of the run being tracked. Each element of the list is a line in
+    the log."""
+
+    def __post_init__(self):  # noqa: C901
+        """Validations done after parsing the model."""
+
+        valid_statuses = {TrackedRunStatus.SUCCEEDED, TrackedRunStatus.FAILED}
+        if self.status not in valid_statuses:
+            raise ValueError("Invalid status value, must be one of: " + ", ".join(valid_statuses))
+
+        if self.error is not None and self.error != "" and self.status != TrackedRunStatus.FAILED:
+            raise ValueError("Error message must be empty if the run succeeded.")
+
+        if isinstance(self.input, Input):
+            if self.input.input_format != InputFormat.JSON:
+                raise ValueError("Input.input_format must be JSON.")
+        elif isinstance(self.input, dict):
+            try:
+                _ = json.dumps(self.input)
+            except (TypeError, OverflowError) as e:
+                raise ValueError("Input is dict[str, any] but it is not JSON serializable") from e
+
+        if isinstance(self.output, Output):
+            if self.output.output_format != OutputFormat.JSON:
+                raise ValueError("Output.output_format must be JSON.")
+        elif isinstance(self.output, dict):
+            try:
+                _ = json.dumps(self.output)
+            except (TypeError, OverflowError) as e:
+                raise ValueError("Output is dict[str, any] but it is not JSON serializable") from e
+
+    def logs_text(self) -> str:
+        """
+        Returns the logs as a single string.
+
+        Parameters
+        ----------
+        None
+
+        Returns
+        -------
+        str
+            The logs as a single string.
+        """
+
+        if self.logs is None:
+            return ""
+
+        return "\n".join(self.logs)

--- a/nextmv/nextmv/input.py
+++ b/nextmv/nextmv/input.py
@@ -91,6 +91,26 @@ class Input:
         new_options = copy.deepcopy(init_options)
         self.options = new_options
 
+    def to_dict(self) -> dict[str, any]:
+        """
+        Convert the input to a dictionary.
+
+        Parameters
+        ----------
+        None
+
+        Returns
+        -------
+        dict[str, any]
+            The input as a dictionary.
+        """
+
+        return {
+            "data": self.data,
+            "input_format": self.input_format.value,
+            "options": self.options.to_dict() if self.options is not None else None,
+        }
+
 
 class InputLoader:
     """Base class for loading inputs."""

--- a/nextmv/nextmv/output.py
+++ b/nextmv/nextmv/output.py
@@ -337,7 +337,6 @@ class Output:
             "output_format": self.output_format,
             "solution": self.solution,
             "statistics": self.statistics.to_dict() if self.statistics is not None else None,
-            "csv_configurations": self.csv_configurations,
             "assets": [asset.to_dict() for asset in self.assets] if self.assets is not None else None,
         }
 

--- a/nextmv/nextmv/output.py
+++ b/nextmv/nextmv/output.py
@@ -322,6 +322,30 @@ class Output:
                 "output_format OutputFormat.CSV_ARCHIVE, supported type is `dict`"
             )
 
+    def to_dict(self) -> dict[str, any]:
+        """
+        Convert the `Output` object to a dictionary.
+
+        Returns
+        -------
+        dict[str, any]
+            The dictionary representation of the `Output` object.
+        """
+
+        output_dict = {
+            "options": self.options.to_dict() if self.options is not None else None,
+            "output_format": self.output_format,
+            "solution": self.solution,
+            "statistics": self.statistics.to_dict() if self.statistics is not None else None,
+            "csv_configurations": self.csv_configurations,
+            "assets": [asset.to_dict() for asset in self.assets] if self.assets is not None else None,
+        }
+
+        if self.output_format == OutputFormat.CSV_ARCHIVE:
+            output_dict["csv_configurations"] = self.csv_configurations
+
+        return output_dict
+
 
 class OutputWriter:
     """Base class for writing outputs."""


### PR DESCRIPTION
# Description

Adds two new methods to the `cloud.Application`:
* `track_run`: tracks a new run (convenience function for registering an external run).
* `track_run_with_result`: calls track a new run but executed polling (which should be almost immediate).

For this, a new `TrackedRun` class is introduced. The original API design for `external_runs` is still there, and this is just a convenient method that combines uploading a large input and obtaining the `upload_id` to be able to track the external run.