### PR TITLE
Introduce write, load and deprecate write_local, load_local

### DIFF
--- a/nextmv/nextmv/__entrypoint__.py
+++ b/nextmv/nextmv/__entrypoint__.py
@@ -9,22 +9,20 @@ human to use it during local development. It is the standard way in which a
 
 from mlflow.pyfunc import load_model
 
-from nextmv.cloud.manifest import Manifest
-from nextmv.input import load_local
-from nextmv.options import Options
-from nextmv.output import write_local
+import nextmv
+from nextmv import cloud
 
 
 def main() -> None:
     """Entry point for the program."""
 
-    manifest = Manifest.from_yaml(".")
+    manifest = cloud.Manifest.from_yaml(".")
 
     # Load the options from the manifest.
     options = None
     options_dict = manifest.python.model.options
     if options_dict is not None:
-        options = Options.from_options_dict(options_dict)
+        options = nextmv.Options.from_options_dict(options_dict)
 
     # Load the model.
     loaded_model = load_model(
@@ -33,11 +31,11 @@ def main() -> None:
     )
 
     # Load the input and solve the model by using mlflow’s inference API.
-    input = load_local(options=options)
+    input = nextmv.load(options=options)
     output = loaded_model.predict(input)
 
     # Write the output.
-    write_local(output)
+    nextmv.write(output)
 
 
 if __name__ == "__main__":

--- a/nextmv/nextmv/__init__.py
+++ b/nextmv/nextmv/__init__.py
@@ -6,6 +6,7 @@ from .input import Input as Input
 from .input import InputFormat as InputFormat
 from .input import InputLoader as InputLoader
 from .input import LocalInputLoader as LocalInputLoader
+from .input import load as load
 from .input import load_local as load_local
 from .logger import log as log
 from .logger import redirect_stdout as redirect_stdout
@@ -28,6 +29,7 @@ from .output import SeriesData as SeriesData
 from .output import Statistics as Statistics
 from .output import Visual as Visual
 from .output import VisualSchema as VisualSchema
+from .output import write as write
 from .output import write_local as write_local
 
 VERSION = __version__

--- a/nextmv/nextmv/input.py
+++ b/nextmv/nextmv/input.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Optional, Union
 
+from nextmv.deprecated import deprecated
 from nextmv.options import Options
 
 
@@ -311,6 +312,10 @@ def load_local(
     csv_configurations: Optional[dict[str, Any]] = None,
 ) -> Input:
     """
+    DEPRECATION WARNING
+    ----------
+    `load_local` is deprecated, use `load` instead.
+
     This is a convenience function for instantiating a `LocalInputLoader`
     and calling its `load` method.
 
@@ -357,5 +362,74 @@ def load_local(
         If the path is not a directory when working with CSV_ARCHIVE.
     """
 
+    deprecated(
+        name="load_local",
+        reason="`load_local` is deprecated, use `load` instead.",
+    )
+
     loader = LocalInputLoader()
+    return loader.load(input_format, options, path, csv_configurations)
+
+
+_LOCAL_INPUT_LOADER = LocalInputLoader()
+
+
+def load(
+    input_format: Optional[InputFormat] = InputFormat.JSON,
+    options: Optional[Options] = None,
+    path: Optional[str] = None,
+    csv_configurations: Optional[dict[str, Any]] = None,
+    loader: Optional[InputLoader] = _LOCAL_INPUT_LOADER,
+) -> Input:
+    """
+    This is a convenience function for loading an `Input`, i.e.: load the input
+    data. The `loader` is used to call the `.load` method. Note that the
+    default loader is the `LocalInputLoader`.
+
+    The input data can be in various formats. For
+    `InputFormat.JSON`, `InputFormat.TEXT`, and `InputFormat.CSV`, the data can
+    be streamed from stdin or read from a file. When the `path` argument is
+    provided (and valid), the input data is read from the file specified by
+    `path`, otherwise, it is streamed from stdin. For
+    `InputFormat.CSV_ARCHIVE`, the input data is read from the directory
+    specified by `path`. If the `path` is not provided, the default location
+    `input` is used. The directory should contain one or more files, where each
+    file in the directory is a CSV file.
+
+    The `Input` that is returned contains the `data` attribute. This data can
+    be of different types, depending on the provided `input_format`:
+
+    - `InputFormat.JSON`: the data is a `dict[str, Any]`.
+    - `InputFormat.TEXT`: the data is a `str`.
+    - `InputFormat.CSV`: the data is a `list[dict[str, Any]]`.
+    - `InputFormat.CSV_ARCHIVE`: the data is a `dict[str, list[dict[str, Any]]]`.
+        Each key is the name of the CSV file, minus the `.csv` extension.
+
+    Parameters
+    ----------
+    input_format: InputFormat, optional
+        Format of the input data. Default is `InputFormat.JSON`.
+    options: Options, optional
+        Options for loading the input data.
+    path: str, optional
+        Path to the input data.
+    csv_configurations: dict[str, Any], optional
+        Configurations for loading CSV files. The default `DictReader` is used
+        when loading a CSV file, so you have the option to pass in a dictionary
+        with custom kwargs for the `DictReader`.
+    loader: InputLoader, optional
+        The loader to use for loading the input data. Default is
+        `LocalInputLoader`.
+
+    Returns
+    -------
+    Input
+        The input data.
+
+    Raises
+    ------
+    ValueError
+        If the path is not a directory when working with CSV_ARCHIVE.
+    """
+
     return loader.load(input_format, options, path, csv_configurations)

