### PR TITLE
Add `nextmv.Option` and deprecate `nextmv.Parameter`

### DIFF
--- a/nextmv/nextmv/__entrypoint__.py
+++ b/nextmv/nextmv/__entrypoint__.py
@@ -22,9 +22,9 @@ def main() -> None:
 
     # Load the options from the manifest.
     options = None
-    parameters_dict = manifest.python.model.options
-    if parameters_dict is not None:
-        options = Options.from_parameters_dict(parameters_dict)
+    options_dict = manifest.python.model.options
+    if options_dict is not None:
+        options = Options.from_options_dict(options_dict)
 
     # Load the model.
     loaded_model = load_model(

--- a/nextmv/nextmv/__init__.py
+++ b/nextmv/nextmv/__init__.py
@@ -12,6 +12,7 @@ from .logger import redirect_stdout as redirect_stdout
 from .logger import reset_stdout as reset_stdout
 from .model import Model as Model
 from .model import ModelConfiguration as ModelConfiguration
+from .options import Option as Option
 from .options import Options as Options
 from .options import Parameter as Parameter
 from .output import Asset as Asset

--- a/nextmv/nextmv/cloud/application.py
+++ b/nextmv/nextmv/cloud/application.py
@@ -1201,12 +1201,12 @@ class Application:
 
 
         # Define the options that the model needs.
-        parameters = []
+        opt = []
         default_options = nextroute.Options()
         for name, default_value in default_options.to_dict().items():
-            parameters.append(nextmv.Parameter(name.lower(), type(default_value), default_value, name, False))
+            opt.append(nextmv.Option(name.lower(), type(default_value), default_value, name, False))
 
-        options = nextmv.Options(*parameters)
+        options = nextmv.Options(*opt)
 
         # Instantiate the model and model configuration.
         model = DecisionModel()

--- a/nextmv/nextmv/cloud/manifest.py
+++ b/nextmv/nextmv/cloud/manifest.py
@@ -89,7 +89,7 @@ class ManifestPythonModel(BaseModel):
     """
     Options for the decision model. This is a data representation of the
     `nextmv.Options` class. It consists of a list of dicts. Each dict
-    represents the `nextmv.Parameter` class. It is used to be able to
+    represents the `nextmv.Option` class. It is used to be able to
     reconstruct an Options object from data when loading a decision model.
     """
 

--- a/nextmv/nextmv/cloud/manifest.py
+++ b/nextmv/nextmv/cloud/manifest.py
@@ -222,7 +222,7 @@ class Manifest(BaseModel):
         }
 
         if model_configuration.options is not None:
-            manifest_python_dict["model"]["options"] = model_configuration.options.parameters_dict()
+            manifest_python_dict["model"]["options"] = model_configuration.options.options_dict()
 
         manifest_python = ManifestPython.from_dict(manifest_python_dict)
 

--- a/nextmv/nextmv/deprecated.py
+++ b/nextmv/nextmv/deprecated.py
@@ -5,5 +5,9 @@ def deprecated(name: str, reason: str):
     """A very simple functon to mark something as deprecated."""
 
     warnings.simplefilter("always", DeprecationWarning)
-    warnings.warn(f"{name}: {reason}", category=DeprecationWarning, stacklevel=2)
+    warnings.warn(
+        f"{name}: {reason}. This functionality will be removed in a future release",
+        category=DeprecationWarning,
+        stacklevel=2,
+    )
     warnings.simplefilter("default", DeprecationWarning)

--- a/nextmv/nextmv/deprecated.py
+++ b/nextmv/nextmv/deprecated.py
@@ -1,0 +1,9 @@
+import warnings
+
+
+def deprecated(name: str, reason: str):
+    """A very simple functon to mark something as deprecated."""
+
+    warnings.simplefilter("always", DeprecationWarning)
+    warnings.warn(f"{name}: {reason}", category=DeprecationWarning, stacklevel=2)
+    warnings.simplefilter("default", DeprecationWarning)

--- a/nextmv/nextmv/options.py
+++ b/nextmv/nextmv/options.py
@@ -6,14 +6,19 @@ import copy
 import json
 import os
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import Any, Optional, Union
 
 from nextmv.base_model import BaseModel
+from nextmv.deprecated import deprecated
 
 
 @dataclass
 class Parameter:
     """
+    DEPRECATION WARNING
+    ----------
+    `Parameter` is deprecated, use `Option` instead.
+
     Parameter that is used in a `Configuration`. When a parameter is required,
     it is a good practice to provide a default value for it. This is because
     the configuration will raise an error if a required parameter is not
@@ -58,9 +63,20 @@ class Parameter:
     choices: list[Optional[Any]] = None
     """Limits values to a specific set of choices."""
 
+    def __post_init__(self):
+        deprecated(
+            name="Parameter",
+            reason="`Parameter` is deprecated, use `Option` instead.",
+        )
+
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "Parameter":
         """
+        DEPRECATION WARNING
+        ----------
+        `Parameter` is deprecated, use `Option` instead. Parameter.from_dict ->
+        Option.from_dict
+
         Creates an instance of `Parameter` from a dictionary.
 
         Parameters
