### PR TITLE
Improves output handling with dicts

### DIFF
--- a/nextmv/nextmv/cloud/run.py
+++ b/nextmv/nextmv/cloud/run.py
@@ -270,9 +270,9 @@ class TrackedRun:
         the log. This field is optional.
     """
 
-    input: Union[Input, dict[str, any], str]
+    input: Union[Input, dict[str, Any], str]
     """The input of the run being tracked."""
-    output: Union[Output, dict[str, any], str]
+    output: Union[Output, dict[str, Any], str]
     """The output of the run being tracked. Only JSON output_format is supported."""
     status: TrackedRunStatus
     """The status of the run being tracked"""

--- a/nextmv/nextmv/output.py
+++ b/nextmv/nextmv/output.py
@@ -252,7 +252,7 @@ class Output:
     result of the decision problem. The solution’s type must match the
     `output_format`:
 
-    - `OutputFormat.JSON`: the data must be `dict[str, Any]`.
+    - `OutputFormat.JSON`: the data must be `dict[str, Any]`, or `Any`.
     - `OutputFormat.CSV_ARCHIVE`: the data must be `dict[str, list[dict[str,
       Any]]]`. The keys represent the file names where the data should be
       written. The values are lists of dictionaries, where each dictionary
@@ -263,20 +263,73 @@ class Output:
     dictionary, we recommend using the `Statistics` class to ensure that the
     data is correctly formatted.
 
-    Parameters
+    The assets are used to keep track of different downloadable information that
+    is part of the output. The assets can be of type `Asset` or a simple
+    dictionary, but we recommend using the `Asset` class to ensure that the data is
+    correctly formatted.
+
+    Attributes
     ----------
-    options : Options, optional
-        Options that the `Input` were created with.
-    output_format : OutputFormat, optional
+    options : Optional[Union[Options, dict[str, Any]]]
+        Options that the `Output` was created with. These options can be of type
+        `Options` or a simple dictionary. If the options are of type `Options`,
+        they will be serialized to a dictionary using the `to_dict` method. If
+        they are a dictionary, they will be used as is. If the options are not
+        provided, an empty dictionary will be used. If the options are of type
+        `dict`, then the dictionary should have the following structure:
+        ```
+        {
+            "duration": "30",
+            "threads": 4,
+        }
+        ```
+    output_format : Optional[OutputFormat]
         Format of the output data. Default is `OutputFormat.JSON`.
-    solution : Union[dict[str, Any], dict[str, list[dict[str, Any]]], optional
-        The solution to the decision problem.
-    statistics : Union[Statistics, dict[str, Any], optional
-        Statistics of the solution.
+    solution : Optional[Union[dict[str, Any], dict[str, list[dict[str, Any]]]]
+        The solution to the decision problem. The type must match the
+        `output_format`:
+        - `OutputFormat.JSON`: the data must be `dict[str, Any]`.
+        - `OutputFormat.CSV_ARCHIVE`: the data must be `dict[str,
+          list[dict[str, Any]]]`. The keys represent the file names where the
+          data should be written. The values are lists of dictionaries, where
+          each dictionary represents a row in the CSV file.
+    statistics : Optional[Union[Statistics, dict[str, Any]]]
+        Statistics of the solution. These statistics can be of type
+        `Statistics` or a simple dictionary. If the statistics are of type
+        `Statistics`, they will be serialized to a dictionary using the
+        `to_dict` method. If they are a dictionary, they will be used as is. If
+        the statistics are not provided, an empty dictionary will be used.
+    csv_configurations : Optional[dict[str, Any]]
+        Optional configuration for writing CSV files, to be used when the
+        `output_format` is `OutputFormat.CSV_ARCHIVE`. These configurations are
+        passed as kwargs to the `DictWriter` class from the `csv` module.
+    json_configurations : Optional[dict[str, Any]]
+        Optional configuration for writing JSON files, to be used when the
+        `output_format` is `OutputFormat.JSON`. These configurations are passed
+        as kwargs to the `json.dumps` function.
+    assets : Optional[list[Union[Asset, dict[str, Any]]]]
+        Optional list of assets to be included in the output. These assets can
+        be of type `Asset` or a simple dictionary. If the assets are of type
+        `Asset`, they will be serialized to a dictionary using the `to_dict`
+        method. If they are a dictionary, they will be used as is. If the
+        assets are not provided, an empty list will be used.
     """
 
