### PR TITLE
Allows requirements as code

### DIFF
--- a/docs/nextmv/tutorials/applications/push.md
+++ b/docs/nextmv/tutorials/applications/push.md
@@ -10,23 +10,28 @@ following minimum requirements:
 
 1. Must read from either `stdin` or a file.
 2. Must write results either to `stdout` or a file.
-3. Must contain an [`app.yaml` manifest][app-manifest] in the root of your app
-project.
+3. Depending on the push strategy (see below), may require an `app.yaml`
+   manifest file and an entrypoint (`main.py`, `main`, `main.jar`, etc.).
 
 To push an app to Nextmv Cloud using the `nextmv` Python SDK, you can use one
 of the following strategies:
 
-* [External strategy][external-strategy]: push an app that is composed of files
-      in a directory.
+* [Directory strategy][directory-strategy]: push an _existing_ app that is
+      composed of files in a directory.
+* [Python strategy][python-strategy]: describe and push an app purely in
+      Python (without the need for an [`app.yaml` manifest][app-manifest]
+      for example).
 * [Internal strategy][internal-strategy]: push an app that is created from a
   [`nextmv.Model`][model].
 
-## External strategy
+## Directory strategy
 
-The external strategy consists of specifying `app_dir`, which is the path to an
+The directory strategy consists of specifying `app_dir`, which is the path to an
 app’s root directory. The app is composed of files in a directory and those
-apps are packaged and pushed to Nextmv Cloud. This is language-agnostic and can
-work for an app written in any language.
+apps are packaged and pushed to Nextmv Cloud. This is language-agnostic and
+works for an app written in any language. It is particularly useful
+when the app is already structured as a directory with the necessary files (like
+apps cloned from [community apps][community-apps]).
 
 Place the following script in the root of your app directory and run it to push
 your app to the Nextmv Cloud. This is equivalent to using the [Nextmv CLI][cli]
@@ -43,10 +48,54 @@ app = cloud.Application(client=client, id="<YOUR_APP_ID>")
 app.push()  # Use verbose=True for step-by-step output.
 ```
 
+You can also specify the `app_dir` parameter to point to a specific directory
+
+## Python strategy
+
+The Python strategy consists of describing your app in Python and pushing it to
+Nextmv Cloud. This is very similar to the directory strategy, but you can define
+your app as code and keep it in a single file. This approach is still
+language-agnostic.
+
+For example, if you have a simply Python app consisting of a single `main.py`
+file, you can push it to Nextmv Cloud using the following `push.py` script. This
+example is based on the [python-ortools-knapsack][python-ortools-knapsack] app
+from the [community apps][community-apps] repository.
+
+```python
+import os
+
+from nextmv import cloud
+
+client = cloud.Client(api_key=os.getenv("NEXTMV_API_KEY"))
+app = cloud.Application(client=client, id="<YOUR_APP_ID>")
+
+# Describe your app and push it to Nextmv Cloud.
+app.push(
+    manifest=cloud.Manifest(
+        # List the files that are part of your app.
+        files=["main.py"], 
+        python=cloud.ManifestPython(
+            # Specify the dependencies of your app.
+            pip_requirements=[
+                "nextmv==0.28.1",
+                "ortools==9.12.4544",
+            ],
+        ),
+        type=cloud.ManifestType.PYTHON,
+        runtime=cloud.ManifestRuntime.PYTHON,
+    ),
+)
+```
+
 ## Internal strategy
 
 The internal strategy consists of specifying a `model` and
-`model_configuration`. This acts as a Python-native strategy called "Apps from
+`model_configuration`. This is useful when you are in an interactive environment
+like a Jupyter notebook or a Python script, and you want to push the model
+_object_ directly.
+
+This acts as a Python-native strategy called "Apps from
 Models", where an app is created from a [`Nextmv.Model`][model]. The model is
 encoded, some dependencies and accompanying files are packaged, and the app is
 pushed to Nextmv Cloud. To push a `nextmv.Model` to Nextmv Cloud, you need
@@ -62,6 +111,7 @@ Nextmv Cloud.
 ```python
 import os
 
