### PR TITLE
Improves tracked run duration experience

### DIFF
--- a/nextmv/nextmv/cloud/__init__.py
+++ b/nextmv/nextmv/cloud/__init__.py
@@ -53,6 +53,7 @@ from .run import RunType as RunType
 from .run import RunTypeConfiguration as RunTypeConfiguration
 from .run import TrackedRun as TrackedRun
 from .run import TrackedRunStatus as TrackedRunStatus
+from .run import run_duration as run_duration
 from .scenario import Scenario as Scenario
 from .scenario import ScenarioConfiguration as ScenarioConfiguration
 from .scenario import ScenarioInput as ScenarioInput

--- a/nextmv/nextmv/cloud/run.py
+++ b/nextmv/nextmv/cloud/run.py
@@ -14,6 +14,36 @@ from nextmv.input import Input, InputFormat
 from nextmv.output import Output, OutputFormat
 
 
+def run_duration(
+    start: Union[datetime, float],
+    end: Union[datetime, float],
+) -> int:
+    """
+    Calculate the duration of a run in milliseconds.
+
+    Parameters
+    ----------
+    start : datetime
+        The start time of the run.
+    end : datetime
+        The end time of the run.
+
+    Returns
+    -------
+    int
+        The duration of the run in milliseconds.
+    """
+    if isinstance(start, float) and isinstance(end, float):
+        if start > end:
+            raise ValueError("Start time must be before end time.")
+        return int(round((end - start) * 1000))
+    if isinstance(start, datetime) and isinstance(end, datetime):
+        if start > end:
+            raise ValueError("Start time must be before end time.")
+        return int(round((end - start).total_seconds() * 1000))
+    raise TypeError("Start and end must be either datetime or float.")
+
+
 class Metadata(BaseModel):
     """Metadata of a run, whether it was successful or not."""
 
@@ -180,8 +210,8 @@ class ExternalRunResult(BaseModel):
     """Status of the run."""
     error_message: Optional[str] = None
     """Error message of the run."""
-    execution_duration: Optional[float] = None
-    """Duration of the run, in seconds."""
+    execution_duration: Optional[int] = None
+    """Duration of the run, in milliseconds."""
 
     def __post_init_post_parse__(self):
         """Validations done after parsing the model."""
@@ -245,8 +275,8 @@ class TrackedRun:
     status: TrackedRunStatus
     """The status of the run being tracked"""
 
-    duration: Optional[float] = None
-    """The duration of the run being tracked, in seconds."""
+    duration: Optional[int] = None
+    """The duration of the run being tracked, in milliseconds."""
     error: Optional[str] = None
     """An error message if the run failed. You should only specify this if the
     run failed, otherwise an exception will be raised."""

--- a/nextmv/nextmv/cloud/run.py
+++ b/nextmv/nextmv/cloud/run.py
@@ -23,10 +23,12 @@ def run_duration(
 
     Parameters
     ----------
-    start : datetime
-        The start time of the run.
-    end : datetime
-        The end time of the run.
+    start : Union[datetime, float]
+        The start time of the run. Can be a datetime object or a float
+        representing the start time in seconds since the epoch.
+    end : Union[datetime, float]
+        The end time of the run. Can be a datetime object or a float
+        representing the end time in seconds since the epoch.
 
     Returns
     -------

--- a/nextmv/nextmv/cloud/run.py
+++ b/nextmv/nextmv/cloud/run.py
@@ -245,7 +245,7 @@ class TrackedRun:
     status: TrackedRunStatus
     """The status of the run being tracked"""
 
-    duration: Optional[int] = None
+    duration: Optional[float] = None
     """The duration of the run being tracked, in seconds."""
     error: Optional[str] = None
     """An error message if the run failed. You should only specify this if the

--- a/nextmv/nextmv/cloud/run.py
+++ b/nextmv/nextmv/cloud/run.py
@@ -180,7 +180,7 @@ class ExternalRunResult(BaseModel):
     """Status of the run."""
     error_message: Optional[str] = None
     """Error message of the run."""
-    execution_duration: Optional[int] = None
+    execution_duration: Optional[float] = None
     """Duration of the run, in seconds."""
 
     def __post_init_post_parse__(self):


### PR DESCRIPTION
# Description

Improves the experience around specifying duration on tracked runs by introducing a convenience function for converting typical Python time measurements to milliseconds.

Example of `time.now()` being used:

```python
before = time.time()
# ... Make the run here
tracked_result = app.track_run_with_result(
     # ...
    tracked_run=nextmv.cloud.TrackedRun(
        # ...
        duration=nextmv.cloud.run_duration(
            start=before,
            end=time.time(),
        ),
        # ...
    ),
)
```

Example of `datetime.now()` being used:

```python
before = datetime.now()
# ... Make the run here
tracked_result = app.track_run_with_result(
     # ...
    tracked_run=nextmv.cloud.TrackedRun(
        # ...
        duration=nextmv.cloud.run_duration(
            start=before,
            end=datetime.now(),
        ),
        # ...
    ),
)
```


## Changes

* Introduces `nextmv.cloud.run_duration(start=<start-time>, end=<end-time>)` convenience function for run duration.