### PR TITLE
Improves order of checking whether app exists

### DIFF
--- a/nextmv/nextmv/cloud/application.py
+++ b/nextmv/nextmv/cloud/application.py
@@ -459,7 +459,7 @@ class Application:
             The new application.
         """
 
-        if cls.exists(client=client, id=id) and exist_ok:
+        if exist_ok and cls.exists(client=client, id=id):
             return Application(client=client, id=id)
 
         payload = {


### PR DESCRIPTION
# Description

A small miss on #77: the order of checking was inefficient. This PR addresses that.

## Changes

* Only checks whether application exists on creating a new one if `exist_ok=true` is given.