@@ -73,6 +89,11 @@ class Parameter:
         Parameter
             An instance of `Parameter`.
         """
+
+        deprecated(
+            name="Parameter.from_dict",
+            reason="`Parameter` is deprecated, use `Option` instead. Parameter.from_dict -> Option.from_dict",
+        )
 
         param_type_string = data["param_type"]
         param_type = getattr(builtins, param_type_string.split("'")[1])
@@ -88,6 +109,11 @@ class Parameter:
 
     def to_dict(self) -> dict[str, Any]:
         """
+        DEPRECATION WARNING
+        ----------
+        `Parameter` is deprecated, use `Option` instead. Parameter.to_dict ->
+        Option.to_dict
+
         Converts the parameter to a dict.
 
         Returns
@@ -95,6 +121,11 @@ class Parameter:
         dict[str, Any]
             The parameter as a dict.
         """
+
+        deprecated(
+            name="Parameter.to_dict",
+            reason="`Parameter` is deprecated, use `Option` instead. Parameter.to_dict -> Option.to_dict",
+        )
 
         return {
             "name": self.name,
@@ -106,19 +137,120 @@ class Parameter:
         }
 
 
+@dataclass
+class Option:
+    """
+    `Option` that is used in `Options`. When an `Option` is required,
+    it is a good practice to provide a default value for it. This is because
+    the `Options` will raise an error if a required `Option` is not
+    provided through a command-line argument, an environment variable or a
+    default value.
+
+    Attributes
+    ----------
+    name : str
+        The name of the option.
+    option_type : type
+        The type of the option.
+    default : Any, optional
+        The default value of the option. Even though this is optional, it is
+        recommended to provide a default value for all options.
+    description : str, optional
+        An optional description of the option. This is useful for generating
+        help messages for the `Options`.
+    required : bool, optional
+        Whether the option is required. If an option is required, it will
+        be an error to not provide a value for it, either trough a command-line
+        argument, an environment variable or a default value.
+    choices : list[Optional[Any]], optional
+        Limits values to a specific set of choices.
+    """
+
+    name: str
+    """The name of the option."""
+    option_type: type
+    """The type of the option."""
+
+    default: Optional[Any] = None
+    """
+    The default value of the option. Even though this is optional, it is
+    recommended to provide a default value for all options.
+    """
+    description: Optional[str] = None
+    """
+    An optional description of the option. This is useful for generating help
+    messages for the `Options`.
+    """
+    required: bool = False
+    """
+    Whether the option is required. If a option is required, it will be an
+    error to not provide a value for it, either trough a command-line argument,
+    an environment variable or a default value.
+    """
+    choices: list[Optional[Any]] = None
+    """Limits values to a specific set of choices."""
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "Option":
+        """
+        Creates an instance of `Option` from a dictionary.
+
+        Parameters
+        ----------
+        data : dict[str, Any]
+            The dictionary representation of an option.
+
+        Returns
+        -------
+        Option
+            An instance of `Option`.
+        """
+
+        option_type_string = data["option_type"]
+        option_type = getattr(builtins, option_type_string.split("'")[1])
+
+        return Option(
+            name=data["name"],
+            option_type=option_type,
+            default=data.get("default"),
+            description=data.get("description"),
+            required=data.get("required", False),
+            choices=data.get("choices"),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """
+        Converts the option to a dict.
+
+        Returns
+        -------
+        dict[str, Any]
+            The option as a dict.
+        """
+
+        return {
+            "name": self.name,
+            "option_type": str(self.option_type),
+            "default": self.default,
+            "description": self.description,
+            "required": self.required,
+            "choices": self.choices,
+        }
+
+
 class Options:
     """
-    Options for a run. To initialize options, pass in one or more `Parameter`
+    Options for a run. To initialize options, pass in one or more `Option`
     objects. The options will look for the values of the given parameters in
     the following order: command-line arguments, environment variables, default
     values.
 
-    Once the options are initialized, you can access the parameters as
-    attributes of the `Options` object. For example, if you have a
-    `Parameter` object with the name "duration", you can access it as
+    Once the `Options` are initialized, you can access the underlying options as
+    attributes of the `Options` object. For example, if you have an
+    `Option` object with the name "duration", you can access it as
     `options.duration`.
 
-    If a parameter is required and not provided through a command-line
+    If an option is required and not provided through a command-line
     argument, an environment variable or a default value, an error will be
     raised.
 
@@ -132,19 +264,19 @@ class Options:
     be merged with other options. After options are parsed, you may get the
     help message by running the script with the `-h/--help` flag.
 
-    Parameters
+    Attributes
     ----------
-    *parameters : Parameter
-        The parameters that are used in the options. At least one
-        parameter is required.
+    *options : Option
+        The list of `Option` objects that are used in the options. At least one
+        option is required.
 
     Examples
     --------
     >>> import nextmv
     >>>
     >>> options = nextmv.Options(
-    ...     nextmv.Parameter("duration", str, "30s", description="solver duration", required=False),
-    ...     nextmv.Parameter("threads", int, 4, description="computer threads", required=False),
+    ...     nextmv.Option("duration", str, "30s", description="solver duration", required=False),
+    ...     nextmv.Option("threads", int, 4, description="computer threads", required=False),
     ... )
     >>>
     >>> print(options.duration, options.threads, options.to_dict())
@@ -154,10 +286,11 @@ class Options:
     Raises
     ------
     ValueError
-        If a required parameter is not provided through a command-line
+        If a required option is not provided through a command-line
         argument, an environment variable or a default value.
     TypeError