--- a/nextmv/nextmv/output.py
+++ b/nextmv/nextmv/output.py
@@ -13,6 +13,7 @@ from typing import Any, Optional, Union
 from pydantic import AliasChoices, Field
 
 from nextmv.base_model import BaseModel
+from nextmv.deprecated import deprecated
 from nextmv.logger import reset_stdout
 from nextmv.options import Options
 
@@ -589,6 +590,10 @@ def write_local(
     skip_stdout_reset: bool = False,
 ) -> None:
     """
+    DEPRECATION WARNING
+    ----------
+    `write_local` is deprecated, use `write` instead.
+
     This is a convenience function for instantiating a `LocalOutputWriter` and
     calling its `write` method.
 
@@ -623,7 +628,60 @@ def write_local(
         If the `Output.output_format` is not supported.
     """
 
+    deprecated(
+        name="write_local",
+        reason="`write_local` is deprecated, use `write` instead.",
+    )
+
     writer = LocalOutputWriter()
+    writer.write(output, path, skip_stdout_reset)
+
+
+_LOCAL_OUTPUT_WRITER = LocalOutputWriter()
+
+
+def write(
+    output: Union[Output, dict[str, Any]],
+    path: Optional[str] = None,
+    skip_stdout_reset: bool = False,
+    writer: Optional[OutputWriter] = _LOCAL_OUTPUT_WRITER,
+) -> None:
+    """
+    This is a convenience function for writing an `Output`, i.e.: write the
+    output to the specified destination. The `writer` is used to call the
+    `.write` method. Note that the default writes is the `LocalOutputWriter`.
+
+    Consider the following for the `path` parameter, depending on the
+    `Output.output_format`:
+
+    - `OutputFormat.JSON`: the `path` is the file where the JSON data will
+        be written. If empty or `None`, the data will be written to stdout.
+    - `OutputFormat.CSV_ARCHIVE`: the `path` is the directory where the CSV
+        files will be written. If empty or `None`, the data will be written
+        to a directory named `output` under the current working directory.
+        The `Output.options` and `Output.statistics` will be written to
+        stdout.
+
+    This function detects if stdout was redirected and resets it to avoid
+    unexpected behavior. If you want to skip this behavior, set the
+    `skip_stdout_reset` parameter to `True`.
+
+    Parameters
+    ----------
+    output : Output, dict[str, Any]
+        Output data to write.
+    path : str
+        Path to write the output data to.
+    skip_stdout_reset : bool, optional
+        Skip resetting stdout before writing the output data. Default is
+        `False`.
+
+    Raises
+    ------
+    ValueError
+        If the `Output.output_format` is not supported.
+    """
+
     writer.write(output, path, skip_stdout_reset)
 
 

--- a/nextmv/tests/test_output.py
+++ b/nextmv/tests/test_output.py
@@ -273,7 +273,7 @@ class TestOutput(unittest.TestCase):
     def test_local_write_bad_output_type(self):
         output = "I am clearly not an output object."
         with self.assertRaises(TypeError):
-            nextmv.write_local(output)
+            nextmv.write(output)
 
     def test_local_write_passthrough_output(self):
         output = {


### PR DESCRIPTION
# Description

Introduces the following functions:

- `nextmv.write` ➡️ replaces `nextmv.write_local` (which has been marked as deprecated).
- `nextmv.load` ➡️  replaces `nextmv.loadl_local` (which has been marked as deprecated).
