### PR TITLE
Fixes 'Any' type hinting

### DIFF
--- a/nextmv-gurobipy/nextmv_gurobipy/model.py
+++ b/nextmv-gurobipy/nextmv_gurobipy/model.py
@@ -16,7 +16,7 @@ def Model(options: nextmv.Options, license_path: Optional[str] = "") -> gp.Model
     it can be used as any other Gurobi model. This loader will look for the
     `gurobi.lic` file in the provided `license_path`. If the file is not found,
     it will not be read. This means that by default, you will be working with
-    Gurobi’s community license.
+    Gurobi's community license.
 
     Only the parameters that are available in the Gurobi API are set. If a
     parameter is not available, it will be skipped.

--- a/nextmv-gurobipy/nextmv_gurobipy/solution.py
+++ b/nextmv-gurobipy/nextmv_gurobipy/solution.py
@@ -1,11 +1,11 @@
 """Defines gurobipy solution interoperability."""
 
-from typing import Optional
+from typing import Any, Optional
 
 import gurobipy as gp
 
 
-def ModelSolution(model: gp.Model) -> Optional[dict[str, any]]:
+def ModelSolution(model: gp.Model) -> Optional[dict[str, Any]]:
     """
     Creates a basic solution dictionary from a Gurobi model. The simple
     solution dictionary contains the variable name and the value of the
@@ -21,7 +21,7 @@ def ModelSolution(model: gp.Model) -> Optional[dict[str, any]]:
 
     Returns:
     ----------
-    dict[str, any] | None
+    dict[str, Any] | None
         The solution dictionary.
     """
 

--- a/nextmv-scikit-learn/nextmv_sklearn/dummy/solution.py
+++ b/nextmv-scikit-learn/nextmv_sklearn/dummy/solution.py
@@ -1,5 +1,7 @@
 """Defines sklearn.dummy solution interoperability."""
 
+from typing import Any
+
 import numpy as np
 from pydantic import BaseModel, ConfigDict
 from sklearn import dummy
@@ -24,13 +26,13 @@ class DummyRegressorSolution(BaseModel):
     """Number of outputs."""
 
     @classmethod
-    def from_dict(cls, data: dict[str, any]) -> "DummyRegressorSolution":
+    def from_dict(cls, data: dict[str, Any]) -> "DummyRegressorSolution":
         """
         Creates a DummyRegressorSolution instance from a dictionary.
 
         Parameters
         ----------
-        data : dict[str, any]
+        data : dict[str, Any]
             Dictionary containing the model attributes.
 
         Returns

--- a/nextmv-scikit-learn/nextmv_sklearn/ensemble/solution.py
+++ b/nextmv-scikit-learn/nextmv_sklearn/ensemble/solution.py
@@ -56,13 +56,13 @@ class GradientBoostingRegressorSolution(BaseModel):
     loss: Loss = None
 
     @classmethod
-    def from_dict(cls, data: dict[str, any]) -> "GradientBoostingRegressorSolution":
+    def from_dict(cls, data: dict[str, Any]) -> "GradientBoostingRegressorSolution":
         """
         Creates a GradientBoostingRegressorSolution instance from a dictionary.
 
         Parameters
         ----------
-        data : dict[str, any]
+        data : dict[str, Any]
             Dictionary containing the model attributes.
 
         Returns
@@ -185,13 +185,13 @@ class RandomForestRegressorSolution(BaseModel):
     """Prediction computed with out-of-bag estimate on the training set."""
 
     @classmethod
-    def from_dict(cls, data: dict[str, any]) -> "RandomForestRegressorSolution":
+    def from_dict(cls, data: dict[str, Any]) -> "RandomForestRegressorSolution":
         """
         Creates a RandomForestRegressorSolution instance from a dictionary.
 
         Parameters
         ----------
-        data : dict[str, any]
+        data : dict[str, Any]
             Dictionary containing the model attributes.
 
         Returns

--- a/nextmv-scikit-learn/nextmv_sklearn/linear_model/solution.py
+++ b/nextmv-scikit-learn/nextmv_sklearn/linear_model/solution.py
@@ -38,13 +38,13 @@ class LinearRegressionSolution(BaseModel):
     that are all strings."""
 
     @classmethod