-        If a parameter is not a `Parameter` object.
+        If an option is not either an `Option` or `Parameter` (deprecated)
+        object.
     ValueError
         If an environment variable is not of the type of the corresponding
         parameter.
@@ -165,10 +298,14 @@ class Options:
 
     PARSED = False
 
-    def __init__(self, *parameters: Parameter):
+    def __init__(self, *options: Option):
         """Initializes the options."""
 
-        self.parameters = copy.deepcopy(parameters)
+        # Deprecated, but kept for backwards compatibility. Remove as soon as
+        # `Parameter` is removed.
+        self.parameters = copy.deepcopy(options)
+
+        self.options = copy.deepcopy(options)
 
     def to_dict(self) -> dict[str, Any]:
         """
@@ -190,7 +327,7 @@ class Options:
 
         self_dict = copy.deepcopy(self.__dict__)
 
-        rm_keys = ["parameters", "PARSED"]
+        rm_keys = ["parameters", "PARSED", "options"]
         for key in rm_keys:
             if key in self_dict:
                 self_dict.pop(key)
@@ -227,6 +364,11 @@ class Options:
 
     def parameters_dict(self) -> list[dict[str, Any]]:
         """
+        DEPRECATION WARNING
+        ----------
+        `Parameter` is deprecated, use `Option` instead. Options.parameters_dict
+        -> Options.options_dict
+
         Converts the options to a list of dicts. Each dict is the dict
         representation of a `Parameter`.
 
@@ -236,7 +378,25 @@ class Options:
             The list of dictionaries (parameter entries).
         """
 
+        deprecated(
+            name="Options.parameters_dict",
+            reason="`Parameter` is deprecated, use `Option` instead. Options.parameters_dict -> Options.options_dict",
+        )
+
         return [param.to_dict() for param in self.parameters]
+
+    def options_dict(self) -> list[dict[str, Any]]:
+        """
+        Converts the `Options` to a list of dicts. Each dict is the dict
+        representation of an `Option`.
+
+        Returns
+        -------
+        list[dict[str, Any]]
+            The list of dictionaries (`Option` entries).
+        """
+
+        return [opt.to_dict() for opt in self.options]
 
     def parse(self):
         """
@@ -257,8 +417,8 @@ class Options:
         >>> import nextmv
         >>>
         >>> options = nextmv.Options(
-        ...     nextmv.Parameter("duration", str, "30s", description="solver duration", required=False),
-        ...     nextmv.Parameter("threads", int, 4, description="computer threads", required=False),
+        ...     nextmv.Option("duration", str, "30s", description="solver duration", required=False),
+        ...     nextmv.Option("threads", int, 4, description="computer threads", required=False),
         ... )
         >>> options.parse() # Does not raise an exception.
 
@@ -267,8 +427,8 @@ class Options:
         >>> import nextmv
         >>>
         >>> options = nextmv.Options(
-        ...     nextmv.Parameter("duration", str, "30s", description="solver duration", required=False),
-        ...     nextmv.Parameter("threads", int, 4, description="computer threads", required=False),
+        ...     nextmv.Option("duration", str, "30s", description="solver duration", required=False),
+        ...     nextmv.Option("threads", int, 4, description="computer threads", required=False),
         ... )
         >>> print(options.duration) # Parses the options.
         >>> options.parse() # Raises an exception because the options have already been parsed.
@@ -278,10 +438,10 @@ class Options:
         RuntimeError
             If the options have already been parsed.
         ValueError
-            If a required parameter is not provided through a command-line
+            If a required option is not provided through a command-line
             argument, an environment variable or a default value.
         TypeError
-            If a parameter is not a `Parameter` object.
+            If an option is not an `Option` or `Parameter` (deprecated) object.
         ValueError
             If an environment variable is not of the type of the corresponding
             parameter.
@@ -328,7 +488,11 @@ class Options:
                 "new options have already been parsed, cannot merge. See `Options.parse()` for more information."
             )
 
+        # Deprecated, but kept for backwards compatibility. Remove as soon as
+        # `Parameter` is removed.
         self.parameters += new.parameters
+
+        self.options += new.options
 
         self._parse()
 
@@ -356,16 +520,21 @@ class Options:
             An instance of `Options`.
         """
 
-        parameters = []
+        options = []
         for key, value in data.items():
-            parameter = Parameter(name=key, param_type=type(value), default=value)
-            parameters.append(parameter)
+            opt = Option(name=key, option_type=type(value), default=value)
+            options.append(opt)
 
-        return cls(*parameters)
+        return cls(*options)
 
     @classmethod
     def from_parameters_dict(cls, parameters_dict: list[dict[str, Any]]) -> "Options":
         """
+        DEPRECATION WARNING
+        ----------
+        `Parameter` is deprecated, use `Option` instead. Options.from_parameters_dict
+        -> Options.from_options_dict
+
         Creates an instance of `Options` from parameters in dict form. Each
         entry is the dict representation of a `Parameter`.
 
