### PR TITLE
Allows control over json serialization

### DIFF
--- a/nextmv/nextmv/__about__.py
+++ b/nextmv/nextmv/__about__.py
@@ -1,1 +1,1 @@
-__version__ = "v0.26.1"
+__version__ = "v0.26.2.dev0"

--- a/nextmv/nextmv/output.py
+++ b/nextmv/nextmv/output.py
@@ -292,6 +292,10 @@ class Output:
     """Optional configuration for writing CSV files, to be used when the
     `output_format` is OutputFormat.CSV_ARCHIVE. These configurations are
     passed as kwargs to the `DictWriter` class from the `csv` module."""
+    json_configurations: Optional[dict[str, Any]] = None
+    """Optional configuration for writing JSON files, to be used when the
+    `output_format` is OutputFormat.JSON. These configurations are passed as
+    kwargs to the `json.dumps` function."""
     assets: Optional[list[Asset]] = None
     """Optional list of assets to be included in the output."""
 
@@ -342,6 +346,8 @@ class Output:
 
         if self.output_format == OutputFormat.CSV_ARCHIVE:
             output_dict["csv_configurations"] = self.csv_configurations
+        elif self.output_format == OutputFormat.JSON:
+            output_dict["json_configurations"] = self.json_configurations
 
         return output_dict
 
@@ -383,10 +389,23 @@ class LocalOutputWriter(OutputWriter):
                 "assets": assets,
             }
 
+        json_configurations = output.json_configurations
+        if json_configurations is None:
+            json_configurations = {}
+
+        indent, custom_serial = 2, _custom_serial
+        if "indent" in json_configurations:
+            indent = json_configurations["indent"]
+            del json_configurations["indent"]
+        if "default" in json_configurations:
+            custom_serial = json_configurations["default"]
+            del json_configurations["default"]
+
         serialized = json.dumps(
             final_output,
-            indent=2,
-            default=_custom_serial,
+            indent=indent,
+            default=custom_serial,
+            **json_configurations,
         )
 
         if path is None or path == "":

--- a/nextmv/nextmv/output.py
+++ b/nextmv/nextmv/output.py
@@ -389,9 +389,9 @@ class LocalOutputWriter(OutputWriter):
                 "assets": assets,
             }
 
-        json_configurations = output.json_configurations
-        if json_configurations is None:
-            json_configurations = {}
+        json_configurations = {}
+        if hasattr(output, "json_configurations") and output.json_configurations is not None:
+            json_configurations = output.json_configurations
 
         indent, custom_serial = 2, _custom_serial
         if "indent" in json_configurations:

--- a/nextmv/tests/test_output.py
+++ b/nextmv/tests/test_output.py
@@ -73,6 +73,27 @@ class TestOutput(unittest.TestCase):
 
             self.assertDictEqual(got, expected)
 
+    def test_local_writer_json_stdout_with_configurations(self):
+        output = nextmv.Output(
+            output_format=nextmv.OutputFormat.JSON,
+            solution={"empanadas": "are_life"},
+            statistics={"foo": "bar"},
+            json_configurations={
+                "indent": None,
+                "separators": (",", ":"),
+                "sort_keys": True,
+            },
+        )
+        output_writer = nextmv.LocalOutputWriter()
+
+        with patch("sys.stdout", new=StringIO()) as mock_stdout:
+            output_writer.write(output, skip_stdout_reset=True)
+
+            self.assertEqual(
+                mock_stdout.getvalue(),
+                '{"assets":[],"options":{},"solution":{"empanadas":"are_life"},"statistics":{"foo":"bar"}}\n',
+            )
+
     def test_local_writer_json_stdout_with_options(self):
         options = nextmv.Options()
         options.duration = 5


### PR DESCRIPTION
# Description

Allows control over JSON serialization of output.

Example:

```python
output = nextmv.Output(
    output_format=nextmv.OutputFormat.JSON,
    solution={"empanadas": "are_life"},
    statistics={"foo": "bar"},
    # Configure the output JSON to use minimal whitespace and sort the keys:
    json_configurations={
        "indent": None,
        "separators": (",", ":"),
        "sort_keys": True,
    },
)
```

## Changes

* Allows users to control JSON serialization of the output.