-    def from_dict(cls, data: dict[str, any]) -> "LinearRegressionSolution":
+    def from_dict(cls, data: dict[str, Any]) -> "LinearRegressionSolution":
         """
         Creates a LinearRegressionSolution instance from a dictionary.
 
         Parameters
         ----------
-        data : dict[str, any]
+        data : dict[str, Any]
             Dictionary containing the model attributes.
 
         Returns

--- a/nextmv-scikit-learn/nextmv_sklearn/neural_network/solution.py
+++ b/nextmv-scikit-learn/nextmv_sklearn/neural_network/solution.py
@@ -52,13 +52,13 @@ class MLPRegressorSolution(BaseModel):
     """Name of the output activation function."""
 
     @classmethod
-    def from_dict(cls, data: dict[str, any]) -> "MLPRegressorSolution":
+    def from_dict(cls, data: dict[str, Any]) -> "MLPRegressorSolution":
         """
         Creates a MLPRegressorSolution instance from a dictionary.
 
         Parameters
         ----------
-        data : dict[str, any]
+        data : dict[str, Any]
             Dictionary containing the model attributes.
 
         Returns

--- a/nextmv-scikit-learn/nextmv_sklearn/tree/solution.py
+++ b/nextmv-scikit-learn/nextmv_sklearn/tree/solution.py
@@ -2,7 +2,7 @@
 
 import base64
 import pickle
-from typing import Annotated
+from typing import Annotated, Any
 
 import numpy as np
 from pydantic import BaseModel, BeforeValidator, ConfigDict, PlainSerializer
@@ -35,13 +35,13 @@ class DecisionTreeRegressorSolution(BaseModel):
     """The underlying Tree object."""
 
     @classmethod
-    def from_dict(cls, data: dict[str, any]) -> "DecisionTreeRegressorSolution":
+    def from_dict(cls, data: dict[str, Any]) -> "DecisionTreeRegressorSolution":
         """
         Creates a DecisionTreeRegressorSolution instance from a dictionary.
 
         Parameters
         ----------
-        data : dict[str, any]
+        data : dict[str, Any]
             Dictionary containing the model attributes.
 
         Returns

--- a/nextmv-scikit-learn/tests/test_model.py
+++ b/nextmv-scikit-learn/tests/test_model.py
@@ -1,4 +1,5 @@
 import unittest
+from typing import Any
 
 from nextmv_sklearn.dummy import DummyRegressor, DummyRegressorOptions
 from nextmv_sklearn.ensemble import (
@@ -48,7 +49,7 @@ class TestModel(unittest.TestCase):
         dt_reg = DecisionTreeRegressor(dt_opt)
         self.assert_model(dt_reg)
 
-    def assert_model(self, model: any):
+    def assert_model(self, model: Any):
         fit = model.fit(self.X, self.y)
         pred = model.predict(self.X[:1])
         self.assertIsNotNone(fit)

--- a/nextmv-scikit-learn/tests/test_options.py
+++ b/nextmv-scikit-learn/tests/test_options.py
@@ -1,6 +1,7 @@
 import json
 import os
 import unittest
+from typing import Any
 
 from nextmv_sklearn.dummy import DummyRegressorOptions
 from nextmv_sklearn.ensemble import GradientBoostingRegressorOptions, RandomForestRegressorOptions
@@ -39,7 +40,7 @@ class TestOptions(unittest.TestCase):
         self.assertIsNotNone(opt)
         self.compare(opt, "decision_tree")
 
-    def compare(self, opt: any, expected_path: str):
+    def compare(self, opt: Any, expected_path: str):
         n_opt = opt.to_nextmv()
         got = n_opt.options_dict()
 

--- a/nextmv-scikit-learn/tests/test_solution.py
+++ b/nextmv-scikit-learn/tests/test_solution.py
@@ -1,5 +1,6 @@
 import os
 import unittest
+from typing import Any
 
 from nextmv_sklearn.dummy import DummyRegressor, DummyRegressorOptions, DummyRegressorSolution, DummyRegressorStatistics
 from nextmv_sklearn.ensemble import (
@@ -109,8 +110,8 @@ class TestModel(unittest.TestCase):
     def assert_load_model(
         self,
         opt: nextmv.Options,
-        model: any,
-        solution_class: any,
+        model: Any,
+        solution_class: Any,
         statistics: callable,
     ):
         fit = model.fit(self.X, self.y)

--- a/nextmv-scikit-learn/tests/test_statistics.py
+++ b/nextmv-scikit-learn/tests/test_statistics.py
@@ -1,4 +1,5 @@
 import unittest
+from typing import Any
 
 from nextmv_sklearn.dummy import DummyRegressor, DummyRegressorOptions, DummyRegressorStatistics
 from nextmv_sklearn.ensemble import (
@@ -52,7 +53,7 @@ class TestModel(unittest.TestCase):
         dt_reg = DecisionTreeRegressor(dt_opt)
         self.assert_statistics(dt_reg, DecisionTreeRegressorStatistics)
 
-    def assert_statistics(self, model: any, statistics: callable):
+    def assert_statistics(self, model: Any, statistics: callable):
         fit = model.fit(self.X, self.y)
         stats: nextmv.Statistics = statistics(fit, self.X, self.y)
         self.assertIsNotNone(fit)

--- a/nextmv/nextmv/__entrypoint__.py
+++ b/nextmv/nextmv/__entrypoint__.py
@@ -1,5 +1,5 @@
 """