@@ -380,12 +549,42 @@ class Options:
             An instance of `Options`.
         """
 
+        deprecated(
+            name="Options.from_parameters_dict",
+            reason="`Parameter` is deprecated, use `Option` instead. "
+            "Options.from_parameters_dict -> Options.from_options_dict",
+        )
+
         parameters = []
         for parameter_dict in parameters_dict:
             parameter = Parameter.from_dict(parameter_dict)
             parameters.append(parameter)
 
         return cls(*parameters)
+
+    @classmethod
+    def from_options_dict(cls, options_dict: list[dict[str, Any]]) -> "Options":
+        """
+        Creates an instance of `Options` from a list of `Option` objects in
+        dict form. Each entry is the dict representation of an `Option`.
+
+        Parameters
+        ----------
+        data : list[dict[str, Any]]
+            The list of dictionaries (`Option` entries).
+
+        Returns
+        -------
+        Options
+            An instance of `Options`.
+        """
+
+        options = []
+        for opt_dict in options_dict:
+            opt = Option.from_dict(opt_dict)
+            options.append(opt)
+
+        return cls(*options)
 
     def __getattr__(self, name: str) -> Any:
         """
@@ -406,10 +605,10 @@ class Options:
         Raises
         ------
         ValueError
-            If a required parameter is not provided through a command-line
+            If a required option is not provided through a command-line
             argument, an environment variable or a default value.
         TypeError
-            If a parameter is not a `Parameter` object.
+            If an option is not an `Option` or `Parameter` (deprecated) object.
         ValueError
             If an environment variable is not of the type of the corresponding
             parameter.
@@ -417,7 +616,7 @@ class Options:
 
         self.PARSED = True
 
-        if not self.parameters:
+        if not self.options:
             return
 
         parser = argparse.ArgumentParser(
@@ -427,41 +626,43 @@ class Options:
             + "or environment variables.",
             allow_abbrev=False,
         )
-        params_by_field_name: dict[str, Parameter] = {}
+        options_by_field_name: dict[str, Option] = {}
 
-        for p, param in enumerate(self.parameters):
-            if not isinstance(param, Parameter):
-                raise TypeError(f"expected a <Parameter> object, but got {type(param)} in index {p}")
+        for ix, option in enumerate(self.options):
+            if not isinstance(option, Option) and not isinstance(option, Parameter):
+                raise TypeError(
+                    f"expected an <Option> (or deprecated <Parameter>) object, but got {type(option)} in index {ix}"
+                )
 
             # See comment below about ipykernel adding a `-f` argument. We
             # restrict parameters from having the name 'f' or 'fff' for that
             # reason.
-            if param.name == "f" or param.name == "fff":
-                raise ValueError("parameter names 'f', 'fff' are reserved for internal use")
+            if option.name == "f" or option.name == "fff":
+                raise ValueError("option names 'f', 'fff' are reserved for internal use")
 
-            if param.name == "PARSED":
-                raise ValueError("parameter name 'PARSED' is reserved for internal use")
+            if option.name == "PARSED":
+                raise ValueError("option name 'PARSED' is reserved for internal use")
 
             # Remove any leading '-'. This is in line with argparse's behavior.
-            param.name = param.name.lstrip("-")
+            option.name = option.name.lstrip("-")
 
             kwargs = {
-                "type": param.param_type if param.param_type is not bool else str,
-                "help": self._description(param),
+                "type": self._option_type(option) if self._option_type(option) is not bool else str,
+                "help": self._description(option),
             }
 
-            if param.choices is not None:
-                kwargs["choices"] = param.choices
+            if option.choices is not None:
+                kwargs["choices"] = option.choices
 
             parser.add_argument(
-                f"-{param.name}",
-                f"--{param.name}",
+                f"-{option.name}",
+                f"--{option.name}",
                 **kwargs,
             )
 
             # Store the parameter by its field name for easy access later. argparse
             # replaces '-' with '_', so we do the same here.
-            params_by_field_name[param.name.replace("-", "_")] = param
+            options_by_field_name[option.name.replace("-", "_")] = option
 
         # The ipkyernel uses a `-f` argument by default that it passes to the
         # execution. We don’t want to ignore this argument because we get an
@@ -479,13 +680,13 @@ class Options:
             if arg == "fff" or arg == "f":
                 continue
 
-            param = params_by_field_name[arg]
+            option = options_by_field_name[arg]
 
             # First, attempt to set the value of a parameter from the
             # command-line args.
             arg_value = getattr(args, arg)
             if arg_value is not None:
-                value = self._parameter_value(param, arg_value)
+                value = self._option_value(option, arg_value)
                 setattr(self, arg, value)
                 continue
 
@@ -495,18 +696,22 @@ class Options:
             env_value = os.getenv(upper_name)
             if env_value is not None:
                 try:
-                    typed_env_value = param.param_type(env_value) if param.param_type is not bool else env_value
+                    typed_env_value = (
+                        self._option_type(option)(env_value) if self._option_type(option) is not bool else env_value
+                    )
                 except ValueError:
-                    raise ValueError(f'environment variable "{upper_name}" is not of type {param.param_type}') from None
+                    raise ValueError(
+                        f'environment variable "{upper_name}" is not of type {self._option_type(option)}'
+                    ) from None
 
-                value = self._parameter_value(param, typed_env_value)
+                value = self._option_value(option, typed_env_value)
                 setattr(self, arg, value)
                 continue
 
             # Finally, attempt to set a default value. This is only allowed
             # for non-required parameters.
-            if not param.required:
-                setattr(self, arg, param.default)
+            if not option.required:
+                setattr(self, arg, option.default)
                 continue
 
             # At this point, the parameter is required and no value was
