### PR TITLE
Adds options to the Manifest

### DIFF
--- a/nextmv/nextmv/__entrypoint__.py
+++ b/nextmv/nextmv/__entrypoint__.py
@@ -20,9 +20,8 @@ def main() -> None:
 
     # Load the options from the manifest.
     options = None
-    options_dict = manifest.python.model.options
-    if options_dict is not None:
-        options = nextmv.Options.from_options_dict(options_dict)
+    if manifest.options is not None:
+        options = manifest.extract_options()
 
     # Load the model.
     loaded_model = load_model(

--- a/nextmv/nextmv/cloud/__init__.py
+++ b/nextmv/nextmv/cloud/__init__.py
@@ -33,6 +33,7 @@ from .instance import Instance as Instance
 from .instance import InstanceConfiguration as InstanceConfiguration
 from .manifest import Manifest as Manifest
 from .manifest import ManifestBuild as ManifestBuild
+from .manifest import ManifestOption as ManifestOption
 from .manifest import ManifestPython as ManifestPython
 from .manifest import ManifestPythonModel as ManifestPythonModel
 from .manifest import ManifestRuntime as ManifestRuntime

--- a/nextmv/nextmv/cloud/application.py
+++ b/nextmv/nextmv/cloud/application.py
@@ -893,11 +893,11 @@ class Application:
 
         options_dict = {}
         if isinstance(input, Input) and input.options is not None:
-            options_dict = input.options.to_cloud_dict()
+            options_dict = input.options.to_dict_cloud()
 
         if options is not None:
             if isinstance(options, Options):
-                options_dict = options.to_cloud_dict()
+                options_dict = options.to_dict_cloud()
             elif isinstance(options, dict):
                 for k, v in options.items():
                     if isinstance(v, str):

--- a/nextmv/nextmv/cloud/manifest.py
+++ b/nextmv/nextmv/cloud/manifest.py
@@ -9,6 +9,7 @@ from pydantic import AliasChoices, Field
 
 from nextmv.base_model import BaseModel
 from nextmv.model import _REQUIREMENTS_FILE, ModelConfiguration
+from nextmv.options import Option, Options
 
 FILE_NAME = "app.yaml"
 """Name of the app manifest file."""
@@ -113,6 +114,94 @@ class ManifestPython(BaseModel):
     """
 
 
+class ManifestOption(BaseModel):
+    """An option for the decision model that is recorded in the manifest."""
+
+    name: str
+    """The name of the option"""
+    option_type: str = Field(
+        serialization_alias="type",
+        validation_alias=AliasChoices("type", "option_type"),
+    )
+    """The type of the option"""
+
+    default: Optional[Any] = None
+    """The default value of the option"""
+    description: Optional[str] = ""
+    """The description of the option"""
+    required: bool = False
+    """Whether the option is required or not"""
+    choices: Optional[list[Any]] = None
+    """The choices for the option"""
+
+    @classmethod
+    def from_option(cls, option: Option) -> "ManifestOption":
+        """
+        Create a `ManifestOption` from an `Option`.
+
+        Parameters
+        ----------
+        option: Option
+            The option to convert.
+
+        Returns
+        -------
+        ManifestOption
+            The converted option.
+        """
+        option_type = option.option_type
+        if option_type is str:
+            option_type = "string"
+        elif option_type is bool:
+            option_type = "boolean"
+        elif option_type is int:
+            option_type = "integer"
+        elif option_type is float:
+            option_type = "float"
+        else:
+            raise ValueError(f"unknown option type: {option_type}")
+
+        return cls(
+            name=option.name,
+            option_type=option_type,
+            default=option.default,
+            description=option.description,
+            required=option.required,
+            choices=option.choices,
+        )
+
+    def to_option(self) -> Option:
+        """
+        Convert the `ManifestOption` to an `Option`.
+
+        Returns
+        -------
+        Option
+            The converted option.
+        """
+
+        option_type_string = self.option_type
+        if option_type_string == "string":
+            option_type = str
+        elif option_type_string == "boolean":
+            option_type = bool
+        elif option_type_string == "integer":
+            option_type = int
+        elif option_type_string == "float":
+            option_type = float
+        else:
+            raise ValueError(f"unknown option type: {option_type_string}")
+
+        return Option(
+            name=self.name,
+            option_type=option_type,
+            default=self.default,
+            description=self.description,
+            required=self.required,
+            choices=self.choices,
+        )
+
+
 class Manifest(BaseModel):
     """
     An application that runs on the Nextmv Platform must contain a file named
@@ -161,6 +250,11 @@ class Manifest(BaseModel):
     Optional. Only for Python apps. Contains further Python-specific
     attributes.
     """
+    options: Optional[list[ManifestOption]] = None
+    """
+    Optional. A list of options for the decision model. An option is a
+    parameter that configures the decision model.
+    """
 
     @classmethod
     def from_yaml(cls, dirpath: str) -> "Manifest":
@@ -169,7 +263,7 @@ class Manifest(BaseModel):
 
         Parameters
         ----------
-        dirpath : str
+        dirpath: str
             Path to the directory containing the app.yaml file.
 
         Returns
@@ -190,7 +284,7 @@ class Manifest(BaseModel):
 
         Parameters
         ----------
-        dirpath : str
+        dirpath: str
             Path to the directory where the app.yaml file will be written.
 
         """
@@ -198,14 +292,35 @@ class Manifest(BaseModel):
         with open(os.path.join(dirpath, FILE_NAME), "w") as file:
             yaml.dump(self.to_dict(), file)
 
+    def extract_options(self) -> Options:
+        """
+        Convert the manifest options to a `nextmv.Options` object.
+
+        Returns
+        -------
+        Options
+            The converted options.
+        """
+
+        if self.options is None:
+            raise ValueError("No options found in the manifest")
+
+        options = [option.to_option() for option in self.options]
+
+        return Options(*options)
+
     @classmethod
     def from_model_configuration(cls, model_configuration: ModelConfiguration) -> "Manifest":
         """
-        Create a Python manifest from a Python model configuration.
+        Create a Python manifest from a Python model configuration. Note that
+        the `ModelConfiguration` is almost always used in conjunction with the
+        `nextmv.Model` class. If you are not implementing an instance of
+        `nextmv.Model`, maybe you should use the `from_options` method instead,
+        to initialize the manifest with the options of the model.
 
         Parameters
         ----------
-        model_configuration : ModelConfiguration
+        model_configuration: ModelConfiguration
             The model configuration.
 
         Returns
@@ -225,10 +340,44 @@ class Manifest(BaseModel):
             manifest_python_dict["model"]["options"] = model_configuration.options.options_dict()
 
         manifest_python = ManifestPython.from_dict(manifest_python_dict)
-
-        return cls(
+        manifest = cls(
             files=["main.py", f"{model_configuration.name}/**"],
             runtime=ManifestRuntime.PYTHON,
             type=ManifestType.PYTHON,
             python=manifest_python,
         )
+
+        if model_configuration.options is not None:
+            manifest.options = [ManifestOption.from_option(opt) for opt in model_configuration.options.options]
+
+        return manifest
+
+    @classmethod
+    def from_options(cls, options: Options) -> "Manifest":
+        """
+        Create a basic Python manifest from `Options`. If you have more files
+        than just a `main.py`, make sure you modify the `.files` attribute of
+        the resulting manifest. This method assumes that requirements are
+        specified in a `requirements.txt` file. You may also specify a
+        different requirements file once you instantiate the manifest.
+
+        Parameters
+        ----------
+        options: Options
+            The options to include in the manifest.
+
+        Returns
+        -------
+        Manifest
+            The manifest with the given options.
+        """
+
+        manifest = cls(
+            files=["main.py"],
+            runtime=ManifestRuntime.PYTHON,
+            type=ManifestType.PYTHON,
+            python=ManifestPython(pip_requirements="requirements.txt"),
+            options=[ManifestOption.from_option(opt) for opt in options.options],
+        )
+
+        return manifest

--- a/nextmv/nextmv/options.py
+++ b/nextmv/nextmv/options.py
@@ -187,7 +187,7 @@ class Option:
     error to not provide a value for it, either trough a command-line argument,
     an environment variable or a default value.
     """
-    choices: list[Optional[Any]] = None
+    choices: Optional[list[Any]] = None
     """Limits values to a specific set of choices."""
 
     @classmethod
@@ -332,7 +332,7 @@ class Options:
 
         return m.to_dict()["config"]
 
-    def to_cloud_dict(self) -> dict[str, str]:
+    def to_dict_cloud(self) -> dict[str, str]:
         """
         Converts the options to a dict that can be used in the Nextmv Cloud.
         Cloud has a hard requirement that options are passed as strings. This
@@ -729,7 +729,7 @@ class Options:
 
         description += f" (type: {self._option_type(option).__name__})"
 
-        if option.description is not None:
+        if option.description is not None and option.description != "":
             description += f": {option.description}"
 
         return description

--- a/nextmv/tests/cloud/app.yaml
+++ b/nextmv/tests/cloud/app.yaml
@@ -20,3 +20,24 @@ build:
   environment:
     SUPER: COOL
     EXTRA: AWESOME
+options:
+  - name: a string parameter
+    option_type: string
+    default: a default value
+    description: a description
+    required: true
+  - name: a boolean parameter
+    option_type: boolean
+    default: true
+    description: a description
+    required: false
+  - name: an integer parameter
+    option_type: integer
+    default: 42
+    description: a description
+    required: false
+  - name: a float parameter
+    option_type: float
+    default: 3.14
+    description: a description
+    required: false

--- a/nextmv/tests/cloud/test_manifest.py
+++ b/nextmv/tests/cloud/test_manifest.py
@@ -1,6 +1,6 @@
 import unittest
 
-from nextmv.cloud.manifest import Manifest, ManifestPython, ManifestRuntime, ManifestType
+from nextmv.cloud.manifest import Manifest, ManifestOption, ManifestPython, ManifestRuntime, ManifestType
 from nextmv.model import ModelConfiguration
 from nextmv.options import Option, Options
 
@@ -100,3 +100,175 @@ class TestManifest(unittest.TestCase):
                 "EXTRA": "AWESOME",
             },
         )
+
+    def test_extract_options(self):
+        manifest = Manifest.from_yaml("tests/cloud")
+        options = manifest.extract_options()
+        self.assertEqual(len(options.options), 4)
+
+        found = {
+            "string": False,
+            "boolean": False,
+            "integer": False,
+            "float": False,
+        }
+
+        for option in options.options:
+            if option.option_type is str:
+                found["string"] = True
+            elif option.option_type is bool:
+                found["boolean"] = True
+            elif option.option_type is int:
+                found["integer"] = True
+            elif option.option_type is float:
+                found["float"] = True
+
+        self.assertTrue(found["string"])
+        self.assertTrue(found["boolean"])
+        self.assertTrue(found["integer"])
+        self.assertTrue(found["float"])
+
+    def test_from_options(self):
+        options = Options(
+            Option("param1", str, "default", "A description", True),
+            Option("param2", bool, True, "A description", True),
+            Option("param3", int, 42, "A description", True),
+            Option("param4", float, 3.14, "A description", True),
+        )
+        manifest = Manifest.from_options(options)
+
+        self.assertListEqual(manifest.files, ["main.py"])
+        self.assertEqual(manifest.runtime, ManifestRuntime.PYTHON)
+        self.assertEqual(manifest.type, ManifestType.PYTHON)
+        self.assertEqual(manifest.python.pip_requirements, "requirements.txt")
+        self.assertListEqual(
+            manifest.options,
+            [
+                ManifestOption(
+                    name="param1",
+                    option_type="string",
+                    default="default",
+                    description="A description",
+                    required=True,
+                ),
+                ManifestOption(
+                    name="param2",
+                    option_type="boolean",
+                    default=True,
+                    description="A description",
+                    required=True,
+                ),
+                ManifestOption(
+                    name="param3",
+                    option_type="integer",
+                    default=42,
+                    description="A description",
+                    required=True,
+                ),
+                ManifestOption(
+                    name="param4",
+                    option_type="float",
+                    default=3.14,
+                    description="A description",
+                    required=True,
+                ),
+            ],
+        )
+
+
+class TestManifestOption(unittest.TestCase):
+    def test_from_option(self):
+        test_cases = [
+            {
+                "name": "string option",
+                "option": Option("param1", str, "default", "A description", True),
+                "expected_option_type": "string",
+            },
+            {
+                "name": "bool option",
+                "option": Option("param2", bool, True, "A description", True),
+                "expected_option_type": "boolean",
+            },
+            {
+                "name": "int option",
+                "option": Option("param3", int, 42, "A description", True),
+                "expected_option_type": "integer",
+            },
+            {
+                "name": "float option",
+                "option": Option("param4", float, 3.14, "A description", True),
+                "expected_option_type": "float",
+            },
+        ]
+
+        for test_case in test_cases:
+            with self.subTest(test_case["name"]):
+                option = test_case["option"]
+                manifest_option = ManifestOption.from_option(option)
+
+                self.assertEqual(manifest_option.name, option.name)
+                self.assertEqual(manifest_option.option_type, test_case["expected_option_type"])
+                self.assertEqual(manifest_option.default, option.default)
+                self.assertEqual(manifest_option.description, option.description)
+                self.assertEqual(manifest_option.required, option.required)
+                self.assertEqual(manifest_option.choices, option.choices)
+
+    def test_to_option(self):
+        test_cases = [
+            {
+                "name": "string option",
+                "manifest_option": ManifestOption(
+                    name="param1",
+                    option_type="string",
+                    default="default",
+                    description="A description",
+                    required=True,
+                ),
+                "expected_option_type": str,
+            },
+            {
+                "name": "bool option",
+                "manifest_option": ManifestOption(
+                    name="param2",
+                    option_type="boolean",
+                    default=True,
+                    description="A description",
+                    required=True,
+                ),
+                "expected_option_type": bool,
+            },
+            {
+                "name": "int option",
+                "manifest_option": ManifestOption(
+                    name="param3",
+                    option_type="integer",
+                    default=42,
+                    description="A description",
+                    required=True,
+                ),
+                "expected_option_type": int,
+            },
+            {
+                "name": "float option",
+                "manifest_option": ManifestOption(
+                    name="param4",
+                    option_type="float",
+                    default=3.14,
+                    description="A description",
+                    required=True,
+                ),
+                "expected_option_type": float,
+            },
+        ]
+
+        for test_case in test_cases:
+            with self.subTest(test_case["name"]):
+                manifest_option = test_case["manifest_option"]
+                option = manifest_option.to_option()
+
+                self.assertEqual(option.name, manifest_option.name)
+                self.assertIs(option.option_type, test_case["expected_option_type"])
+                self.assertEqual(option.default, manifest_option.default)
+                self.assertEqual(option.description, manifest_option.description)
+                self.assertEqual(option.required, manifest_option.required)
+                self.assertEqual(option.choices, manifest_option.choices)


### PR DESCRIPTION
# Description

Adds a new property to the `Manifest`: `options`. This is a list of a new object, called `ManifestOption`. Convenience methods are introduced to `ManifestOption` and `Manifest` to be able to extract `nextmv.Options` from them, and viceversa: instantiating if one already has the options.

For the "Apps from Models" experience (notebooks), the `__entrypoint__.py` is modified so that the options are consumed from the manifest options as opposed to the underlying model configuration options.