-When working in a notebook environment, we don’t really create a `main.py` file
+When working in a notebook environment, we don't really create a `main.py` file
 with the main entrypoint of the program. Because the logic is mostly encoded
 inside the `Model` class, we need to create a `main.py` file that we can run in
 Nextmv Cloud. This file is used as that entrypoint. It is not intended for a
@@ -29,7 +29,7 @@ def main() -> None:
         suppress_warnings=True,
     )
 
-    # Load the input and solve the model by using mlflow’s inference API.
+    # Load the input and solve the model by using mlflow's inference API.
     input = nextmv.load(options=options)
     output = loaded_model.predict(input)
 

--- a/nextmv/nextmv/cloud/application.py
+++ b/nextmv/nextmv/cloud/application.py
@@ -881,7 +881,7 @@ class Application:
         instance_id: Optional[str]
             ID of the instance to use for the input set. This is used to
             filter the runs associated with the input set. If not provided,
-            the application’s `default_instance_id` is used.
+            the application's `default_instance_id` is used.
         maximum_runs: Optional[int]
             Maximum number of runs to use for the input set. This is used to
             filter the runs associated with the input set. If not provided,
@@ -997,7 +997,7 @@ class Application:
         description: Optional[str] = None,
         upload_id: Optional[str] = None,
         run_id: Optional[str] = None,
-        format: Optional[Union[Format, dict[str, any]]] = None,
+        format: Optional[Union[Format, dict[str, Any]]] = None,
     ) -> ManagedInput:
         """
         Create a new managed input. There are two methods for creating a
@@ -1076,9 +1076,9 @@ class Application:
         description: Optional[str] = None,
         upload_id: Optional[str] = None,
         options: Optional[Union[Options, dict[str, str]]] = None,
-        configuration: Optional[Union[RunConfiguration, dict[str, any]]] = None,
+        configuration: Optional[Union[RunConfiguration, dict[str, Any]]] = None,
         batch_experiment_id: Optional[str] = None,
-        external_result: Optional[Union[ExternalRunResult, dict[str, any]]] = None,
+        external_result: Optional[Union[ExternalRunResult, dict[str, Any]]] = None,
     ) -> str:
         """
         Submit an input to start a new run of the application. Returns the
