### PR TITLE
Fix the option parsing with the manifest

### DIFF
--- a/nextmv/nextmv/__entrypoint__.py
+++ b/nextmv/nextmv/__entrypoint__.py
@@ -19,9 +19,7 @@ def main() -> None:
     manifest = cloud.Manifest.from_yaml(".")
 
     # Load the options from the manifest.
-    options = None
-    if manifest.options is not None:
-        options = manifest.extract_options()
+    options = manifest.extract_options()
 
     # Load the model.
     loaded_model = load_model(

--- a/nextmv/nextmv/cloud/application.py
+++ b/nextmv/nextmv/cloud/application.py
@@ -2327,6 +2327,10 @@ class Application:
                 "runtime": manifest.runtime,
             },
         }
+
+        if manifest.configuration is not None and manifest.configuration.options is not None:
+            activation_request["requirements"]["options"] = manifest.configuration.options.to_dict()
+
         response = self.client.request(
             method="PUT",
             endpoint=endpoint,

--- a/nextmv/nextmv/cloud/manifest.py
+++ b/nextmv/nextmv/cloud/manifest.py
@@ -16,8 +16,19 @@ FILE_NAME = "app.yaml"
 
 
 class ManifestType(str, Enum):
-    """Type of application in the manifest, based on the programming
-    language."""
+    """
+    Type of application in the manifest, based on the programming
+    language.
+
+    Attributes
+    ----------
+    PYTHON: str
+        Python format
+    GO: str
+        Go format
+    JAVA: str
+        Java format
+    """
 
     PYTHON = "python"
     """Python format"""
@@ -28,7 +39,23 @@ class ManifestType(str, Enum):
 
 
 class ManifestRuntime(str, Enum):
-    """Runtime (environment) where the app will be run on Nextmv Cloud."""
+    """
+    Runtime (environment) where the app will be run on Nextmv Cloud.
+
+    Attributes
+    ----------
+    DEFAULT: str
+        This runtime is used to run compiled applications such as Go binaries.
+    PYTHON: str
+        This runtime is used as the basis for all other Python runtimes and
+        Python applications.
+    JAVA: str
+        This runtime is used to run Java applications.
+    PYOMO: str
+        This runtime provisions Python packages to run Pyomo applications.
+    HEXALY: str
+        This runtime provisions Python packages to run Hexaly applications.
+    """
 
     DEFAULT = "ghcr.io/nextmv-io/runtime/default:latest"
     """This runtime is used to run compiled applications such as Go binaries."""
@@ -49,7 +76,20 @@ class ManifestRuntime(str, Enum):
 
 
 class ManifestBuild(BaseModel):
-    """Build-specific attributes."""
+    """
+    Build-specific attributes.
+
+    Attributes
+    ----------
+    command: Optional[str]
+        The command to run to build the app. This command will be executed
+        without a shell, i.e., directly. The command must exit with a status of
+        0 to continue the push process of the app to Nextmv Cloud. This command
+        is executed prior to the pre-push command.
+    environment: Optional[dict[str, Any]]
+        Environment variables to set when running the build command given as
+        key-value pairs.
+    """
 
     command: Optional[str] = None
     """
@@ -82,7 +122,19 @@ class ManifestBuild(BaseModel):
 
 
 class ManifestPythonModel(BaseModel):
-    """Model-specific instructions for a Python app."""
+    """
+    Model-specific instructions for a Python app.
+
+    Attributes
+    ----------
+    name: str
+        The name of the decision model.
+    options: Optional[list[dict[str, Any]]]
+        Options for the decision model. This is a data representation of the
+        `nextmv.Options` class. It consists of a list of dicts. Each dict
+        represents the `nextmv.Option` class. It is used to be able to
+        reconstruct an Options object from data when loading a decision model.
+    """
 
     name: str
     """The name of the decision model."""
@@ -96,7 +148,18 @@ class ManifestPythonModel(BaseModel):
 
 
 class ManifestPython(BaseModel):
-    """Python-specific instructions."""
+    """
+    Python-specific instructions.
+
+    Attributes
+    ----------
+    pip_requirements: Optional[str]
+        Path to a requirements.txt file containing (additional) Python
+        dependencies that will be bundled with the app.
+    model: Optional[ManifestPythonModel]
+        Information about an encoded decision model as handlded via mlflow. This
+        information is used to load the decision model from the app bundle.
+    """
 
     pip_requirements: Optional[str] = Field(
         serialization_alias="pip-requirements",
@@ -115,7 +178,23 @@ class ManifestPython(BaseModel):
 
 
 class ManifestOption(BaseModel):
-    """An option for the decision model that is recorded in the manifest."""
+    """
+    An option for the decision model that is recorded in the manifest.
+
+    Attributes
+    ----------
+    name: str
+        The name of the option.
+    option_type: str
+        The type of the option. This is a string representation of the
+        `nextmv.Option` class.
+    default: Optional[Any]
+        The default value of the option.
+    description: Optional[str]
+        The description of the option.
+    required: bool
+        Whether the option is required or not.
+    """
 
     name: str
     """The name of the option"""
@@ -131,8 +210,13 @@ class ManifestOption(BaseModel):
     """The description of the option"""
     required: bool = False
     """Whether the option is required or not"""
-    choices: Optional[list[Any]] = None
-    """The choices for the option"""
+    additional_attributes: Optional[dict[str, Any]] = None
+    """
+    Optional additional attributes for the option. The Nextmv Cloud may
+    perform validation on these attributes. For example, the maximum length of
+    a string or the maximum value of an integer. These additional attributes
+    will be shown in the help message of the `Options`.
+    """
 
     @classmethod
     def from_option(cls, option: Option) -> "ManifestOption":
@@ -153,9 +237,9 @@ class ManifestOption(BaseModel):
         if option_type is str:
             option_type = "string"
         elif option_type is bool:
-            option_type = "boolean"
+            option_type = "bool"
         elif option_type is int:
-            option_type = "integer"
+            option_type = "int"
         elif option_type is float:
             option_type = "float"
         else:
@@ -167,7 +251,7 @@ class ManifestOption(BaseModel):
             default=option.default,
             description=option.description,
             required=option.required,
-            choices=option.choices,
+            additional_attributes=option.additional_attributes,
         )
 
     def to_option(self) -> Option:
@@ -183,9 +267,9 @@ class ManifestOption(BaseModel):
         option_type_string = self.option_type
         if option_type_string == "string":
             option_type = str
-        elif option_type_string == "boolean":
+        elif option_type_string == "bool":
             option_type = bool
-        elif option_type_string == "integer":
+        elif option_type_string == "int":
             option_type = int
         elif option_type_string == "float":
             option_type = float
@@ -198,8 +282,45 @@ class ManifestOption(BaseModel):
             default=self.default,
             description=self.description,
             required=self.required,
-            choices=self.choices,
+            additional_attributes=self.additional_attributes,
         )
+
+
+class ManifestOptions(BaseModel):
+    """
+    Options for the decision model.
+
+    Attributes
+    ----------
+    strict: bool
+        If strict is set to `True`, only the listed options will be allowed.
+    items: list[ManifestOption]
+        Optional. The actual list of options for the decision model. An option
+        is a parameter that configures the decision model.
+    """
+
+    strict: Optional[bool] = False
+    """If strict is set to `True`, only the listed options will be allowed."""
+    items: Optional[list[ManifestOption]] = None
+    """
+    Optional. The actual list of options for the decision model. An option is a
+    parameter that configures the decision model.
+    """
+
+
+class ManifestConfiguration(BaseModel):
+    """
+    Configuration for the decision model.
+
+    Attributes
+    ----------
+    options: ManifestOptions
+        Optional. The actual list of options for the decision model. An option
+        is a parameter that configures the decision model.
+    """
+
+    options: ManifestOptions
+    """Options for the decision model."""
 
 
 class Manifest(BaseModel):
@@ -210,6 +331,34 @@ class Manifest(BaseModel):
 
     This class represents the app manifest and allows you to load it from a
     file or create it programmatically.
+
+    Attributes
+    ----------
+    files: list[str]
+        Mandatory. The files to include (or exclude) in the app.
+    runtime: ManifestRuntime
+        Mandatory. The runtime to use for the app, it provides the environment
+        in which the app runs.
+    type: ManifestType
+        Mandatory. Type of application, based on the programming language.
+    build: Optional[ManifestBuild]
+        Optional. Build-specific attributes. The build.command to run to build
+        the app. This command will be executed without a shell, i.e., directly.
+        The command must exit with a status of 0 to continue the push process of
+        the app to Nextmv Cloud. This command is executed prior to the pre-push
+        command. The build.environment is used to set environment variables when
+        running the build command given as key-value pairs.
+    pre_push: Optional[str]
+        Optional. A command to run before the app is pushed to the Nextmv Cloud.
+        This command can be used to compile a binary, run tests or similar tasks.
+        One difference with what is specified under build, is that the command
+        will be executed via
+    python: Optional[ManifestPython]
+        Optional. Only for Python apps. Contains further Python-specific
+        attributes.
+    configuration: Optional[ManifestConfiguration]
+        Optional. A list of options for the decision model. An option is a
+        parameter that configures the decision model.
     """
 
     files: list[str]
@@ -250,7 +399,7 @@ class Manifest(BaseModel):
     Optional. Only for Python apps. Contains further Python-specific
     attributes.
     """
-    options: Optional[list[ManifestOption]] = None
+    configuration: Optional[ManifestConfiguration] = None
     """
     Optional. A list of options for the decision model. An option is a
     parameter that configures the decision model.
@@ -302,10 +451,16 @@ class Manifest(BaseModel):
             The converted options.
         """
 
-        if self.options is None:
-            raise ValueError("No options found in the manifest")
+        if self.configuration is None:
+            raise ValueError("No configuration found in the manifest")
 
-        options = [option.to_option() for option in self.options]
+        if self.configuration.options is None:
+            raise ValueError("No options found in the manifest configuration")
+
+        if self.configuration.options.items is None:
+            raise ValueError("No items found in the manifest configuration options")
+
+        options = [option.to_option() for option in self.configuration.options.items]
 
         return Options(*options)
 
@@ -377,7 +532,12 @@ class Manifest(BaseModel):
             runtime=ManifestRuntime.PYTHON,
             type=ManifestType.PYTHON,
             python=ManifestPython(pip_requirements="requirements.txt"),
-            options=[ManifestOption.from_option(opt) for opt in options.options],
+            configuration=ManifestConfiguration(
+                options=ManifestOptions(
+                    strict=False,
+                    items=[ManifestOption.from_option(opt) for opt in options.options],
+                ),
+            ),
         )
 
         return manifest

--- a/nextmv/nextmv/cloud/manifest.py
+++ b/nextmv/nextmv/cloud/manifest.py
@@ -441,24 +441,21 @@ class Manifest(BaseModel):
         with open(os.path.join(dirpath, FILE_NAME), "w") as file:
             yaml.dump(self.to_dict(), file)
 
-    def extract_options(self) -> Options:
+    def extract_options(self) -> Optional[Options]:
         """
-        Convert the manifest options to a `nextmv.Options` object.
+        Convert the manifest options to a `nextmv.Options` object. If the
+        manifest does not have valid options defined in
+        `.configuration.options.items`, this method simply returns a `None`.
 
         Returns
         -------
-        Options
-            The converted options.
+        Optional[Options]
+            The options extracted from the manifest. If no options are found,
+            `None` is returned.
         """
 
-        if self.configuration is None:
-            raise ValueError("No configuration found in the manifest")
-
-        if self.configuration.options is None:
-            raise ValueError("No options found in the manifest configuration")
-
-        if self.configuration.options.items is None:
-            raise ValueError("No items found in the manifest configuration options")
+        if self.configuration is None or self.configuration.options is None or self.configuration.options.items is None:
+            return None
 
         options = [option.to_option() for option in self.configuration.options.items]
 
@@ -503,7 +500,12 @@ class Manifest(BaseModel):
         )
 
         if model_configuration.options is not None:
-            manifest.options = [ManifestOption.from_option(opt) for opt in model_configuration.options.options]
+            manifest.configuration = ManifestConfiguration(
+                options=ManifestOptions(
+                    strict=False,
+                    items=[ManifestOption.from_option(opt) for opt in model_configuration.options.options],
+                ),
+            )
 
         return manifest
 

--- a/nextmv/nextmv/options.py
+++ b/nextmv/nextmv/options.py
@@ -164,6 +164,11 @@ class Option:
         argument, an environment variable or a default value.
     choices : list[Optional[Any]], optional
         Limits values to a specific set of choices.
+    additional_attributes : dict[str, Any], optional
+        Optional additional attributes for the option. The Nextmv Cloud may
+        perform validation on these attributes. For example, the maximum length
+        of a string or the maximum value of an integer. These additional
+        attributes will be shown in the help message of the `Options`.
     """
 
     name: str
@@ -189,6 +194,13 @@ class Option:
     """
     choices: Optional[list[Any]] = None
     """Limits values to a specific set of choices."""
+    additional_attributes: Optional[dict[str, Any]] = None
+    """
+    Optional additional attributes for the option. The Nextmv Cloud may
+    perform validation on these attributes. For example, the maximum length of
+    a string or the maximum value of an integer. These additional attributes
+    will be shown in the help message of the `Options`.
+    """
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "Option":
@@ -209,13 +221,14 @@ class Option:
         option_type_string = data["option_type"]
         option_type = getattr(builtins, option_type_string.split("'")[1])
 
-        return Option(
+        return cls(
             name=data["name"],
             option_type=option_type,
             default=data.get("default"),
             description=data.get("description"),
             required=data.get("required", False),
             choices=data.get("choices"),
+            additional_attributes=data.get("additional_attributes"),
         )
 
     def to_dict(self) -> dict[str, Any]:
@@ -235,6 +248,7 @@ class Option:
             "description": self.description,
             "required": self.required,
             "choices": self.choices,
+            "additional_attributes": self.additional_attributes,
         }
 
 
@@ -728,6 +742,9 @@ class Options:
             description += f" (default: {option.default})"
 
         description += f" (type: {self._option_type(option).__name__})"
+
+        if isinstance(option, Option) and option.additional_attributes is not None:
+            description += f" (additional attributes: {option.additional_attributes})"
 
         if option.description is not None and option.description != "":
             description += f": {option.description}"

--- a/nextmv/nextmv/options.py
+++ b/nextmv/nextmv/options.py
@@ -66,7 +66,7 @@ class Parameter:
     def __post_init__(self):
         deprecated(
             name="Parameter",
-            reason="`Parameter` is deprecated, use `Option` instead.",
+            reason="`Parameter` is deprecated, use `Option` instead",
         )
 
     @classmethod

--- a/nextmv/tests/cloud/app.yaml
+++ b/nextmv/tests/cloud/app.yaml
@@ -5,10 +5,9 @@ python:
   model:
     name: super_cool_model
     options:
-      - choices: null
+      - name: duration
         default: 30
         description: Max runtime duration (in seconds).
-        name: duration
         param_type: <class 'int'>
         required: false
   pip-requirements: model_requirements.txt
@@ -20,24 +19,27 @@ build:
   environment:
     SUPER: COOL
     EXTRA: AWESOME
-options:
-  - name: a string parameter
-    option_type: string
-    default: a default value
-    description: a description
-    required: true
-  - name: a boolean parameter
-    option_type: boolean
-    default: true
-    description: a description
-    required: false
-  - name: an integer parameter
-    option_type: integer
-    default: 42
-    description: a description
-    required: false
-  - name: a float parameter
-    option_type: float
-    default: 3.14
-    description: a description
-    required: false
+configuration:
+  options:
+    strict: false
+    items:
+      - name: a string parameter
+        option_type: string
+        default: a default value
+        description: a description
+        required: true
+      - name: a boolean parameter
+        option_type: bool
+        default: true
+        description: a description
+        required: false
+      - name: an integer parameter
+        option_type: int
+        default: 42
+        description: a description
+        required: false
+      - name: a float parameter
+        option_type: float
+        default: 3.14
+        description: a description
+        required: false

--- a/nextmv/tests/cloud/test_manifest.py
+++ b/nextmv/tests/cloud/test_manifest.py
@@ -80,7 +80,6 @@ class TestManifest(unittest.TestCase):
             manifest.python.model.options,
             [
                 {
-                    "choices": None,
                     "default": 30,
                     "description": "Max runtime duration (in seconds).",
                     "name": "duration",
@@ -108,8 +107,8 @@ class TestManifest(unittest.TestCase):
 
         found = {
             "string": False,
-            "boolean": False,
-            "integer": False,
+            "bool": False,
+            "int": False,
             "float": False,
         }
 
@@ -117,16 +116,22 @@ class TestManifest(unittest.TestCase):
             if option.option_type is str:
                 found["string"] = True
             elif option.option_type is bool:
-                found["boolean"] = True
+                found["bool"] = True
             elif option.option_type is int:
-                found["integer"] = True
+                found["int"] = True
             elif option.option_type is float:
                 found["float"] = True
 
         self.assertTrue(found["string"])
-        self.assertTrue(found["boolean"])
-        self.assertTrue(found["integer"])
+        self.assertTrue(found["bool"])
+        self.assertTrue(found["int"])
         self.assertTrue(found["float"])
+
+        manifest2 = Manifest(
+            files=["main.py"],
+        )
+        options2 = manifest2.extract_options()
+        self.assertIsNone(options2)
 
     def test_from_options(self):
         options = Options(
@@ -142,7 +147,7 @@ class TestManifest(unittest.TestCase):
         self.assertEqual(manifest.type, ManifestType.PYTHON)
         self.assertEqual(manifest.python.pip_requirements, "requirements.txt")
         self.assertListEqual(
-            manifest.options,
+            manifest.configuration.options.items,
             [
                 ManifestOption(
                     name="param1",
@@ -153,14 +158,14 @@ class TestManifest(unittest.TestCase):
                 ),
                 ManifestOption(
                     name="param2",
-                    option_type="boolean",
+                    option_type="bool",
                     default=True,
                     description="A description",
                     required=True,
                 ),
                 ManifestOption(
                     name="param3",
-                    option_type="integer",
+                    option_type="int",
                     default=42,
                     description="A description",
                     required=True,
@@ -187,12 +192,12 @@ class TestManifestOption(unittest.TestCase):
             {
                 "name": "bool option",
                 "option": Option("param2", bool, True, "A description", True),
-                "expected_option_type": "boolean",
+                "expected_option_type": "bool",
             },
             {
                 "name": "int option",
                 "option": Option("param3", int, 42, "A description", True),
-                "expected_option_type": "integer",
+                "expected_option_type": "int",
             },
             {
                 "name": "float option",
@@ -211,7 +216,6 @@ class TestManifestOption(unittest.TestCase):
                 self.assertEqual(manifest_option.default, option.default)
                 self.assertEqual(manifest_option.description, option.description)
                 self.assertEqual(manifest_option.required, option.required)
-                self.assertEqual(manifest_option.choices, option.choices)
 
     def test_to_option(self):
         test_cases = [
@@ -230,7 +234,7 @@ class TestManifestOption(unittest.TestCase):
                 "name": "bool option",
                 "manifest_option": ManifestOption(
                     name="param2",
-                    option_type="boolean",
+                    option_type="bool",
                     default=True,
                     description="A description",
                     required=True,
@@ -241,7 +245,7 @@ class TestManifestOption(unittest.TestCase):
                 "name": "int option",
                 "manifest_option": ManifestOption(
                     name="param3",
-                    option_type="integer",
+                    option_type="int",
                     default=42,
                     description="A description",
                     required=True,
@@ -271,4 +275,3 @@ class TestManifestOption(unittest.TestCase):
                 self.assertEqual(option.default, manifest_option.default)
                 self.assertEqual(option.description, manifest_option.description)
                 self.assertEqual(option.required, manifest_option.required)
-                self.assertEqual(option.choices, manifest_option.choices)


### PR DESCRIPTION
Adheres to the new schema for manifest options:

```yaml
configuration:
  options:
    strict: false
    items:
      - name: a string parameter
        option_type: string
        default: a default value
        description: a description
        required: true
      - name: a boolean parameter
        option_type: bool
        default: true
        description: a description
        required: false
      - name: an integer parameter
        option_type: int
        default: 42
        description: a description
        required: false
      - name: a float parameter
        option_type: float
        default: 3.14
        description: a description
        required: false
```

One can use the following methods to interact with a `cloud.Manifest` and `nextmv.Options`:
- `Manifest.from_options(...)` -> creates a manifest from `nextmv.Options`.
- `manifest.extract_options()` -> creates `nextmv.Options` from a manifest.