### PR TITLE
Addresses issue with multiple stdout redirects

### DIFF
--- a/nextmv/nextmv/logger.py
+++ b/nextmv/nextmv/logger.py
@@ -3,13 +3,17 @@
 import sys
 
 __original_stdout = None
+__stdout_redirected = False
 
 
 def redirect_stdout() -> None:
     """Redirect all messages written to stdout to stderr. When you do not want
     to redirect stdout anymore, call `reset_stdout`."""
 
-    global __original_stdout
+    global __original_stdout, __stdout_redirected
+    if __stdout_redirected:
+        return
+    __stdout_redirected = True
 
     __original_stdout = sys.stdout
     sys.stdout = sys.stderr
@@ -19,7 +23,10 @@ def reset_stdout() -> None:
     """Reset stdout to its original value. This function should always be
     called after `redirect_stdout` to avoid unexpected behavior."""
 
-    global __original_stdout
+    global __original_stdout, __stdout_redirected
+    if not __stdout_redirected:
+        return
+    __stdout_redirected = False
 
     if __original_stdout is None:
         sys.stdout = sys.__stdout__


### PR DESCRIPTION
# Description

Fixes an issue where multiple (unintentional) `nextmv.redirect_stdout()` calls would loose the original `sys.stdout` reference that was originally set. This PR blocks successive redirects and makes sure the original `sys.stdout` is safe. The implementation does not support multi-threading (yet).

## Changes

* Fixes issue with multiple successive `nextmv.redirect_stdout()` calls.