### PR TITLE
Prevents numerical overflows during polling

### DIFF
--- a/nextmv/nextmv/__about__.py
+++ b/nextmv/nextmv/__about__.py
@@ -1,1 +1,1 @@
-__version__ = "v0.28.2"
+__version__ = "v0.28.3.dev1"

--- a/nextmv/nextmv/cloud/application.py
+++ b/nextmv/nextmv/cloud/application.py
@@ -184,9 +184,9 @@ class PollingOptions:
     """
     max_delay: float = 20
     """Maximum delay to use between polls, in seconds."""
-    max_duration: float = 300
+    max_duration: float = -1
     """Maximum duration of the polling strategy, in seconds."""
-    max_tries: int = 100
+    max_tries: int = -1
     """Maximum number of tries to use."""
     jitter: float = 1
     """
@@ -3258,7 +3258,13 @@ def poll(  # noqa: C901
 
     # Begin the polling process.
     max_reached = False
-    for ix in range(polling_options.max_tries):
+    ix = 0
+    while True:
+        # Check if we reached the maximum number of tries. Break if so.
+        if ix >= polling_options.max_tries and polling_options.max_tries >= 0:
+            break
+        ix += 1
+
         # Check is we should stop polling according to the stop callback.
         if polling_options.stop is not None and polling_options.stop():
             stopped = True
@@ -3278,7 +3284,7 @@ def poll(  # noqa: C901
         if polling_options.verbose:
             log(f"polling | elapsed time: {passed}")
 
-        if passed >= polling_options.max_duration:
+        if passed >= polling_options.max_duration and polling_options.max_duration >= 0:
             raise TimeoutError(
                 f"polling did not succeed after {passed} seconds, exceeds max duration: {polling_options.max_duration}",
             )

--- a/nextmv/nextmv/cloud/application.py
+++ b/nextmv/nextmv/cloud/application.py
@@ -3174,7 +3174,7 @@ class Application:
         raise ValueError(f"Unknown scenario input type: {scenario.scenario_input.scenario_input_type}")
 
 
-def poll(polling_options: PollingOptions, polling_func: Callable[[], tuple[Any, bool]]) -> Any:
+def poll(polling_options: PollingOptions, polling_func: Callable[[], tuple[Any, bool]]) -> Any:  # noqa: C901
     """
     Poll a function until it succeeds or the polling strategy is exhausted.
 

--- a/nextmv/nextmv/cloud/application.py
+++ b/nextmv/nextmv/cloud/application.py
@@ -3284,7 +3284,6 @@ def poll(  # noqa: C901
             )
 
         # Calculate the delay.
-        delay = 0.0
         if max_reached:
             # If we already reached the maximum, we don't want to further calculate the
             # delay to avoid overflows.

--- a/nextmv/nextmv/cloud/application.py
+++ b/nextmv/nextmv/cloud/application.py
@@ -3253,6 +3253,7 @@ def poll(polling_options: PollingOptions, polling_func: Callable[[], tuple[Any, 
     stopped = False
 
     # Begin the polling process.
+    max_reached = False
     for ix in range(polling_options.max_tries):
         # Check is we should stop polling according to the stop callback.
         if polling_options.stop is not None and polling_options.stop():
@@ -3279,12 +3280,24 @@ def poll(polling_options: PollingOptions, polling_func: Callable[[], tuple[Any, 
             )
 
         # Calculate the delay.
-        delay = polling_options.delay  # Base
-        delay += polling_options.backoff * (2**ix)  # Add exponential backoff.
-        delay += random.uniform(0, polling_options.jitter)  # Add jitter.
+        delay = 0.0
+        if max_reached:
+            # If we already reached the maximum, we don't want to further calculate the
+            # delay to avoid overflows.
+            delay = polling_options.max_delay
+            delay += random.uniform(0, polling_options.jitter)  # Add jitter.
+        else:
+            delay = polling_options.delay  # Base
+            delay += polling_options.backoff * (2**ix)  # Add exponential backoff.
+            delay += random.uniform(0, polling_options.jitter)  # Add jitter.
 
-        # Sleep for the calculated delay. We cannot exceed the max delay.
-        sleep_duration = min(delay, polling_options.max_delay)
+        # We cannot exceed the max delay.
+        if delay >= polling_options.max_delay:
+            max_reached = True
+            delay = polling_options.max_delay
+
+        # Sleep for the calculated delay.
+        sleep_duration = delay
         if polling_options.verbose:
             log(f"polling | sleeping for duration: {sleep_duration}")
 

--- a/nextmv/nextmv/cloud/application.py
+++ b/nextmv/nextmv/cloud/application.py
@@ -3174,7 +3174,11 @@ class Application:
         raise ValueError(f"Unknown scenario input type: {scenario.scenario_input.scenario_input_type}")
 
 
-def poll(polling_options: PollingOptions, polling_func: Callable[[], tuple[Any, bool]]) -> Any:  # noqa: C901
+def poll(  # noqa: C901
+    polling_options: PollingOptions,
+    polling_func: Callable[[], tuple[Any, bool]],
+    __sleep_func: Callable[[float], None] = time.sleep,
+) -> Any:
     """
     Poll a function until it succeeds or the polling strategy is exhausted.
 
@@ -3247,7 +3251,7 @@ def poll(polling_options: PollingOptions, polling_func: Callable[[], tuple[Any, 
     if polling_options.verbose:
         log(f"polling | sleeping for initial delay: {polling_options.initial_delay}")
 
-    time.sleep(polling_options.initial_delay)
+    __sleep_func(polling_options.initial_delay)
 
     start_time = time.time()
     stopped = False
@@ -3301,7 +3305,7 @@ def poll(polling_options: PollingOptions, polling_func: Callable[[], tuple[Any, 
         if polling_options.verbose:
             log(f"polling | sleeping for duration: {sleep_duration}")
 
-        time.sleep(sleep_duration)
+        __sleep_func(sleep_duration)
 
     if stopped:
         log("polling | stop condition met, stopping polling")

--- a/nextmv/nextmv/cloud/application.py
+++ b/nextmv/nextmv/cloud/application.py
@@ -185,9 +185,11 @@ class PollingOptions:
     max_delay: float = 20
     """Maximum delay to use between polls, in seconds."""
     max_duration: float = -1
-    """Maximum duration of the polling strategy, in seconds."""
+    """
+    Maximum duration of the polling strategy, in seconds. A negative value means no limit.
+    """
     max_tries: int = -1
-    """Maximum number of tries to use."""
+    """Maximum number of tries to use. A negative value means no limit."""
     jitter: float = 1
     """
     Jitter to use for the polling strategy. A uniform distribution is sampled

--- a/nextmv/tests/cloud/test_application.py
+++ b/nextmv/tests/cloud/test_application.py
@@ -4,6 +4,11 @@ from typing import Any
 from nextmv.cloud.application import PollingOptions, poll
 
 
+# This is a dummy function to avoid actually sleeping during tests.
+def no_sleep(value: float) -> None:
+    return
+
+
 class TestApplication(unittest.TestCase):
     def test_poll(self):
         counter = 0
@@ -17,9 +22,9 @@ class TestApplication(unittest.TestCase):
 
             return "result", True
 
-        polling_options = PollingOptions(verbose=True)
+        polling_options = PollingOptions()
 
-        result = poll(polling_options, polling_func)
+        result = poll(polling_options, polling_func, no_sleep)
 
         self.assertEqual(result, "result")
 
@@ -42,8 +47,29 @@ class TestApplication(unittest.TestCase):
             if counter == 3:
                 return True
 
-        polling_options = PollingOptions(verbose=True, stop=stop)
+        polling_options = PollingOptions(stop=stop)
 
-        result = poll(polling_options, polling_func)
+        result = poll(polling_options, polling_func, no_sleep)
 
         self.assertIsNone(result)
+
+    def test_poll_long(self):
+        counter = 0
+        max_tries = 1000000
+
+        def polling_func() -> tuple[Any, bool]:
+            nonlocal counter
+            counter += 1
+
+            if counter < max_tries:
+                return "result", False
+
+            return "result", True
+
+        polling_options = PollingOptions(
+            max_tries=max_tries + 1,
+        )
+
+        result = poll(polling_options, polling_func, no_sleep)
+
+        self.assertEqual(result, "result")


### PR DESCRIPTION
# Description

This PR addresses a numerical overflow (bug) that happens when polling with long timeouts. Furthermore, we change the defaults for polling to not have a timeout or maximum number of polls. This avoids running into unexpected exceptions when polling long runs.

## Changes

- Prevents an overflow that occurs when polling for very long times.
- Remove timeout and max tries from polling defaults.
- Improve test times by allowing to override delay function.

Resolves ENG-6121, ENG-6123