### PR TITLE
Make adjustments to tracked run

### DIFF
--- a/nextmv/nextmv/cloud/application.py
+++ b/nextmv/nextmv/cloud/application.py
@@ -1434,7 +1434,7 @@ class Application:
 
         upload_input = tracked_run.input
         if isinstance(tracked_run.input, Input):
-            upload_input = tracked_run.input.to_dict()
+            upload_input = tracked_run.input.data
 
         self.upload_large_input(input=upload_input, upload_url=url_input)
 

--- a/nextmv/nextmv/output.py
+++ b/nextmv/nextmv/output.py
@@ -163,9 +163,9 @@ class Statistics(BaseModel):
 class OutputFormat(str, Enum):
     """Format of an `Input`."""
 
-    JSON = "JSON"
+    JSON = "json"
     """JSON format, utf-8 encoded."""
-    CSV_ARCHIVE = "CSV_ARCHIVE"
+    CSV_ARCHIVE = "csv-archive"
     """CSV archive format: multiple CSV files."""
 
 
@@ -334,11 +334,10 @@ class Output:
         """
 
         output_dict = {
-            "options": self.options.to_dict() if self.options is not None else None,
-            "output_format": self.output_format,
-            "solution": self.solution,
-            "statistics": self.statistics.to_dict() if self.statistics is not None else None,
-            "assets": [asset.to_dict() for asset in self.assets] if self.assets is not None else None,
+            "options": self.options.to_dict() if self.options is not None else {},
+            "solution": self.solution if self.solution is not None else {},
+            "statistics": self.statistics.to_dict() if self.statistics is not None else {},
+            "assets": [asset.to_dict() for asset in self.assets] if self.assets is not None else [],
         }
 
         if self.output_format == OutputFormat.CSV_ARCHIVE:


### PR DESCRIPTION
# Description

- For tracking the input, we were using `nextmv.Input.to_dict`, which resulted in the input having `options`, `data`, and `input_format`. Instead, we just use `nextmv.Input.data` as an input, to have the actual data as input.
- For tracking the output, the `dict` representation of the `nextmv.Output` is adjusted to stop showing `null` and show empty objects or lists instead, where applicable. This is in line with how `nextmv.write` does it.