@@ -1112,7 +1112,7 @@ class Application:
             used, the options are extracted from the `.to_cloud_dict()` method.
             Note that specifying `options` overrides the `input.options` (if
             the `input` is of type `nextmv.Input`).
-        configuration: Optional[Union[RunConfiguration, dict[str, any]]]
+        configuration: Optional[Union[RunConfiguration, dict[str, Any]]]
             Configuration to use for the run. This can be a
             `cloud.RunConfiguration` object or a dict. If the object is used,
             then the `.to_dict()` method is applied to extract the
@@ -1120,7 +1120,7 @@ class Application:
         batch_experiment_id: Optional[str]
             ID of a batch experiment to associate the run with. This is used
             when the run is part of a batch experiment.
-        external_result: Optional[Union[ExternalRunResult, dict[str, any]]]
+        external_result: Optional[Union[ExternalRunResult, dict[str, Any]]]
             External result to use for the run. This can be a
             `cloud.ExternalRunResult` object or a dict. If the object is used,
             then the `.to_dict()` method is applied to extract the
@@ -1228,9 +1228,9 @@ class Application:
         upload_id: Optional[str] = None,
         run_options: Optional[Union[Options, dict[str, str]]] = None,
         polling_options: PollingOptions = _DEFAULT_POLLING_OPTIONS,
-        configuration: Optional[Union[RunConfiguration, dict[str, any]]] = None,
+        configuration: Optional[Union[RunConfiguration, dict[str, Any]]] = None,
         batch_experiment_id: Optional[str] = None,
-        external_result: Optional[Union[ExternalRunResult, dict[str, any]]] = None,
+        external_result: Optional[Union[ExternalRunResult, dict[str, Any]]] = None,
     ) -> RunResult:
         """
         Submit an input to start a new run of the application and poll for the
@@ -1271,7 +1271,7 @@ class Application:
             convenience method that combines the `new_run` and
             `run_result_with_polling` methods, applying polling logic to check
             when the run succeeded.
-        configuration: Optional[Union[RunConfiguration, dict[str, any]]]
+        configuration: Optional[Union[RunConfiguration, dict[str, Any]]]
             Configuration to use for the run. This can be a
             `cloud.RunConfiguration` object or a dict. If the object is used,
             then the `.to_dict()` method is applied to extract the
@@ -1279,7 +1279,7 @@ class Application:
         batch_experiment_id: Optional[str]
             ID of a batch experiment to associate the run with. This is used
             when the run is part of a batch experiment.
-        external_result: Optional[Union[ExternalRunResult, dict[str, any]]]
+        external_result: Optional[Union[ExternalRunResult, dict[str, Any]]]
             External result to use for the run. This can be a
             `cloud.ExternalRunResult` object or a dict. If the object is used,
             then the `.to_dict()` method is applied to extract the
@@ -1555,7 +1555,7 @@ class Application:
         exception will be raised.
 
         There are two ways to push an app to Nextmv Cloud:
-        1. Specifying `app_dir`, which is the path to an app’s root directory.
+        1. Specifying `app_dir`, which is the path to an app's root directory.
         This acts as an external strategy, where the app is composed of files
         in a directory and those apps are packaged and pushed to Nextmv Cloud.
         2. Specifying a `model` and `model_configuration`. This acts as an
@@ -1566,7 +1566,7 @@ class Application:
         Examples
         -------
 
-        1. Push an app using an external strategy, i.e., specifying the app’s
+        1. Push an app using an external strategy, i.e., specifying the app's
         directory:
         ```python
         import os
@@ -1640,7 +1640,7 @@ class Application:
         manifest : Optional[Manifest], optional
             The manifest for the app, by default None.
         app_dir : Optional[str], optional
-            The path to the app’s directory, by default None.
+            The path to the app's directory, by default None.
         verbose : bool, optional
             Whether to print verbose output, by default False.
         """