-    options: Optional[Options] = None
-    """Options that the `Input` were created with."""
+    options: Optional[Union[Options, dict[str, Any]]] = None
+    """
+    Options that the `Output` was created with. These options can be of type
+    `Options` or a simple dictionary. If the options are of type `Options`,
+    they will be serialized to a dictionary using the `to_dict` method. If
+    they are a dictionary, they will be used as is. If the options are not
+    provided, an empty dictionary will be used. If the options are of type
+    `dict`, then the dictionary should have the following structure:
+    ```
+    {
+        "duration": "30",
+        "threads": 4,
+    }
+    ```
+    """
     output_format: Optional[OutputFormat] = OutputFormat.JSON
     """Format of the output data. Default is `OutputFormat.JSON`."""
     solution: Optional[
@@ -287,17 +340,33 @@ class Output:
     ] = None
     """The solution to the decision problem."""
     statistics: Optional[Union[Statistics, dict[str, Any]]] = None
-    """Statistics of the solution."""
+    """
+    Statistics of the solution. These statistics can be of type `Statistics` or a
+    simple dictionary. If the statistics are of type `Statistics`, they will be
+    serialized to a dictionary using the `to_dict` method. If they are a
+    dictionary, they will be used as is. If the statistics are not provided, an
+    empty dictionary will be used.
+    """
     csv_configurations: Optional[dict[str, Any]] = None
-    """Optional configuration for writing CSV files, to be used when the
-    `output_format` is OutputFormat.CSV_ARCHIVE. These configurations are
-    passed as kwargs to the `DictWriter` class from the `csv` module."""
+    """
+    Optional configuration for writing CSV files, to be used when the
+    `output_format` is `OutputFormat.CSV_ARCHIVE`. These configurations are
+    passed as kwargs to the `DictWriter` class from the `csv` module.
+    """
     json_configurations: Optional[dict[str, Any]] = None
-    """Optional configuration for writing JSON files, to be used when the
-    `output_format` is OutputFormat.JSON. These configurations are passed as
-    kwargs to the `json.dumps` function."""
-    assets: Optional[list[Asset]] = None
-    """Optional list of assets to be included in the output."""
+    """
+    Optional configuration for writing JSON files, to be used when the
+    `output_format` is `OutputFormat.JSON`. These configurations are passed as
+    kwargs to the `json.dumps` function.
+    """
+    assets: Optional[list[Union[Asset, dict[str, Any]]]] = None
+    """
+    Optional list of assets to be included in the output. These assets can be of
+    type `Asset` or a simple dictionary. If the assets are of type `Asset`, they
+    will be serialized to a dictionary using the `to_dict` method. If they are a
+    dictionary, they will be used as is. If the assets are not provided, an
+    empty list will be used.
+    """
 
     def __post_init__(self):
         """Check that the solution matches the format given to initialize the
@@ -327,7 +396,7 @@ class Output:
                 "output_format OutputFormat.CSV_ARCHIVE, supported type is `dict`"
             )
 
-    def to_dict(self) -> dict[str, any]:
+    def to_dict(self) -> dict[str, any]:  # noqa: C901
         """
         Convert the `Output` object to a dictionary.
 
