### PR TITLE
Adds multi-way option merge

### DIFF
--- a/docs/nextmv/tutorials/options.md
+++ b/docs/nextmv/tutorials/options.md
@@ -79,11 +79,14 @@ options1 = nextmv.Options(
 options2 = nextmv.Options(
     nextmv.Option("str_option2", str, "default value", "A string option", required=True),
     nextmv.Option("int_option2", int, 1, "An int option", required=False),
+)
+
+options3 = nextmv.Options(
     nextmv.Option("float_option2", float, 1.0, "A float option", required=False),
     nextmv.Option("bool_option2", bool, True, "A bool option", required=True),
 )
 
-options = options1.merge(options2)
+options = options1.merge(options2, options3)
 
 print(options.str_option1)
 print(options.int_option1)

--- a/nextmv/nextmv/options.py
+++ b/nextmv/nextmv/options.py
@@ -676,15 +676,15 @@ class Options:
         if not options:
             raise ValueError("at least one Options instance is required to merge")
 
-        merged = []
+        merged_options_list = []
         for opt in options:
             if opt.PARSED:
                 raise RuntimeError(
                     "options have already been parsed, cannot merge. See `Options.parse()` for more information."
                 )
-            merged += opt.options
+            merged_options_list += opt.options
 
-        merged_options = cls(*merged)
+        merged_options = cls(*merged_options_list)
 
         if not skip_parse:
             merged_options._parse()

--- a/nextmv/nextmv/options.py
+++ b/nextmv/nextmv/options.py
@@ -587,7 +587,8 @@ class Options:
         Parameters
         ----------
         new : Options
-            The new options to merge with the current options.
+            The new options to merge with the current options. At least one new option set
+            is required to merge. Multiple `Options` instances can be passed.
         skip_parse : bool, optional
             If True, the merged options will not be parsed after merging. This is useful
             if you want to merge further options after this merge. The default is False.

--- a/nextmv/nextmv/options.py
+++ b/nextmv/nextmv/options.py
@@ -627,7 +627,8 @@ class Options:
 
         self.options += new.options
 
-        self._parse()
+        if not skip_parse:
+            self._parse()
 
         return self
 

--- a/nextmv/nextmv/options.py
+++ b/nextmv/nextmv/options.py
@@ -575,7 +575,7 @@ class Options:
 
         self._parse()
 
-    def merge(self, new: "Options") -> "Options":
+    def merge(self, new: "Options", skip_parse: bool = False) -> "Options":
         """
         Merges the current options with the new options.
 
@@ -588,6 +588,9 @@ class Options:
         ----------
         new : Options
             The new options to merge with the current options.
+        skip_parse : bool, optional
+            If True, the merged options will not be parsed after merging. This is useful
+            if you want to merge further options after this merge. The default is False.
 
         Returns
         -------
@@ -627,6 +630,65 @@ class Options:
         self._parse()
 
         return self
+
+    @classmethod
+    def merge_all(cls, *options: "Options", skip_parse: bool = False) -> "Options":
+        """
+        Merges multiple `Options` instances into a single `Options` instance.
+
+        This method cannot be used if any of the options have been parsed already. When
+        options are parsed, values are read from the command-line arguments, environment
+        variables and default values. Merging options after parsing would result in
+        unpredictable behavior.
+
+        Parameters
+        ----------
+        *options : Options
+            The `Options` instances to merge. At least one `Options` instance is required.
+        skip_parse : bool, optional
+            If True, the merged options will not be parsed after merging. This is useful
+            if you want to merge further options after this merge. The default is False.
+
+        Returns
+        -------
+        Options
+            A new `Options` instance containing all options from the provided instances.
+
+        Raises
+        ------
+        ValueError
+            If no `Options` instances are provided to merge.
+        RuntimeError
+            If any of the provided `Options` instances have already been parsed.
+
+        Examples
+        --------
+        >>> opt1 = Options(Option("duration", str, "30s"))
+        >>> opt2 = Options(Option("threads", int, 4))
+        >>> merged = Options.merge_all(opt1, opt2)
+        >>> merged.duration
+        '30s'
+        >>> merged.threads
+        4
+        """
+
+        if not options:
+            raise ValueError("at least one Options instance is required to merge")
+
+        merged = []
+        for opt in options:
+            if opt.PARSED:
+                raise RuntimeError(
+                    "options have already been parsed, cannot merge. See `Options.parse()` for more information."
+                )
+            merged += opt.options
+
+        merged_options = cls(*merged)
+
+        if not skip_parse:
+            merged_options._parse()
+
+        return merged_options
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "Options":

--- a/nextmv/nextmv/options.py
+++ b/nextmv/nextmv/options.py
@@ -575,7 +575,7 @@ class Options:
 
         self._parse()
 
-    def merge(self, new: "Options", skip_parse: bool = False) -> "Options":
+    def merge(self, *new: "Options", skip_parse: bool = False) -> "Options":
         """
         Merges the current options with the new options.
 
@@ -608,11 +608,14 @@ class Options:
         --------
         >>> opt1 = Options(Option("duration", str, "30s"))
         >>> opt2 = Options(Option("threads", int, 4))
-        >>> merged = opt1.merge(opt2)
+        >>> opt3 = Options(Option("verbose", bool, False))
+        >>> merged = opt1.merge(opt2, opt3)
         >>> merged.duration
         '30s'
         >>> merged.threads
         4
+        >>> merged.verbose
+        False
         """
 
         if self.PARSED:
@@ -620,76 +623,26 @@ class Options:
                 "base options have already been parsed, cannot merge. See `Options.parse()` for more information."
             )
 
-        if new.PARSED:
-            raise RuntimeError(
-                "new options have already been parsed, cannot merge. See `Options.parse()` for more information."
-            )
+        if not new:
+            raise ValueError("at least one new Options instance is required to merge")
 
-        self.options += new.options
-
-        if not skip_parse:
-            self._parse()
-
-        return self
-
-    @classmethod
-    def merge_all(cls, *options: "Options", skip_parse: bool = False) -> "Options":
-        """
-        Merges multiple `Options` instances into a single `Options` instance.
-
-        This method cannot be used if any of the options have been parsed already. When
-        options are parsed, values are read from the command-line arguments, environment
-        variables and default values. Merging options after parsing would result in
-        unpredictable behavior.
-
-        Parameters
-        ----------
-        *options : Options
-            The `Options` instances to merge. At least one `Options` instance is required.
-        skip_parse : bool, optional
-            If True, the merged options will not be parsed after merging. This is useful
-            if you want to merge further options after this merge. The default is False.
-
-        Returns
-        -------
-        Options
-            A new `Options` instance containing all options from the provided instances.
-
-        Raises
-        ------
-        ValueError
-            If no `Options` instances are provided to merge.
-        RuntimeError
-            If any of the provided `Options` instances have already been parsed.
-
-        Examples
-        --------
-        >>> opt1 = Options(Option("duration", str, "30s"))
-        >>> opt2 = Options(Option("threads", int, 4))
-        >>> merged = Options.merge_all(opt1, opt2)
-        >>> merged.duration
-        '30s'
-        >>> merged.threads
-        4
-        """
-
-        if not options:
-            raise ValueError("at least one Options instance is required to merge")
-
-        merged_options_list = []
-        for opt in options:
+        for i, opt in enumerate(new):
+            if not isinstance(opt, Options):
+                raise TypeError(f"expected an <Options> object, but got {type(opt)} in index {i}")
             if opt.PARSED:
                 raise RuntimeError(
-                    "options have already been parsed, cannot merge. See `Options.parse()` for more information."
+                    f"new options at index {i} have already been parsed, cannot merge. "
+                    + "See `Options.parse()` for more information."
                 )
-            merged_options_list += opt.options
 
-        merged_options = cls(*merged_options_list)
+        # Add the new options to the current options.
+        for n in new:
+            self.options += n.options
 
         if not skip_parse:
-            merged_options._parse()
+            self.parse()
 
-        return merged_options
+        return self
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "Options":

--- a/nextmv/tests/test_options.py
+++ b/nextmv/tests/test_options.py
@@ -588,6 +588,69 @@ class TestParameter(unittest.TestCase):
         self.assertEqual(opt.foo2, 3)
         self.assertEqual(opt.bar2, 4)
 
+    def test_merge_lazy(self):
+        opt1 = nextmv.Options(
+            nextmv.Parameter("foo1", int, default=1),
+            nextmv.Parameter("bar1", int, default=2),
+        )
+        self.assertFalse(opt1.PARSED)
+
+        opt2 = nextmv.Options(
+            nextmv.Parameter("foo2", int, default=3),
+            nextmv.Parameter("bar2", int, default=4),
+        )
+        self.assertFalse(opt2.PARSED)
+
+        opt3 = nextmv.Options(
+            nextmv.Parameter("foo3", int, default=5),
+            nextmv.Parameter("bar3", int, default=6),
+        )
+        self.assertFalse(opt3.PARSED)
+
+        opt = opt1.merge(opt2, skip_parse=True)
+        self.assertFalse(opt.PARSED)
+
+        opt = opt.merge(opt3, skip_parse=True)
+        self.assertFalse(opt.PARSED)
+
+        opt.parse()
+        self.assertTrue(opt.PARSED)
+
+        self.assertEqual(opt.foo1, 1)
+        self.assertEqual(opt.bar1, 2)
+        self.assertEqual(opt.foo2, 3)
+        self.assertEqual(opt.bar2, 4)
+        self.assertEqual(opt.foo3, 5)
+        self.assertEqual(opt.bar3, 6)
+
+    def test_merge_all(self):
+        opt1 = nextmv.Options(
+            nextmv.Parameter("foo1", int, default=1),
+            nextmv.Parameter("bar1", int, default=2),
+        )
+        self.assertFalse(opt1.PARSED)
+
+        opt2 = nextmv.Options(
+            nextmv.Parameter("foo2", int, default=3),
+            nextmv.Parameter("bar2", int, default=4),
+        )
+        self.assertFalse(opt2.PARSED)
+
+        opt3 = nextmv.Options(
+            nextmv.Parameter("foo3", int, default=5),
+            nextmv.Parameter("bar3", int, default=6),
+        )
+        self.assertFalse(opt3.PARSED)
+
+        opt = nextmv.Options.merge_all(opt1, opt2, opt3)
+        self.assertTrue(opt.PARSED)
+        self.assertEqual(opt.foo1, 1)
+        self.assertEqual(opt.bar1, 2)
+        self.assertEqual(opt.foo2, 3)
+        self.assertEqual(opt.bar2, 4)
+        self.assertEqual(opt.foo3, 5)
+        self.assertEqual(opt.bar3, 6)
+
     def test_cant_merge(self):
         opt1 = nextmv.Options(
             nextmv.Parameter("foo1", int, default=1),

--- a/nextmv/tests/test_options.py
+++ b/nextmv/tests/test_options.py
@@ -623,7 +623,7 @@ class TestParameter(unittest.TestCase):
         self.assertEqual(opt.foo3, 5)
         self.assertEqual(opt.bar3, 6)
 
-    def test_merge_all(self):
+    def test_merge_multi(self):
         opt1 = nextmv.Options(
             nextmv.Parameter("foo1", int, default=1),
             nextmv.Parameter("bar1", int, default=2),
@@ -642,14 +642,14 @@ class TestParameter(unittest.TestCase):
         )
         self.assertFalse(opt3.PARSED)
 
-        opt = nextmv.Options.merge_all(opt1, opt2, opt3)
-        self.assertTrue(opt.PARSED)
-        self.assertEqual(opt.foo1, 1)
-        self.assertEqual(opt.bar1, 2)
-        self.assertEqual(opt.foo2, 3)
-        self.assertEqual(opt.bar2, 4)
-        self.assertEqual(opt.foo3, 5)
-        self.assertEqual(opt.bar3, 6)
+        opt1.merge(opt2, opt3)
+        self.assertTrue(opt1.PARSED)
+        self.assertEqual(opt1.foo1, 1)
+        self.assertEqual(opt1.bar1, 2)
+        self.assertEqual(opt1.foo2, 3)
+        self.assertEqual(opt1.bar2, 4)
+        self.assertEqual(opt1.foo3, 5)
+        self.assertEqual(opt1.bar3, 6)
 
     def test_cant_merge(self):
         opt1 = nextmv.Options(


### PR DESCRIPTION
# Description

Adds functionality for merging multiple option sets at once. Furthermore, allows the user to skip parsing if further options will be added later after the merge was done.

## Changes

* Adds `Options.merge_all(...)` function for merging multiple options sets at once.
  * E.g.: `merged_options = Options.merge_all(option_set1, option_set2, option_set3)`
* Adds `skip_parse` parameter to option merge functions to allow lazy option merging and delayed (explicit) parsing.