@@ -515,31 +720,29 @@ class Options:
                 f'parameter "{arg}" is required but not provided through: command-line args, env vars, or default value'
             )
 
-    @staticmethod
-    def _description(param: Parameter) -> str:
+    def _description(self, option: Option) -> str:
         """Returns a description for a parameter."""
 
-        description = f"[env var: {param.name.upper()}]"
+        description = f"[env var: {option.name.upper()}]"
 
-        if param.required:
+        if option.required:
             description += " (required)"
 
-        if param.default is not None:
-            description += f" (default: {param.default})"
+        if option.default is not None:
+            description += f" (default: {option.default})"
 
-        description += f" (type: {param.param_type.__name__})"
+        description += f" (type: {self._option_type(option).__name__})"
 
-        if param.description is not None:
-            description += f": {param.description}"
+        if option.description is not None:
+            description += f": {option.description}"
 
         return description
 
-    @staticmethod
-    def _parameter_value(parameter: Parameter, value: Any) -> Any:
-        """Handles how the value of a parameter is extracted."""
+    def _option_value(self, option: Option, value: Any) -> Any:
+        """Handles how the value of an option is extracted."""
 
-        param_type = parameter.param_type
-        if param_type is not bool:
+        opt_type = self._option_type(option)
+        if opt_type is not bool:
             return value
 
         value = str(value).lower()
@@ -548,3 +751,19 @@ class Options:
             return True
 
         return False
+
+    @staticmethod
+    def _option_type(option: Union[Option, Parameter]) -> type:
+        """Auxiliary function for handling the type of an option. This function
+        was introduced for backwards compatibility with the deprecated
+        `Parameter` class. Once `Parameter` is removed, this function can be removed
+        as well. When the function is removed, use the `option.option_type`
+        attribute directly, instead of calling this function.
+        """
+
+        if isinstance(option, Option):
+            return option.option_type
+        elif isinstance(option, Parameter):
+            return option.param_type
+        else:
+            raise TypeError(f"expected an <Option> (or deprecated <Parameter>) object, but got {type(option)}")

--- a/nextmv/nextmv/options.py
+++ b/nextmv/nextmv/options.py
@@ -715,7 +715,11 @@ class Options:
     def _description(self, option: Option) -> str:
         """Returns a description for an option."""
 
-        description = f"[env var: {option.name.upper()}]"
+        description = ""
+        if isinstance(option, Parameter):
+            description = "DEPRECATED (initialized with <Parameter>, use <Option> instead) "
+
+        description += f"[env var: {option.name.upper()}]"
 
         if option.required:
             description += " (required)"

--- a/nextmv/nextmv/options.py
+++ b/nextmv/nextmv/options.py
@@ -301,10 +301,6 @@ class Options:
     def __init__(self, *options: Option):
         """Initializes the options."""
 
-        # Deprecated, but kept for backwards compatibility. Remove as soon as
-        # `Parameter` is removed.
-        self.parameters = copy.deepcopy(options)
-
         self.options = copy.deepcopy(options)
 
     def to_dict(self) -> dict[str, Any]:
@@ -327,7 +323,7 @@ class Options:
 
         self_dict = copy.deepcopy(self.__dict__)
 
-        rm_keys = ["parameters", "PARSED", "options"]
+        rm_keys = ["PARSED", "options"]
         for key in rm_keys:
             if key in self_dict:
                 self_dict.pop(key)
@@ -383,7 +379,7 @@ class Options:
             reason="`Parameter` is deprecated, use `Option` instead. Options.parameters_dict -> Options.options_dict",
         )
 