@@ -1793,7 +1793,7 @@ class Application:
             requests.HTTPError: If the response status code is not 2xx.
         """
 
-        def polling_func() -> tuple[any, bool]:
+        def polling_func() -> tuple[Any, bool]:
             run_information = self.run_metadata(run_id=run_id)
             if run_information.metadata.status_v2 in {
                 StatusV2.succeeded,
@@ -2402,11 +2402,11 @@ class Application:
         raise ValueError(f"Unknown scenario input type: {scenario.scenario_input.scenario_input_type}")
 
 
-def poll(polling_options: PollingOptions, polling_func: Callable[[], tuple[any, bool]]) -> any:
+def poll(polling_options: PollingOptions, polling_func: Callable[[], tuple[Any, bool]]) -> Any:
     """
     Auxiliary function for polling.
 
-    The `polling_func` is a callable that must return a `tuple[any, bool]`
+    The `polling_func` is a callable that must return a `tuple[Any, bool]`
     where the first element is the result of the polling and the second
     element is a boolean indicating if the polling was successful or should be
     retried.
@@ -2424,7 +2424,7 @@ def poll(polling_options: PollingOptions, polling_func: Callable[[], tuple[any, 
 
     Returns
     -------
-    any
+    Any
         Result of the polling function.
     """
 

--- a/nextmv/nextmv/cloud/run.py
+++ b/nextmv/nextmv/cloud/run.py
@@ -248,11 +248,11 @@ class TrackedRun:
 
     Attributes
     ----------
-    input : Union[Input, dict[str, any], str]
+    input : Union[Input, dict[str, Any], str]
         The input of the run being tracked. Please note that if the input
         format is JSON, then the input data must be JSON serializable. This
         field is required.
-    output : Union[Output, dict[str, any], str]
+    output : Union[Output, dict[str, Any], str]
         The output of the run being tracked. Please note that if the output
         format is JSON, then the output data must be JSON serializable. This
         field is required.
@@ -270,9 +270,9 @@ class TrackedRun:
         the log. This field is optional.
     """
 
-    input: Union[Input, dict[str, any], str]
+    input: Union[Input, dict[str, Any], str]
     """The input of the run being tracked."""
-    output: Union[Output, dict[str, any], str]
+    output: Union[Output, dict[str, Any], str]
     """The output of the run being tracked. Only JSON output_format is supported."""
     status: TrackedRunStatus
     """The status of the run being tracked"""
@@ -303,7 +303,7 @@ class TrackedRun:
             try:
                 _ = json.dumps(self.input)
             except (TypeError, OverflowError) as e:
-                raise ValueError("Input is dict[str, any] but it is not JSON serializable") from e
+                raise ValueError("Input is dict[str, Any] but it is not JSON serializable") from e
 
         if isinstance(self.output, Output):
             if self.output.output_format != OutputFormat.JSON:
@@ -312,7 +312,7 @@ class TrackedRun:
             try:
                 _ = json.dumps(self.output)
             except (TypeError, OverflowError) as e:
-                raise ValueError("Output is dict[str, any] but it is not JSON serializable") from e
+                raise ValueError("Output is dict[str, Any] but it is not JSON serializable") from e
 
     def logs_text(self) -> str:
         """

--- a/nextmv/nextmv/cloud/scenario.py
+++ b/nextmv/nextmv/cloud/scenario.py
@@ -211,7 +211,7 @@ def _option_sets(scenarios: list[Scenario]) -> dict[str, dict[str, dict[str, str
 def _scenarios_by_id(scenarios: list[Scenario]) -> dict[str, Scenario]:
     """
     This function maps a scenario to its ID. A scenario ID is created if it
-    wasn’t defined. This function also checks that there are no duplicate
+    wasn't defined. This function also checks that there are no duplicate
     scenario IDs.
     """
 

--- a/nextmv/nextmv/input.py
+++ b/nextmv/nextmv/input.py
@@ -92,7 +92,7 @@ class Input:
         new_options = copy.deepcopy(init_options)
         self.options = new_options
 
-    def to_dict(self) -> dict[str, any]:
+    def to_dict(self) -> dict[str, Any]:
         """
         Convert the input to a dictionary.
 
@@ -102,7 +102,7 @@ class Input:
 
         Returns
         -------
-        dict[str, any]
+        dict[str, Any]
             The input as a dictionary.
         """
 

--- a/nextmv/nextmv/model.py
+++ b/nextmv/nextmv/model.py
@@ -47,7 +47,7 @@ warnings.showwarning = custom_showwarning
 # the model requires and that we install and bundle with the app.
 _REQUIREMENTS_FILE = "model_requirements.txt"
 
-# When working in a notebook environment, we don’t really create a `main.py`
+# When working in a notebook environment, we don't really create a `main.py`
 # file with the main entrypoint of the program. Because the logic is mostly
 # encoded inside the `Model` class, we need to create a `main.py` file that we
 # can run in Nextmv Cloud. This file is used as that entrypoint.
@@ -148,7 +148,7 @@ class Model:
             saved and loaded.
         """
 
-        # mlflow is a big package. We don’t want to make it a dependency of
+        # mlflow is a big package. We don't want to make it a dependency of
         # `nextmv` because it is not always needed. We only need it if we are
         # working with the "app from model" logic, which involves working with
         # this `Model` class.
@@ -180,7 +180,7 @@ class Model:
                 params: Optional[dict[str, Any]] = None,
             ) -> Any:
                 """
-                The predict method allows us to work with mlflow’s [python_function]
+                The predict method allows us to work with mlflow's [python_function]
                 model flavor. Warning: This method should not be used or overridden
                 directly. Instead, you should implement the `solve` method.
 

--- a/nextmv/nextmv/options.py
+++ b/nextmv/nextmv/options.py
@@ -657,7 +657,7 @@ class Options:
             options_by_field_name[option.name.replace("-", "_")] = option
 
         # The ipkyernel uses a `-f` argument by default that it passes to the
-        # execution. We don’t want to ignore this argument because we get an
+        # execution. We don't want to ignore this argument because we get an
         # error. Fix source: https://stackoverflow.com/a/56349168
         parser.add_argument(
             "-f",

--- a/nextmv/nextmv/output.py
+++ b/nextmv/nextmv/output.py
@@ -249,7 +249,7 @@ class Output:
     serialized to the write location.
 
     The most important part of the output is the solution, which represents the
-    result of the decision problem. The solution’s type must match the
+    result of the decision problem. The solution's type must match the
     `output_format`:
 
     - `OutputFormat.JSON`: the data must be `dict[str, Any]`.
@@ -327,13 +327,13 @@ class Output:
                 "output_format OutputFormat.CSV_ARCHIVE, supported type is `dict`"
             )
 
-    def to_dict(self) -> dict[str, any]:
+    def to_dict(self) -> dict[str, Any]:
         """
         Convert the `Output` object to a dictionary.
 
         Returns
         -------
-        dict[str, any]
+        dict[str, Any]
             The dictionary representation of the `Output` object.
         """
 

--- a/nextmv/tests/cloud/test_application.py
+++ b/nextmv/tests/cloud/test_application.py
@@ -1,4 +1,5 @@
 import unittest
+from typing import Any
 
 from nextmv.cloud.application import PollingOptions, poll
 
@@ -7,7 +8,7 @@ class TestApplication(unittest.TestCase):
     def test_poll(self):
         counter = 0
 
-        def polling_func() -> tuple[any, bool]:
+        def polling_func() -> tuple[Any, bool]:
             nonlocal counter
             counter += 1
 
@@ -26,7 +27,7 @@ class TestApplication(unittest.TestCase):
         counter = 0
 
         # The polling func would stop after 9 calls.
-        def polling_func() -> tuple[any, bool]:
+        def polling_func() -> tuple[Any, bool]:
             nonlocal counter
             counter += 1
 


### PR DESCRIPTION
# Description

Fixes the `Any` type hint across the code base (some were accidentally set to `any` instead).

## Changes

* Fixes the `Any` type hint.
* Simplifies the single-quote char (`'`) in comments.