+import nextmv
 from nextmv import cloud
 
 
@@ -95,5 +145,8 @@ app.push( # Use verbose=True for step-by-step output.
 [cli]: https://docs.nextmv.io/docs/using-nextmv/reference/cli
 [model]: ../model.md
 [app-manifest]: https://docs.nextmv.io/docs/using-nextmv/deploy/app/manifest
-[external-strategy]: #external-strategy
+[directory-strategy]: #directory-strategy
+[python-strategy]: #python-strategy
 [internal-strategy]: #internal-strategy
+[community-apps]: https://github.com/nextmv-io/community-apps
+[python-ortools-knapsack]: https://github.com/nextmv-io/community-apps/tree/develop/python-ortools-knapsack

--- a/docs/nextmv/tutorials/applications/push.md
+++ b/docs/nextmv/tutorials/applications/push.md
@@ -26,7 +26,7 @@ of the following strategies:
 The file strategy assumes that the model exists as source code on disk. We can
 distinguish between two types of file strategies:
 
-* **Directory based**: the app is described with a [`app.yaml`][app-manifest]
+* **Directory based**: the app is described with an [`app.yaml`][app-manifest]
   manifest file.
 * **Code based**: the app is described in Python as code.
 
@@ -54,7 +54,18 @@ app = cloud.Application(client=client, id="<YOUR_APP_ID>")
 app.push()  # Use verbose=True for step-by-step output.
 ```
 
-You can also specify the `app_dir` parameter to point to a specific directory
+You can also specify the `app_dir` parameter to point to a specific directory.
+
+The typical structure of an app directory for the directory based file strategy
+looks like this:
+
+```txt
+.
+├── app.yaml          # Describes the app and its dependencies
+├── requirements.txt  # Lists the dependencies
+├── main.py           # The actual app / model code
+└── push.py           # Python script to define and push the app (see below)
+```
 
 ### Code based
 
@@ -92,6 +103,17 @@ app.push(
         runtime=cloud.ManifestRuntime.PYTHON,
     ),
 )
+```
+
+The typical structure of an app directory for the code based file strategy looks
+like this:
+
+```txt
+.
+├── app.yaml          # Describes the app and its dependencies
+├── requirements.txt  # Lists the dependencies
+├── main.py           # The actual app / model code
+└── push.py           # Python script to define and push the app (see below)
 ```
 
 ## Object strategy

--- a/docs/nextmv/tutorials/applications/push.md
+++ b/docs/nextmv/tutorials/applications/push.md
@@ -16,22 +16,28 @@ following minimum requirements:
 To push an app to Nextmv Cloud using the `nextmv` Python SDK, you can use one
 of the following strategies:
 
-* [Directory strategy][directory-strategy]: push an _existing_ app that is
-      composed of files in a directory.
-* [Python strategy][python-strategy]: describe and push an app purely in
-      Python (without the need for an [`app.yaml` manifest][app-manifest]
-      for example).
-* [Internal strategy][internal-strategy]: push an app that is created from a
-  [`nextmv.Model`][model].
+* [File strategy][file-strategy]: push an _existing_ app that exists
+      as file(s) in a directory. This is the most common strategy.
+* [Object strategy][object-strategy]: push an app that is created from a
+  [`nextmv.Model`][model] directly from the in-memory object.
 
-## Directory strategy
+## File strategy
 
-The directory strategy consists of specifying `app_dir`, which is the path to an
-app’s root directory. The app is composed of files in a directory and those
-apps are packaged and pushed to Nextmv Cloud. This is language-agnostic and
-works for an app written in any language. It is particularly useful
-when the app is already structured as a directory with the necessary files (like
-apps cloned from [community apps][community-apps]).
+The file strategy assumes that the model exists as source code on disk. We can
+distinguish between two types of file strategies:
+
+* **Directory based**: the app is described with a [`app.yaml`][app-manifest]
+  manifest file.
+* **Code based**: the app is described in Python as code.
+
+### Directory based
+
+The directory based file strategy consists of specifying `app_dir`, which is the
+path to an app’s root directory. The app is composed of files in a directory and
+those apps are packaged and pushed to Nextmv Cloud. This is language-agnostic
+and works for an app written in any language. It is particularly useful when the
+app is already structured as a directory with the necessary files (like apps
+cloned from [community apps][community-apps]).
 
 Place the following script in the root of your app directory and run it to push
 your app to the Nextmv Cloud. This is equivalent to using the [Nextmv CLI][cli]
@@ -50,12 +56,12 @@ app.push()  # Use verbose=True for step-by-step output.
 
 You can also specify the `app_dir` parameter to point to a specific directory
 
-## Python strategy
+### Code based
 
-The Python strategy consists of describing your app in Python and pushing it to
-Nextmv Cloud. This is very similar to the directory strategy, but you can define
-your app as code and keep it in a single file. This approach is still
-language-agnostic.
+The code based file strategy consists of describing your app in Python and
+pushing it to Nextmv Cloud. This is very similar to the directory based
+approach, but you can define your app as code and keep it in a single file.
+This approach is still language-agnostic.
 
 For example, if you have a simply Python app consisting of a single `main.py`
 file, you can push it to Nextmv Cloud using the following `push.py` script. This
@@ -88,12 +94,11 @@ app.push(
 )
 ```
 
-## Internal strategy
+## Object strategy
 
-The internal strategy consists of specifying a `model` and
-`model_configuration`. This is useful when you are in an interactive environment
-like a Jupyter notebook or a Python script, and you want to push the model
-_object_ directly.
+The object strategy consists of specifying a `model` and `model_configuration`.
+This is useful when you are in an interactive environment like a Jupyter
+notebook or a Python script, and you want to push the model _object_ directly.
 
 This acts as a Python-native strategy called "Apps from
 Models", where an app is created from a [`Nextmv.Model`][model]. The model is
@@ -145,8 +150,7 @@ app.push( # Use verbose=True for step-by-step output.
 [cli]: https://docs.nextmv.io/docs/using-nextmv/reference/cli
 [model]: ../model.md
 [app-manifest]: https://docs.nextmv.io/docs/using-nextmv/deploy/app/manifest
-[directory-strategy]: #directory-strategy
-[python-strategy]: #python-strategy
-[internal-strategy]: #internal-strategy
+[file-strategy]: #file-strategy
+[object-strategy]: #object-strategy
 [community-apps]: https://github.com/nextmv-io/community-apps
 [python-ortools-knapsack]: https://github.com/nextmv-io/community-apps/tree/develop/python-ortools-knapsack

--- a/nextmv/nextmv/cloud/manifest.py
+++ b/nextmv/nextmv/cloud/manifest.py
@@ -301,7 +301,7 @@ class ManifestPython(BaseModel):
     'requirements.txt'
     """
 
-    pip_requirements: Optional[Union[str, list]] = Field(
+    pip_requirements: Optional[Union[str, list[str]]] = Field(
         serialization_alias="pip-requirements",
         validation_alias=AliasChoices("pip-requirements", "pip_requirements"),
         default=None,

--- a/nextmv/nextmv/cloud/manifest.py
+++ b/nextmv/nextmv/cloud/manifest.py
@@ -33,7 +33,7 @@ FILE_NAME
 
 import os
 from enum import Enum
-from typing import Any, Optional
+from typing import Any, Optional, Union
 
 import yaml
 from pydantic import AliasChoices, Field
@@ -282,7 +282,9 @@ class ManifestPython(BaseModel):
     ----------
     pip_requirements : Optional[str], default=None
         Path to a requirements.txt file containing (additional) Python
-        dependencies that will be bundled with the app.
+        dependencies that will be bundled with the app. Alternatively, you can provide a
+        list of strings, each representing a package to install, e.g.,
+        `["nextmv==0.28.2", "ortools==9.12.4544"]`.
         Aliases: `pip-requirements`.
     model : Optional[ManifestPythonModel], default=None
         Information about an encoded decision model as handled via mlflow. This
@@ -299,7 +301,7 @@ class ManifestPython(BaseModel):
     'requirements.txt'
     """
 
-    pip_requirements: Optional[str] = Field(
+    pip_requirements: Optional[Union[str, list]] = Field(
         serialization_alias="pip-requirements",
         validation_alias=AliasChoices("pip-requirements", "pip_requirements"),
         default=None,

--- a/nextmv/nextmv/cloud/package.py
+++ b/nextmv/nextmv/cloud/package.py
@@ -233,11 +233,25 @@ def __install_dependencies(
         return
 
     pip_requirements = manifest.python.pip_requirements
+
     if pip_requirements is None or pip_requirements == "":
+        # If no pip requirements are specified, we do not install any dependencies.
         return
 
-    if not os.path.isfile(os.path.join(app_dir, pip_requirements)):
-        raise FileNotFoundError(f"pip requirements file '{pip_requirements}' not found in '{app_dir}'")
+    if isinstance(pip_requirements, list):
+        # If pip_requirements is a list, we write it to a temporary file so that we can
+        # pass it to pip.
+        pip_requirements_file = os.path.join(temp_dir, "requirements.txt")
+        with open(pip_requirements_file, "w") as f:
+            for requirement in pip_requirements:
+                f.write(requirement + "\n")
+        pip_requirements = pip_requirements_file
+    elif isinstance(pip_requirements, str):
+        # If pip_requirements is a string, we expect it to be a file path to a
+        # requirements file.
+        pip_requirements = pip_requirements.strip()
+        if not os.path.isfile(os.path.join(app_dir, pip_requirements)):
+            raise FileNotFoundError(f"pip requirements file '{pip_requirements}' not found in '{app_dir}'")
 
     py_cmd = __get_python_command()
     dep_dir = os.path.join(".nextmv", "python", "deps")


### PR DESCRIPTION
# Description

Allows the user to specify requirements as code. I.e., the user can now setup their app **_without_** having to create _app.yaml_ and _requirements.txt_ files.

This allows to only have the following files / structure:

```txt
.
├── main.py           # The actual app / model code
└── push.py           # Python script to define and push the app (see below)
```

Example of a **_push.py_** file (next to the _main.py_ file containing the actual app/model code):

```python
import datetime
import os

from nextmv import cloud

# App directory is the same as this file.
app_dir = os.path.dirname(os.path.abspath(__file__))

# Create and push the app to the cloud.
client = cloud.Client(api_key=os.getenv("NEXTMV_API_KEY"))
app = cloud.Application(client=client, id=os.getenv("<app-id>"))
app.push(
    app_dir=app_dir,
    verbose=True,  # See some output from the push process.
    manifest=cloud.Manifest(
        files=[
            "main.py",  # The main file of the app.
        ],
        python=cloud.ManifestPython(
            pip_requirements=[
                "nextmv==0.28.1",
                "ortools==9.12.4544",
            ],
        ),
        type=cloud.ManifestType.PYTHON,
        runtime=cloud.ManifestRuntime.PYTHON,
    ),
)

# Create a new version and update the staging instance to use it.
version_id = f"sandbox-auto-{datetime.datetime.now().strftime('%Y-%m-%dT%H-%M-%S')}"
app.new_version(id=version_id, name=f"Auto version {version_id}")
app.update_instance(id="staging", name="staging", version_id=version_id)
```

The example above does the following:

* Make sure to push from the directory of the app independent of where it was called from.
* Use a `NEXTMV_API_KEY` from env for auth.
* Push the code for `<app-id>` app.
* Bundle `main.py` (which contains the model code).
* Define all requirements.
* Set the app type to Python.
* Set the runtime to one suiting Python apps.
* Automatically create a version for the pushed code.
* Update the `staging` instance to use the new version.

## Changes

* Allows the user to fully define and push the app in Python.