-        return [param.to_dict() for param in self.parameters]
+        return [param.to_dict() for param in self.options]
 
     def options_dict(self) -> list[dict[str, Any]]:
         """
@@ -487,10 +483,6 @@ class Options:
             raise RuntimeError(
                 "new options have already been parsed, cannot merge. See `Options.parse()` for more information."
             )
-
-        # Deprecated, but kept for backwards compatibility. Remove as soon as
-        # `Parameter` is removed.
-        self.parameters += new.parameters
 
         self.options += new.options
 
@@ -635,7 +627,7 @@ class Options:
                 )
 
             # See comment below about ipykernel adding a `-f` argument. We
-            # restrict parameters from having the name 'f' or 'fff' for that
+            # restrict options from having the name 'f' or 'fff' for that
             # reason.
             if option.name == "f" or option.name == "fff":
                 raise ValueError("option names 'f', 'fff' are reserved for internal use")
@@ -660,7 +652,7 @@ class Options:
                 **kwargs,
             )
 
-            # Store the parameter by its field name for easy access later. argparse
+            # Store the option by its field name for easy access later. argparse
             # replaces '-' with '_', so we do the same here.
             options_by_field_name[option.name.replace("-", "_")] = option
 
@@ -682,7 +674,7 @@ class Options:
 
             option = options_by_field_name[arg]
 
-            # First, attempt to set the value of a parameter from the
+            # First, attempt to set the value of an option from the
             # command-line args.
             arg_value = getattr(args, arg)
             if arg_value is not None:
@@ -690,7 +682,7 @@ class Options:
                 setattr(self, arg, value)
                 continue
 
-            # Second, attempt to set the value of a parameter from the
+            # Second, attempt to set the value of am option from the
             # environment variables.
             upper_name = arg.upper()
             env_value = os.getenv(upper_name)
@@ -709,19 +701,19 @@ class Options:
                 continue
 
             # Finally, attempt to set a default value. This is only allowed
-            # for non-required parameters.
+            # for non-required options.
             if not option.required:
                 setattr(self, arg, option.default)
                 continue
 
-            # At this point, the parameter is required and no value was
+            # At this point, the option is required and no value was
             # provided
             raise ValueError(
-                f'parameter "{arg}" is required but not provided through: command-line args, env vars, or default value'
+                f'option "{arg}" is required but not provided through: command-line args, env vars, or default value'
             )
 
     def _description(self, option: Option) -> str:
-        """Returns a description for a parameter."""
+        """Returns a description for an option."""
 
         description = f"[env var: {option.name.upper()}]"
 

--- a/nextmv/tests/cloud/test_manifest.py
+++ b/nextmv/tests/cloud/test_manifest.py
@@ -33,7 +33,7 @@ class TestManifest(unittest.TestCase):
                 "pip-requirements": "model_requirements.txt",
                 "model": {
                     "name": model_configuration.name,
-                    "options": model_configuration.options.parameters_dict(),
+                    "options": model_configuration.options.options_dict(),
                 },
             }
         )

--- a/nextmv/tests/cloud/test_manifest.py
+++ b/nextmv/tests/cloud/test_manifest.py
@@ -2,14 +2,14 @@ import unittest
 
 from nextmv.cloud.manifest import Manifest, ManifestPython, ManifestRuntime, ManifestType
 from nextmv.model import ModelConfiguration
-from nextmv.options import Options, Parameter
+from nextmv.options import Option, Options
 
 
 class TestManifest(unittest.TestCase):
     def test_from_model_configuration(self):
         options = Options(
-            Parameter("param1", str, ""),
-            Parameter("param2", str, ""),
+            Option("param1", str, ""),
+            Option("param2", str, ""),
         )
         model_configuration = ModelConfiguration(
             name="super_cool_model",

--- a/nextmv/tests/scripts/options1.py
+++ b/nextmv/tests/scripts/options1.py
@@ -1,8 +1,8 @@
 import nextmv
 
 options = nextmv.Options(
-    nextmv.Parameter("duration", str, "30s", description="solver duration"),
-    nextmv.Parameter("threads", int, 4, description="computer threads"),
+    nextmv.Option("duration", str, "30s", description="solver duration"),
+    nextmv.Option("threads", int, 4, description="computer threads"),
 )
 
 print(options.to_dict())

--- a/nextmv/tests/scripts/options2.py
+++ b/nextmv/tests/scripts/options2.py
@@ -1,8 +1,8 @@
 import nextmv
 
 options = nextmv.Options(
-    nextmv.Parameter("duration", str, description="solver duration", required=True),
-    nextmv.Parameter("threads", int, description="computer threads", required=True),
+    nextmv.Option("duration", str, description="solver duration", required=True),
+    nextmv.Option("threads", int, description="computer threads", required=True),
 )
 
 print(options.to_dict())

--- a/nextmv/tests/scripts/options3.py
+++ b/nextmv/tests/scripts/options3.py
@@ -1,8 +1,8 @@
 import nextmv
 
 options = nextmv.Options(
-    nextmv.Parameter("duration", str),
-    nextmv.Parameter("threads", int),
+    nextmv.Option("duration", str),
+    nextmv.Option("threads", int),
 )
 
 print(options.to_dict())

--- a/nextmv/tests/scripts/options4.py
+++ b/nextmv/tests/scripts/options4.py
@@ -1,7 +1,7 @@
 import nextmv
 
 options = nextmv.Options(
-    nextmv.Parameter("bool_opt", bool, default=True),
+    nextmv.Option("bool_opt", bool, default=True),
 )
 
 print(options.to_dict())

--- a/nextmv/tests/scripts/options5.py
+++ b/nextmv/tests/scripts/options5.py
@@ -1,7 +1,7 @@
 import nextmv
 
 options = nextmv.Options(
-    nextmv.Parameter("str_opt", str, default=None),
+    nextmv.Option("str_opt", str, default=None),
 )
 
 print(f"str_opt: {options.str_opt}")

--- a/nextmv/tests/scripts/options6.py
+++ b/nextmv/tests/scripts/options6.py
@@ -1,9 +1,9 @@
 import nextmv
 
 options = nextmv.Options(
-    nextmv.Parameter("-dash-opt", str, default="dash"),
-    nextmv.Parameter("underscore_opt", str, default="underscore"),
-    nextmv.Parameter("camelCaseOpt", str, default="camel"),
+    nextmv.Option("-dash-opt", str, default="dash"),
+    nextmv.Option("underscore_opt", str, default="underscore"),
+    nextmv.Option("camelCaseOpt", str, default="camel"),
 )
 
 print(options.to_dict())

--- a/nextmv/tests/scripts/options7.py
+++ b/nextmv/tests/scripts/options7.py
@@ -10,7 +10,7 @@ class ChoiceEnum(Enum):
 
 
 options = nextmv.Options(
-    nextmv.Parameter("choice_opt", ChoiceEnum, default=ChoiceEnum.choice1),
+    nextmv.Option("choice_opt", ChoiceEnum, default=ChoiceEnum.choice1),
 )
 
 print(options.to_dict())

--- a/nextmv/tests/scripts/options_deprecated.py
+++ b/nextmv/tests/scripts/options_deprecated.py
@@ -1,0 +1,8 @@
+import nextmv
+
+options = nextmv.Options(
+    nextmv.Option("duration", str, description="solver duration", required=True),
+    nextmv.Parameter("threads", int, description="computer threads", required=True),
+)
+
+print(options.to_dict())

--- a/nextmv/tests/test_entrypoint/test_entrypoint.py
+++ b/nextmv/tests/test_entrypoint/test_entrypoint.py
@@ -53,7 +53,7 @@ class TestEntrypoint(unittest.TestCase):
         """
 
         model = SimpleDecisionModel()
