### PR TITLE
Add console_url to run information and result

### DIFF
--- a/nextmv/nextmv/cloud/application.py
+++ b/nextmv/nextmv/cloud/application.py
@@ -1326,7 +1326,10 @@ class Application:
             endpoint=f"{self.endpoint}/runs/{run_id}/metadata",
         )
 
-        return RunInformation.from_dict(response.json())
+        info = RunInformation.from_dict(response.json())
+        info.console_url = self.__console_url(info.id)
+
+        return info
 
     def run_logs(self, run_id: str) -> RunLog:
         """
@@ -1702,6 +1705,8 @@ class Application:
             query_params=query_params,
         )
         result = RunResult.from_dict(response.json())
+        result.console_url = self.__console_url(result.id)
+
         if not large_output:
             return result
 
@@ -1765,6 +1770,11 @@ class Application:
                     indent=2,
                 )
             )
+
+    def __console_url(self, run_id: str) -> str:
+        """Auxiliary method to get the console URL for a run."""
+
+        return f"https://cloud.nextmv.io/app/{self.id}/run/{run_id}?view=details"
 
 
 def poll(polling_options: PollingOptions, polling_func: Callable[[], tuple[any, bool]]) -> any:

--- a/nextmv/nextmv/cloud/application.py
+++ b/nextmv/nextmv/cloud/application.py
@@ -1774,7 +1774,7 @@ class Application:
     def __console_url(self, run_id: str) -> str:
         """Auxiliary method to get the console URL for a run."""
 
-        return f"https://cloud.nextmv.io/app/{self.id}/run/{run_id}?view=details"
+        return f"{self.client.console_url}/app/{self.id}/run/{run_id}?view=details"
 
 
 def poll(polling_options: PollingOptions, polling_func: Callable[[], tuple[any, bool]]) -> any:

--- a/nextmv/nextmv/cloud/client.py
+++ b/nextmv/nextmv/cloud/client.py
@@ -55,6 +55,8 @@ class Client:
     """Timeout to use for requests to the Nextmv Cloud API."""
     url: str = "https://api.cloud.nextmv.io"
     """URL of the Nextmv Cloud API."""
+    console_url: str = "https://cloud.nextmv.io"
+    """URL of the Nextmv Cloud console."""
 
     def __post_init__(self):
         """Logic to run after the class is initialized."""

--- a/nextmv/nextmv/cloud/run.py
+++ b/nextmv/nextmv/cloud/run.py
@@ -52,6 +52,7 @@ class RunInformation(BaseModel):
     """Name of the run."""
     user_email: str
     """Email of the user who submitted the run."""
+    console_url: str = Field(default="")
 
 
 class ErrorLog(BaseModel):


### PR DESCRIPTION
# Description

The `console_url` can not be retrieved from either the `RunResult` or the `RunInformation`, with the following methods:

- `new_run_with_result`
- `run_result`
- `run_result_with_polling`
- `run_metadata`
- `track_run_with_result`