@@ -337,16 +406,66 @@ class Output:
             The dictionary representation of the `Output` object.
         """
 
+        # Options need to end up as a dict, so we achieve that based on the
+        # type of options that were used to create the class.
+        if self.options is None:
+            options = {}
+        elif isinstance(self.options, Options):
+            options = self.options.to_dict()
+        elif isinstance(self.options, dict):
+            options = self.options
+        else:
+            raise TypeError(f"unsupported options type: {type(self.options)}, supported types are `Options` or `dict`")
+
+        # Statistics need to end up as a dict, so we achieve that based on the
+        # type of statistics that were used to create the class.
+        if self.statistics is None:
+            statistics = {}
+        elif isinstance(self.statistics, Statistics):
+            statistics = self.statistics.to_dict()
+        elif isinstance(self.statistics, dict):
+            statistics = self.statistics
+        else:
+            raise TypeError(
+                f"unsupported statistics type: {type(self.statistics)}, supported types are `Statistics` or `dict`"
+            )
+
+        # Assets need to end up as a list of dicts, so we achieve that based on
+        # the type of each asset in the list.
+        assets = []
+        if isinstance(self.assets, list):
+            for ix, asset in enumerate(self.assets):
+                if isinstance(asset, Asset):
+                    assets.append(asset.to_dict())
+                elif isinstance(asset, dict):
+                    assets.append(asset)
+                else:
+                    raise TypeError(
+                        f"unsupported asset {ix}, type: {type(asset)}; supported types are `Asset` or `dict`"
+                    )
+        elif self.assets is not None:
+            raise TypeError(f"unsupported assets type: {type(self.assets)}, supported types are `list`")
+
         output_dict = {
-            "options": self.options.to_dict() if self.options is not None else {},
+            "options": options,
             "solution": self.solution if self.solution is not None else {},
-            "statistics": self.statistics.to_dict() if self.statistics is not None else {},
-            "assets": [asset.to_dict() for asset in self.assets] if self.assets is not None else [],
+            "statistics": statistics,
+            "assets": assets,
         }
 
-        if self.output_format == OutputFormat.CSV_ARCHIVE:
+        # Add the auxiliary configurations to the output dictionary if they are
+        # defined and not empty.
+        if (
+            self.output_format == OutputFormat.CSV_ARCHIVE
+            and self.csv_configurations is not None
+            and self.csv_configurations != {}
+        ):
             output_dict["csv_configurations"] = self.csv_configurations
-        elif self.output_format == OutputFormat.JSON:
+        elif (
+            self.output_format == OutputFormat.JSON
+            and self.json_configurations is not None
+            and self.json_configurations != {}
+        ):
             output_dict["json_configurations"] = self.json_configurations
 
         return output_dict
@@ -371,24 +490,9 @@ class LocalOutputWriter(OutputWriter):
 
     def _write_json(
         output: Union[Output, dict[str, Any], BaseModel],
-        options: dict[str, Any],
-        statistics: dict[str, Any],
-        assets: list[dict[str, Any]],
+        output_dict: dict[str, Any],
         path: Optional[str] = None,
     ) -> None:
-        if isinstance(output, dict):
-            final_output = output
-        elif isinstance(output, BaseModel):
-            final_output = output.to_dict()
-        else:
-            solution = output.solution if output.solution is not None else {}
-            final_output = {
-                "options": options,
-                "solution": solution,
-                "statistics": statistics,
-                "assets": assets,
-            }
-
         json_configurations = {}
         if hasattr(output, "json_configurations") and output.json_configurations is not None:
             json_configurations = output.json_configurations
@@ -402,7 +506,7 @@ class LocalOutputWriter(OutputWriter):
             del json_configurations["default"]
 
         serialized = json.dumps(
-            final_output,
+            output_dict,
             indent=indent,
             default=custom_serial,
             **json_configurations,
@@ -416,10 +520,8 @@ class LocalOutputWriter(OutputWriter):
             file.write(serialized + "\n")
 
     def _write_archive(
-        output: Output,
-        options: dict[str, Any],
-        statistics: dict[str, Any],
-        assets: list[dict[str, Any]],
+        output: Union[Output, dict[str, Any], BaseModel],
+        output_dict: dict[str, Any],
         path: Optional[str] = None,
     ) -> None:
         dir_path = "output"
@@ -434,9 +536,9 @@ class LocalOutputWriter(OutputWriter):
 
         serialized = json.dumps(
             {
-                "options": options,
-                "statistics": statistics,
-                "assets": assets,
+                "options": output_dict.get("options", {}),
+                "statistics": output_dict.get("statistics", {}),
+                "assets": output_dict.get("assets", []),
             },
             indent=2,
         )
@@ -525,87 +627,23 @@ class LocalOutputWriter(OutputWriter):
                 f"unsupported output type: {type(output)}, supported types are `Output`, `dict`, `BaseModel`"
             )
 
-        statistics = self._extract_statistics(output)
-        options = self._extract_options(output)
-        assets = self._extract_assets(output)
+        output_dict = {}
+        if isinstance(output, Output):
+            output_dict = output.to_dict()
+        elif isinstance(output, BaseModel):
+            output_dict = output.to_dict()
+        elif isinstance(output, dict):
+            output_dict = output
+        else:
+            raise TypeError(
+                f"unsupported output type: {type(output)}, supported types are `Output`, `dict`, `BaseModel`"
+            )
 
         self.FILE_WRITERS[output_format](
             output=output,
-            options=options,
-            statistics=statistics,
-            assets=assets,
+            output_dict=output_dict,
             path=path,
         )
-
-    @staticmethod
-    def _extract_statistics(output: Union[Output, dict[str, Any]]) -> dict[str, Any]:
-        """Extract JSON-serializable statistics."""
-
-        statistics = {}
-
-        if not isinstance(output, Output):
-            return statistics
-
-        stats = output.statistics
-
-        if stats is None:
-            return statistics
-
-        if isinstance(stats, Statistics):
-            statistics = stats.to_dict()
-        elif isinstance(stats, dict):
-            statistics = stats
-        else:
-            raise TypeError(f"unsupported statistics type: {type(stats)}, supported types are `Statistics` or `dict`")
-
-        return statistics
-
-    @staticmethod
-    def _extract_options(output: Union[Output, dict[str, Any]]) -> dict[str, Any]:
-        """Extract JSON-serializable options."""
-
-        options = {}
-
-        if not isinstance(output, Output):
-            return options
-
-        opt = output.options
-
-        if opt is None:
-            return options
-
-        if isinstance(opt, Options):
-            options = opt.to_dict()
-        elif isinstance(opt, dict):
-            options = opt
-        else:
-            raise TypeError(f"unsupported options type: {type(opt)}, supported types are `Options` or `dict`")
-
-        return options
-
-    @staticmethod
-    def _extract_assets(output: Union[Output, dict[str, Any]]) -> list[dict[str, Any]]:
-        """Extract JSON-serializable assets."""
-
-        assets = []
-
-        if not isinstance(output, Output):
-            return assets
-
-        assts = output.assets
-
-        if assts is None:
-            return assets
-
-        for ix, asset in enumerate(assts):
-            if isinstance(asset, Asset):
-                assets.append(asset.to_dict())
-            elif isinstance(asset, dict):
-                assets.append(asset)
-            else:
-                raise TypeError(f"unsupported asset {ix}, type: {type(asset)}; supported types are `Asset` or `dict`")
-
-        return assets
 
 
 def write_local(

--- a/nextmv/tests/test_output.py
+++ b/nextmv/tests/test_output.py
@@ -14,6 +14,177 @@ from nextmv.base_model import BaseModel
 class TestOutput(unittest.TestCase):
     """Tests for the various classes for writing an output."""
 
+    def test_post_init_validation(self):
+        """Test the validation in __post_init__ for different scenarios."""
+
+        # Test with None solution - should not raise any errors
+        output = nextmv.Output()
+        self.assertIsNone(output.solution)
+
+        # Test valid JSON serializable object
+        output = nextmv.Output(solution={"test": 123})
+        self.assertEqual(output.solution, {"test": 123})
+
+        # Test JSON with non-serializable object
+        with self.assertRaises(ValueError) as context:
+
+            class NonSerializable:
+                pass
+
+            nextmv.Output(solution=NonSerializable())
+
+        self.assertIn("which is not JSON serializable", str(context.exception))
+
+        # Test CSV_ARCHIVE with valid dict
+        output = nextmv.Output(
+            output_format=nextmv.OutputFormat.CSV_ARCHIVE, solution={"file": [{"col1": 1, "col2": 2}]}
+        )
+        self.assertEqual(output.solution, {"file": [{"col1": 1, "col2": 2}]})
+
+        # Test CSV_ARCHIVE with non-dict
+        with self.assertRaises(ValueError) as context:
+            nextmv.Output(output_format=nextmv.OutputFormat.CSV_ARCHIVE, solution=["not a dict"])
+
+        self.assertIn("supported type is `dict`", str(context.exception))
+
+    def test_post_init_options_copied(self):
+        """Test that options are deep-copied in __post_init__."""
+
+        options = {"duration": 10}
+        output = nextmv.Output(options=options)
+
+        # Modify the original options
+        options["duration"] = 20
+
+        # The output's options should not be affected by the modification
+        self.assertEqual(output.options["duration"], 10)
+
+    def test_to_dict(self):
+        """Test the to_dict method for different cases."""
+
+        # Test with None values for options, statistics, and assets
+        output = nextmv.Output()
+        expected = {
+            "options": {},
+            "solution": {},
+            "statistics": {},
+            "assets": [],
+        }
+        self.assertDictEqual(output.to_dict(), expected)
+
+        # Test with Options object
+        options = nextmv.Options()
+        options.duration = 30
+        output = nextmv.Output(options=options)
+        result = output.to_dict()
+        self.assertEqual(result["options"]["duration"], 30)
+
+        # Test with dictionary options
+        options_dict = {"duration": 45, "threads": 4}
+        output = nextmv.Output(options=options_dict)
+        result = output.to_dict()
+        self.assertEqual(result["options"]["duration"], 45)
+        self.assertEqual(result["options"]["threads"], 4)
+
+        # Test with Statistics object
+        run_stats = nextmv.RunStatistics(duration=10.5, iterations=100)
+        statistics = nextmv.Statistics(run=run_stats)
+        output = nextmv.Output(statistics=statistics)
+        result = output.to_dict()
+        self.assertEqual(result["statistics"]["run"]["duration"], 10.5)
+        self.assertEqual(result["statistics"]["run"]["iterations"], 100)
+
+        # Test with dictionary statistics
+        stats_dict = {"custom_metric": 123.45}
+        output = nextmv.Output(statistics=stats_dict)
+        result = output.to_dict()
+        self.assertEqual(result["statistics"]["custom_metric"], 123.45)
+
+        # Test with list of Asset objects
+        asset1 = nextmv.Asset(name="asset1", content={"data": [1, 2, 3]}, description="Test asset")
+        asset2 = nextmv.Asset(
+            name="asset2",
+            content={"data": "value"},
+        )
+        output = nextmv.Output(assets=[asset1, asset2])
+        result = output.to_dict()
+        self.assertEqual(len(result["assets"]), 2)
+        self.assertEqual(result["assets"][0]["name"], "asset1")
+        self.assertEqual(result["assets"][1]["name"], "asset2")
+
+        # Test with list of dictionary assets
+        asset_dicts = [{"name": "asset3", "content": {"data": [4, 5, 6]}, "content_type": "json"}]
+        output = nextmv.Output(assets=asset_dicts)
+        result = output.to_dict()
+        self.assertEqual(result["assets"][0]["name"], "asset3")
+
+        # Test with JSON configurations
+        json_config = {"indent": 4, "sort_keys": True}
+        output = nextmv.Output(output_format=nextmv.OutputFormat.JSON, json_configurations=json_config)
+        result = output.to_dict()
+        self.assertEqual(result["json_configurations"]["indent"], 4)
+        self.assertEqual(result["json_configurations"]["sort_keys"], True)
+
+        # Test with CSV configurations
+        csv_config = {"delimiter": ";", "quoting": csv.QUOTE_NONNUMERIC}
+        output = nextmv.Output(output_format=nextmv.OutputFormat.CSV_ARCHIVE, csv_configurations=csv_config)
+        result = output.to_dict()
+        self.assertEqual(result["csv_configurations"]["delimiter"], ";")
+        self.assertEqual(result["csv_configurations"]["quoting"], csv.QUOTE_NONNUMERIC)
+
+        # Test with invalid options type
+        with self.assertRaises(TypeError) as context:
+            output = nextmv.Output(options=123)
+            output.to_dict()
+        self.assertIn("unsupported options type", str(context.exception))
+
+        # Test with invalid statistics type
+        with self.assertRaises(TypeError) as context:
+            output = nextmv.Output(statistics=123)
+            output.to_dict()
+        self.assertIn("unsupported statistics type", str(context.exception))
+
+        # Test with invalid assets type
+        with self.assertRaises(TypeError) as context:
+            output = nextmv.Output(assets=123)
+            output.to_dict()
+        self.assertIn("unsupported assets type", str(context.exception))
+
+        # Test with invalid asset in assets list
+        with self.assertRaises(TypeError) as context:
+            output = nextmv.Output(assets=[123])
+            output.to_dict()
+        self.assertIn("unsupported asset 0, type", str(context.exception))
+
+        # Test with complex nested structure
+        options = nextmv.Options()
+        options.duration = 30
+        run_stats = nextmv.RunStatistics(duration=10.5, iterations=100)
+        result_stats = nextmv.ResultStatistics(value=42.0)
+        statistics = nextmv.Statistics(run=run_stats, result=result_stats)
+        asset = nextmv.Asset(
+            name="asset1",
+            content={"data": [1, 2, 3]},
+            visual=nextmv.Visual(visual_schema=nextmv.VisualSchema.CHARTJS, label="Test Chart"),
+        )
+        output = nextmv.Output(
+            options=options,
+            statistics=statistics,
+            assets=[asset],
+            solution={"value": 42},
+            output_format=nextmv.OutputFormat.JSON,
+            json_configurations={"indent": 4},
+        )
+
+        result = output.to_dict()
+        self.assertEqual(result["options"]["duration"], 30)
+        self.assertEqual(result["statistics"]["run"]["duration"], 10.5)
+        self.assertEqual(result["statistics"]["result"]["value"], 42.0)
+        self.assertEqual(result["assets"][0]["name"], "asset1")
+        self.assertEqual(result["assets"][0]["visual"]["schema"], "chartjs")
+        self.assertEqual(result["solution"]["value"], 42)
+        self.assertEqual(result["json_configurations"]["indent"], 4)
+
     def test_local_writer_json_stdout_default(self):
         output = nextmv.Output(
             solution={"empanadas": "are_life"},
@@ -91,7 +262,7 @@ class TestOutput(unittest.TestCase):
 
             self.assertEqual(
                 mock_stdout.getvalue(),
-                '{"assets":[],"options":{},"solution":{"empanadas":"are_life"},"statistics":{"foo":"bar"}}\n',
+                '{"assets":[],"json_configurations":{"separators":[",",":"],"sort_keys":true},"options":{},"solution":{"empanadas":"are_life"},"statistics":{"foo":"bar"}}\n',
             )
 
     def test_local_writer_json_stdout_with_options(self):
@@ -235,62 +406,6 @@ class TestOutput(unittest.TestCase):
 
         # Removes the output directory after the test is executed.
         shutil.rmtree(output_dir)
-
-    def _test_local_writer_csvarchive(
-        self,
-        write_path: str,
-        function_path: Optional[str] = None,
-    ) -> None:
-        """Auxiliary function that is used to test the flow of a CSV archive
-        output output writer but with different directories."""
-
-        options = nextmv.Options()
-        options.parse()
-        options.duration = 5
-        options.solver = "highs"
-
-        solution = {
-            "empanadas": [
-                {"are": 2.0, "life": 3.0},
-                {"are": 5.0, "life": 6.0},
-            ],
-        }
-
-        output = nextmv.Output(
-            options=options,
-            output_format=nextmv.OutputFormat.CSV_ARCHIVE,
-            solution=solution,
-            statistics={"foo": "bar"},
-            csv_configurations={"quoting": csv.QUOTE_NONNUMERIC},
-        )
-        output_writer = nextmv.LocalOutputWriter()
-
-        with patch("sys.stdout", new=StringIO()) as mock_stdout:
-            output_writer.write(output, path=function_path, skip_stdout_reset=True)
-
-            stdout_got = json.loads(mock_stdout.getvalue())
-            stdout_expected = {
-                "options": {
-                    "duration": 5,
-                    "solver": "highs",
-                },
-                "statistics": {"foo": "bar"},
-                "assets": [],
-            }
-
-            self.assertDictEqual(stdout_got, stdout_expected)
-
-        with open(f"{write_path}/empanadas.csv") as file:
-            csv_got = file.read()
-
-        csv_expected = '"are","life"\n2.0,3.0\n5.0,6.0\n'
-
-        self.assertEqual(csv_got, csv_expected)
-
-        self.assertTrue(os.path.exists(write_path))
-
-        # Removes the output directory after the test is executed.
-        shutil.rmtree(write_path)
 
     def test_local_write_bad_output_type(self):
         output = "I am clearly not an output object."
@@ -518,3 +633,59 @@ class TestOutput(unittest.TestCase):
                 "type": "custom-tab",
             },
         )
+
+    def _test_local_writer_csvarchive(
+        self,
+        write_path: str,
+        function_path: Optional[str] = None,
+    ) -> None:
+        """Auxiliary function that is used to test the flow of a CSV archive
+        output output writer but with different directories."""
+
+        options = nextmv.Options()
+        options.parse()
+        options.duration = 5
+        options.solver = "highs"
+
+        solution = {
+            "empanadas": [
+                {"are": 2.0, "life": 3.0},
+                {"are": 5.0, "life": 6.0},
+            ],
+        }
+
+        output = nextmv.Output(
+            options=options,
+            output_format=nextmv.OutputFormat.CSV_ARCHIVE,
+            solution=solution,
+            statistics={"foo": "bar"},
+            csv_configurations={"quoting": csv.QUOTE_NONNUMERIC},
+        )
+        output_writer = nextmv.LocalOutputWriter()
+
+        with patch("sys.stdout", new=StringIO()) as mock_stdout:
+            output_writer.write(output, path=function_path, skip_stdout_reset=True)
+
+            stdout_got = json.loads(mock_stdout.getvalue())
+            stdout_expected = {
+                "options": {
+                    "duration": 5,
+                    "solver": "highs",
+                },
+                "statistics": {"foo": "bar"},
+                "assets": [],
+            }
+
+            self.assertDictEqual(stdout_got, stdout_expected)
+
+        with open(f"{write_path}/empanadas.csv") as file:
+            csv_got = file.read()
+
+        csv_expected = '"are","life"\n2.0,3.0\n5.0,6.0\n'
+
+        self.assertEqual(csv_got, csv_expected)
+
+        self.assertTrue(os.path.exists(write_path))
+
+        # Removes the output directory after the test is executed.
+        shutil.rmtree(write_path)


### PR DESCRIPTION
# Description

This PR makes enhancements to the `nextmv.Output` class.

1. Every attribute can now be a raw `dict[str, Any]`. There is no need to use the "appropriate" Python classes anymore.
2. For each attribute, it detects it’s type. Based on the type, when converting the `nextmv.Output` to a `dict` using the `to_dict` function, the output knows what to do by either calling `to_dict` on the attribute or leaving it alone if it is a `dict` already.
3. Assets are supported as a `list[dict[str, Any]]` as well now, in addition to `list[Asset]`.
4. Given that the `to_dict` function for the `Output` is now in charge of handling all the cases, there is no need for other auxiliary functions, like `_extract_statistics`, so those were removed.
5. Unit tests are added to test the functionality.