-        options = nextmv.Options(nextmv.Parameter("param1", str, ""))
+        options = nextmv.Options(nextmv.Option("param1", str, ""))
 
         model_configuration = nextmv.ModelConfiguration(
             name=self.MODEL_NAME,

--- a/nextmv/tests/test_input.py
+++ b/nextmv/tests/test_input.py
@@ -63,7 +63,7 @@ class TestInput(unittest.TestCase):
 
     def test_local_loader_with_options(self):
         sample_input = '{"empanadas": "are_life"}\n'
-        options = nextmv.Options(nextmv.Parameter("foo", str, default="bar", required=False))
+        options = nextmv.Options(nextmv.Option("foo", str, default="bar", required=False))
         input_loader = nextmv.LocalInputLoader()
 
         with patch("sys.stdin", new=StringIO(sample_input)):

--- a/nextmv/tests/test_options.py
+++ b/nextmv/tests/test_options.py
@@ -24,7 +24,7 @@ class TestOptions(unittest.TestCase):
     assume that the script is one level up.
     """
 
-    test_scripts = [1, 2, 3, 4, 5, 6, 7, "_deprecated"]
+    test_scripts = ["1", "2", "3", "4", "5", "6", "7", "_deprecated"]
     """These are auxiliary scripts that are used to test different scenarios of
     instantiating an `Options` object."""
 

--- a/nextmv/tests/test_options.py
+++ b/nextmv/tests/test_options.py
@@ -113,16 +113,16 @@ class TestOptions(unittest.TestCase):
         )
 
         self.assertEqual(result.returncode, 1)
-        self.assertIn('parameter "duration" is required', result.stderr)
+        self.assertIn('option "duration" is required', result.stderr)
 
-    def test_no_parameters(self):
+    def test_no_options(self):
         # The test passes if no exception is raised.
         opt = nextmv.Options()
         self.assertTrue(opt)
 
-    def test_bad_parameter_type(self):
+    def test_bad_option_type(self):
         with self.assertRaises(TypeError):
-            opt = nextmv.Options("I am not a valid parameter")
+            opt = nextmv.Options("I am not a valid option")
             opt.parse()
 
     def test_bad_type_command_line_arg(self):

--- a/nextmv/tests/test_options.py
+++ b/nextmv/tests/test_options.py
@@ -600,3 +600,179 @@ class TestParameter(unittest.TestCase):
         self.assertFalse(opt.PARSED)
         opt.parse()
         self.assertTrue(opt.PARSED)
+
+
+class TestOption(unittest.TestCase):
+    def test_from_dict_str(self):
+        data = {
+            "name": "i_am_a_fish",
+            "option_type": "<class 'str'>",
+            "default": "salmon",
+            "description": "I am a fish",
+            "required": False,
+        }
+        opt = nextmv.Option.from_dict(data)
+
+        self.assertEqual(opt.name, data["name"])
+        self.assertEqual(opt.option_type, str)
+        self.assertEqual(opt.default, data["default"])
+        self.assertEqual(opt.description, data["description"])
+        self.assertEqual(opt.required, data["required"])
+
+    def test_from_dict_float(self):
+        data = {
+            "name": "i_am_a_fish",
+            "option_type": "<class 'float'>",
+            "default": 3.14,
+            "description": "I am a fish",
+            "required": False,
+        }
+        opt = nextmv.Option.from_dict(data)
+
+        self.assertEqual(opt.name, data["name"])
+        self.assertEqual(opt.option_type, float)
+        self.assertEqual(opt.default, data["default"])
+        self.assertEqual(opt.description, data["description"])
+        self.assertEqual(opt.required, data["required"])
+
+    def test_from_dict_int(self):
+        data = {
+            "name": "i_am_a_fish",
+            "option_type": "<class 'int'>",
+            "default": 42,
+            "description": "I am a fish",
+            "required": False,
+        }
+        opt = nextmv.Option.from_dict(data)
+
+        self.assertEqual(opt.name, data["name"])
+        self.assertEqual(opt.option_type, int)
+        self.assertEqual(opt.default, data["default"])
+        self.assertEqual(opt.description, data["description"])
+        self.assertEqual(opt.required, data["required"])
+
+    def test_from_dict_bool(self):
+        data = {
+            "name": "i_am_a_fish",
+            "option_type": "<class 'bool'>",
+            "default": False,
+            "description": "I am a fish",
+            "required": False,
+        }
+        opt = nextmv.Option.from_dict(data)
+
+        self.assertEqual(opt.name, data["name"])
+        self.assertEqual(opt.option_type, bool)
+        self.assertEqual(opt.default, data["default"])
+        self.assertEqual(opt.description, data["description"])
+        self.assertEqual(opt.required, data["required"])
+
+    def test_to_dict_str(self):
+        opt = nextmv.Option(
+            name="i_am_a_fish",
+            option_type=str,
+            default="salmon",
+            description="I am a fish",
+            required=False,
+        )
+        data = opt.to_dict()
+
+        self.assertEqual(data["name"], opt.name)
+        self.assertEqual(data["option_type"], "<class 'str'>")
+        self.assertEqual(data["default"], opt.default)
+        self.assertEqual(data["description"], opt.description)
+        self.assertEqual(data["required"], opt.required)
+
+    def test_to_dict_float(self):
+        opt = nextmv.Option(
+            name="i_am_a_fish",
+            option_type=float,
+            default=3.14,
+            description="I am a fish",
+            required=False,
+        )
+        data = opt.to_dict()
+
+        self.assertEqual(data["name"], opt.name)
+        self.assertEqual(data["option_type"], "<class 'float'>")
+        self.assertEqual(data["default"], opt.default)
+        self.assertEqual(data["description"], opt.description)
+        self.assertEqual(data["required"], opt.required)
+
+    def test_to_dict_int(self):
+        opt = nextmv.Option(
+            name="i_am_a_fish",
+            option_type=int,
+            default=42,
+            description="I am a fish",
+            required=False,
+        )
+        data = opt.to_dict()
+
+        self.assertEqual(data["name"], opt.name)
+        self.assertEqual(data["option_type"], "<class 'int'>")
+        self.assertEqual(data["default"], opt.default)
+        self.assertEqual(data["description"], opt.description)
+        self.assertEqual(data["required"], opt.required)
+
+    def test_to_dict_bool(self):
+        opt = nextmv.Option(
+            name="i_am_a_fish",
+            option_type=bool,
+            default=False,
+            description="I am a fish",
+            required=False,
+        )
+        data = opt.to_dict()
+
+        self.assertEqual(data["name"], opt.name)
+        self.assertEqual(data["option_type"], "<class 'bool'>")
+        self.assertEqual(data["default"], opt.default)
+        self.assertEqual(data["description"], opt.description)
+        self.assertEqual(data["required"], opt.required)
+
+    def test_merge(self):
+        opt1 = nextmv.Options(
+            nextmv.Option("foo1", int, default=1),
+            nextmv.Option("bar1", int, default=2),
+        )
+        self.assertFalse(opt1.PARSED)
+
+        opt2 = nextmv.Options(
+            nextmv.Option("foo2", int, default=3),
+            nextmv.Option("bar2", int, default=4),
+        )
+        self.assertFalse(opt2.PARSED)
+
+        opt = opt1.merge(opt2)
+        self.assertTrue(opt.PARSED)
+
+        self.assertEqual(opt.foo1, 1)
+        self.assertEqual(opt.bar1, 2)
+        self.assertEqual(opt.foo2, 3)
+        self.assertEqual(opt.bar2, 4)
+
+    def test_cant_merge(self):
+        opt1 = nextmv.Options(
+            nextmv.Option("foo1", int, default=1),
+            nextmv.Option("bar1", int, default=2),
+        )
+        opt1.parse()
+
+        opt2 = nextmv.Options(
+            nextmv.Option("foo2", int, default=3),
+            nextmv.Option("bar2", int, default=4),
+        )
+
+        with self.assertRaises(RuntimeError):
+            opt1.merge(opt2)
+
+    def test_parse(self):
+        opt = nextmv.Options(
+            nextmv.Option("foo", int, default=1),
+            nextmv.Option("bar", int, default=2),
+        )
+
+        self.assertFalse(opt.PARSED)
+        opt.parse()
+        self.assertTrue(opt.PARSED)

--- a/nextmv/tests/test_options.py
+++ b/nextmv/tests/test_options.py
@@ -24,7 +24,7 @@ class TestOptions(unittest.TestCase):
     assume that the script is one level up.
     """
 
-    test_scripts = [1, 2, 3, 4, 5, 6, 7]
+    test_scripts = [1, 2, 3, 4, 5, 6, 7, "_deprecated"]
     """These are auxiliary scripts that are used to test different scenarios of
     instantiating an `Options` object."""
 
@@ -404,6 +404,18 @@ class TestOptions(unittest.TestCase):
         )
         self.assertEqual(result2.returncode, 0, result2.stderr)
         self.assertEqual(result2.stdout, "{'choice_opt': 'choice1'}\n")
+
+    def test_deprecated_parameter(self):
+        """Test that nextmv.Parameter can co-exist with nextmv.Option."""
+        file = self._file_name("options_deprecated.py", "..")
+        result = subprocess.run(
+            ["python3", file, "--duration", "30s", "--threads", "4"],
+            capture_output=True,
+            text=True,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout, "{'duration': '30s', 'threads': 4}\n")
 
     @staticmethod
     def _file_name(name: str, relative_location: str = ".") -> str:


### PR DESCRIPTION
# Description

Replace `nextmv.Parameter` 👉🏻 `nextmv.Option`. `nextmv.Parameter` is not deleted, just marked as deprecated. All methods in that class are also marked as deprecated.

All the methods in `Options` that used `Parameters` are deprecated, and new methods supporting `Option` were introduced:
- `from_options_dict`
- `options_dict`