### PR TITLE
Adds support for exist_ok on new app

### DIFF
--- a/nextmv/nextmv/cloud/application.py
+++ b/nextmv/nextmv/cloud/application.py
@@ -443,6 +443,7 @@ class Application:
         id: Optional[str] = None,
         description: Optional[str] = None,
         is_workflow: Optional[bool] = None,
+        exist_ok: bool = False,
     ) -> "Application":
         """
         Create a new application.
@@ -457,6 +458,9 @@ class Application:
         Returns:
             The new application.
         """
+
+        if cls.exists(client=client, id=id) and exist_ok:
+            return Application(client=client, id=id)
 
         payload = {
             "name": name,


### PR DESCRIPTION
# Description

Allows simply returning the app when attempting to create a new one if it already exists.

## Changes

* Adds support for `exist_ok=true` on `Application.new(...)` to allow returning the existing app instead of failing to create a new one.