### PR TITLE
Fixes logs being submitted to tracked runs as simple string

### DIFF
--- a/nextmv/nextmv/cloud/run.py
+++ b/nextmv/nextmv/cloud/run.py
@@ -331,4 +331,10 @@ class TrackedRun:
         if self.logs is None:
             return ""
 
-        return "\n".join(self.logs)
+        if isinstance(self.logs, str):
+            return self.logs
+
+        if isinstance(self.logs, list):
+            return "\n".join(self.logs)
+
+        raise TypeError("Logs must be a string or a list of strings.")


### PR DESCRIPTION
# Description

Fixes logs submitted directly as strings (alongside a tracked run) not being displayed correctly.

Submitting a run like this:

```python
app.track_run_with_result(
    tracked_run=nextmv.cloud.TrackedRun(
        # ...
        logs="Hello Nextmv!",
    ),
)
```

Resulted in this log output in Nextmv Console:

```txt
H
e
l
l
o

N
e
x
t
m
v
!
```

## Changes

* Fixed string logs in tracked runs.