### PR TITLE
Adds control and hidden attributes to options

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -24,6 +24,13 @@ jobs:
           pip install .[dev]
         working-directory: ./${{ matrix.package }}
 
+      - name: handle nextmv dependency
+        if: ${{ matrix.package != 'nextmv' }}
+        run: |
+          pip uninstall -y nextmv
+          pip install -e ../nextmv
+        working-directory: ./${{ matrix.package }}
+
       - name: unit tests
         run: python -m unittest
         working-directory: ./${{ matrix.package }}

--- a/nextmv-scikit-learn/pyproject.toml
+++ b/nextmv-scikit-learn/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 ]
 dependencies = [
     "scikit-learn>=1.6.1",
-    "nextmv>=0.25.0"
+    "nextmv>=0.29.0"
 ]
 description = "An SDK for integrating scikit-learn with the Nextmv platform"
 dynamic = [

--- a/nextmv-scikit-learn/tests/expected_decision_tree_option_parameters.json
+++ b/nextmv-scikit-learn/tests/expected_decision_tree_option_parameters.json
@@ -6,7 +6,9 @@
     "description": "The function to measure the quality of a split.",
     "required": false,
     "choices": ["squared_error", "friedman_mse", "absolute_error", "poisson"],
-    "additional_attributes": null
+    "additional_attributes": null,
+    "control_type": null,
+    "hidden_from": null
   },
   {
     "name": "splitter",
@@ -15,7 +17,9 @@
     "description": "The strategy used to choose the split at each node.",
     "required": false,
     "choices": ["best", "random"],
-    "additional_attributes": null
+    "additional_attributes": null,
+    "control_type": null,
+    "hidden_from": null
   },
   {
     "name": "max_depth",
@@ -24,7 +28,9 @@
     "description": "The maximum depth of the tree.",
     "required": false,
     "choices": null,
-    "additional_attributes": null
+    "additional_attributes": null,
+    "control_type": null,
+    "hidden_from": null
   },
   {
     "name": "min_samples_split",
@@ -33,7 +39,9 @@
     "description": "The minimum number of samples required to split an internal node.",
     "required": false,
     "choices": null,
-    "additional_attributes": null
+    "additional_attributes": null,
+    "control_type": null,
+    "hidden_from": null
   },
   {
     "name": "min_samples_leaf",
@@ -42,7 +50,9 @@
     "description": "The minimum number of samples required to be at a leaf node.",
     "required": false,
     "choices": null,
-    "additional_attributes": null
+    "additional_attributes": null,
+    "control_type": null,
+    "hidden_from": null
   },
   {
     "name": "min_weight_fraction_leaf",
@@ -51,7 +61,9 @@
     "description": "The minimum weighted fraction of the sum total of weights required to be at a leaf node.",
     "required": false,
     "choices": null,
-    "additional_attributes": null
+    "additional_attributes": null,
+    "control_type": null,
+    "hidden_from": null
   },
   {
     "name": "max_features",
@@ -60,7 +72,9 @@
     "description": "The number of features to consider when looking for the best split.",
     "required": false,
     "choices": null,
-    "additional_attributes": null
+    "additional_attributes": null,
+    "control_type": null,
+    "hidden_from": null
   },
   {
     "name": "random_state",
@@ -69,7 +83,9 @@
     "description": "Controls the randomness of the estimator.",
     "required": false,
     "choices": null,
-    "additional_attributes": null
+    "additional_attributes": null,
+    "control_type": null,
+    "hidden_from": null
   },
   {
     "name": "max_leaf_nodes",
@@ -78,7 +94,9 @@
     "description": "Grow a tree with max_leaf_nodes in best-first fashion.",
     "required": false,
     "choices": null,
-    "additional_attributes": null
+    "additional_attributes": null,
+    "control_type": null,
+    "hidden_from": null
   },
   {
     "name": "min_impurity_decrease",
@@ -87,7 +105,9 @@
     "description": "A node will be split if this split induces a decrease of the impurity #.",
     "required": false,
     "choices": null,
-    "additional_attributes": null
+    "additional_attributes": null,
+    "control_type": null,
+    "hidden_from": null
   },
   {
     "name": "ccp_alpha",
@@ -96,6 +116,8 @@
     "description": "Complexity parameter used for Minimal Cost-Complexity Pruning.",
     "required": false,
     "choices": null,
-    "additional_attributes": null
+    "additional_attributes": null,
+    "control_type": null,
+    "hidden_from": null
   }
 ]

--- a/nextmv-scikit-learn/tests/expected_dummy_option_parameters.json
+++ b/nextmv-scikit-learn/tests/expected_dummy_option_parameters.json
@@ -6,7 +6,9 @@
     "description": "Strategy to use to generate predictions.",
     "required": false,
     "choices": ["mean", "median", "quantile", "constant"],
-    "additional_attributes": null
+    "additional_attributes": null,
+    "control_type": null,
+    "hidden_from": null
   },
   {
     "name": "constant",
@@ -15,7 +17,9 @@
     "description": "The explicit constant as predicted by the \"constant\" strategy.",
     "required": false,
     "choices": null,
-    "additional_attributes": null
+    "additional_attributes": null,
+    "control_type": null,
+    "hidden_from": null
   },
   {
     "name": "quantile",
@@ -24,6 +28,8 @@
     "description": "The quantile to predict using the \"quantile\" strategy.",
     "required": false,
     "choices": null,
-    "additional_attributes": null
+    "additional_attributes": null,
+    "control_type": null,
+    "hidden_from": null
   }
 ]

--- a/nextmv-scikit-learn/tests/expected_gradient_boosting_option_parameters.json
+++ b/nextmv-scikit-learn/tests/expected_gradient_boosting_option_parameters.json
@@ -6,7 +6,9 @@
     "description": "Loss function to be optimized.",
     "required": false,
     "choices": ["squared_error", "absolute_error", "huber", "quantile"],
-    "additional_attributes": null
+    "additional_attributes": null,
+    "control_type": null,
+    "hidden_from": null
   },
   {
     "name": "learning_rate",
@@ -15,7 +17,9 @@
     "description": "Learning rate shrinks the contribution of each tree by learning_rate.",
     "required": false,
     "choices": null,
-    "additional_attributes": null
+    "additional_attributes": null,
+    "control_type": null,
+    "hidden_from": null
   },
   {
     "name": "n_estimators",
@@ -24,7 +28,9 @@
     "description": "The number of boosting stages to perform.",
     "required": false,
     "choices": null,
-    "additional_attributes": null
+    "additional_attributes": null,
+    "control_type": null,
+    "hidden_from": null
   },
   {
     "name": "subsample",
@@ -33,7 +39,9 @@
     "description": "The fraction of samples to be used for fitting the individual base learners.",
     "required": false,
     "choices": null,
-    "additional_attributes": null
+    "additional_attributes": null,
+    "control_type": null,
+    "hidden_from": null
   },
   {
     "name": "criterion",
@@ -42,7 +50,9 @@
     "description": "The function to measure the quality of a split.",
     "required": false,
     "choices": ["friedman_mse", "squared_error"],
-    "additional_attributes": null
+    "additional_attributes": null,
+    "control_type": null,
+    "hidden_from": null
   },
   {
     "name": "min_samples_split",
@@ -51,7 +61,9 @@
     "description": "The minimum number of samples required to split an internal node.",
     "required": false,
     "choices": null,
-    "additional_attributes": null
+    "additional_attributes": null,
+    "control_type": null,
+    "hidden_from": null
   },
   {
     "name": "min_samples_leaf",
@@ -60,7 +72,9 @@
     "description": "The minimum number of samples required to be at a leaf node.",
     "required": false,
     "choices": null,
-    "additional_attributes": null
+    "additional_attributes": null,
+    "control_type": null,
+    "hidden_from": null
   },
   {
     "name": "min_weight_fraction_leaf",
@@ -69,7 +83,9 @@
     "description": "The minimum weighted fraction of the sum total of weights required to be at a leaf node.",
     "required": false,
     "choices": null,
-    "additional_attributes": null
+    "additional_attributes": null,
+    "control_type": null,
+    "hidden_from": null
   },
   {
     "name": "max_depth",
@@ -78,7 +94,9 @@
     "description": "Maximum depth of the individual regression estimators.",
     "required": false,
     "choices": null,
-    "additional_attributes": null
+    "additional_attributes": null,
+    "control_type": null,
+    "hidden_from": null
   },
   {
     "name": "min_impurity_decrease",
@@ -87,7 +105,9 @@
     "description": "A node will be split if this split induces a decrease of the impurity greater than or equal to this value.",
     "required": false,
     "choices": null,
-    "additional_attributes": null
+    "additional_attributes": null,
+    "control_type": null,
+    "hidden_from": null
   },
   {
     "name": "random_state",
@@ -96,7 +116,9 @@
     "description": "Controls the random seed given to each Tree estimator at each boosting iteration.",
     "required": false,
     "choices": null,
-    "additional_attributes": null
+    "additional_attributes": null,
+    "control_type": null,
+    "hidden_from": null
   },
   {
     "name": "max_features",
@@ -105,7 +127,9 @@
     "description": "The number of features to consider when looking for the best split.",
     "required": false,
     "choices": null,
-    "additional_attributes": null
+    "additional_attributes": null,
+    "control_type": null,
+    "hidden_from": null
   },
   {
     "name": "alpha",
@@ -114,7 +138,9 @@
     "description": "The alpha-quantile of the huber loss function and the quantile loss function.",
     "required": false,
     "choices": null,
-    "additional_attributes": null
+    "additional_attributes": null,
+    "control_type": null,
+    "hidden_from": null
   },
   {
     "name": "max_leaf_nodes",
@@ -123,7 +149,9 @@
     "description": "Grow trees with max_leaf_nodes in best-first fashion.",
     "required": false,
     "choices": null,
-    "additional_attributes": null
+    "additional_attributes": null,
+    "control_type": null,
+    "hidden_from": null
   },
   {
     "name": "warm_start",
@@ -132,7 +160,9 @@
     "description": "When set to True, reuse the solution of the previous call to fit and add more estimators to the ensemble, otherwise, just erase the previous solution.",
     "required": false,
     "choices": null,
-    "additional_attributes": null
+    "additional_attributes": null,
+    "control_type": null,
+    "hidden_from": null
   },
   {
     "name": "validation_fraction",
@@ -141,7 +171,9 @@
     "description": "The proportion of training data to set aside as validation set for early stopping.",
     "required": false,
     "choices": null,
-    "additional_attributes": null
+    "additional_attributes": null,
+    "control_type": null,
+    "hidden_from": null
   },
   {
     "name": "n_iter_no_change",
@@ -150,7 +182,9 @@
     "description": "n_iter_no_change is used to decide if early stopping will be used to terminate training when validation score is not improving.",
     "required": false,
     "choices": null,
-    "additional_attributes": null
+    "additional_attributes": null,
+    "control_type": null,
+    "hidden_from": null
   },
   {
     "name": "tol",
@@ -159,7 +193,9 @@
     "description": "Tolerance for the early stopping.",
     "required": false,
     "choices": null,
-    "additional_attributes": null
+    "additional_attributes": null,
+    "control_type": null,
+    "hidden_from": null
   },
   {
     "name": "ccp_alpha",
@@ -168,6 +204,8 @@
     "description": "Complexity parameter used for Minimal Cost-Complexity Pruning.",
     "required": false,
     "choices": null,
-    "additional_attributes": null
+    "additional_attributes": null,
+    "control_type": null,
+    "hidden_from": null
   }
 ]

--- a/nextmv-scikit-learn/tests/expected_linear_regression_option_parameters.json
+++ b/nextmv-scikit-learn/tests/expected_linear_regression_option_parameters.json
@@ -6,7 +6,9 @@
     "description": "Whether to calculate the intercept for this model.",
     "required": false,
     "choices": null,
-    "additional_attributes": null
+    "additional_attributes": null,
+    "control_type": null,
+    "hidden_from": null
   },
   {
     "name": "copy_X",
@@ -15,7 +17,9 @@
     "description": "If True, X will be copied; else, it may be overwritten.",
     "required": false,
     "choices": null,
-    "additional_attributes": null
+    "additional_attributes": null,
+    "control_type": null,
+    "hidden_from": null
   },
   {
     "name": "n_jobs",
@@ -24,7 +28,9 @@
     "description": "The number of jobs to use for the computation.",
     "required": false,
     "choices": null,
-    "additional_attributes": null
+    "additional_attributes": null,
+    "control_type": null,
+    "hidden_from": null
   },
   {
     "name": "positive",
@@ -33,6 +39,8 @@
     "description": "When set to True, forces the coefficients to be positive.",
     "required": false,
     "choices": null,
-    "additional_attributes": null
+    "additional_attributes": null,
+    "control_type": null,
+    "hidden_from": null
   }
 ]

--- a/nextmv-scikit-learn/tests/expected_mlp_regressor_option_parameters.json
+++ b/nextmv-scikit-learn/tests/expected_mlp_regressor_option_parameters.json
@@ -6,7 +6,9 @@
     "description": "The ith element represents the number of neurons in the ith hidden layer. (e.g. \"1,2,3\")",
     "required": false,
     "choices": null,
-    "additional_attributes": null
+    "additional_attributes": null,
+    "control_type": null,
+    "hidden_from": null
   },
   {
     "name": "activation",
@@ -15,7 +17,9 @@
     "description": "Activation function for the hidden layer.",
     "required": false,
     "choices": ["identity", "logistic", "tanh", "relu"],
-    "additional_attributes": null
+    "additional_attributes": null,
+    "control_type": null,
+    "hidden_from": null
   },
   {
     "name": "solver",
@@ -24,7 +28,9 @@
     "description": "The solver for weight optimization.",
     "required": false,
     "choices": ["lbfgs", "sgd", "adam"],
-    "additional_attributes": null
+    "additional_attributes": null,
+    "control_type": null,
+    "hidden_from": null
   },
   {
     "name": "alpha",
@@ -33,7 +39,9 @@
     "description": "Strength of the L2 regularization term.",
     "required": false,
     "choices": null,
-    "additional_attributes": null
+    "additional_attributes": null,
+    "control_type": null,
+    "hidden_from": null
   },
   {
     "name": "batch_size",
@@ -42,7 +50,9 @@
     "description": "Size of minibatches for stochastic optimizers.",
     "required": false,
     "choices": null,
-    "additional_attributes": null
+    "additional_attributes": null,
+    "control_type": null,
+    "hidden_from": null
   },
   {
     "name": "learning_rate",
@@ -51,7 +61,9 @@
     "description": "Learning rate schedule for weight updates.",
     "required": false,
     "choices": ["constant", "invscaling", "adaptive"],
-    "additional_attributes": null
+    "additional_attributes": null,
+    "control_type": null,
+    "hidden_from": null
   },
   {
     "name": "learning_rate_init",
@@ -60,7 +72,9 @@
     "description": "The initial learning rate used.",
     "required": false,
     "choices": null,
-    "additional_attributes": null
+    "additional_attributes": null,
+    "control_type": null,
+    "hidden_from": null
   },
   {
     "name": "power_t",
@@ -69,7 +83,9 @@
     "description": "The exponent for inverse scaling learning rate.",
     "required": false,
     "choices": null,
-    "additional_attributes": null
+    "additional_attributes": null,
+    "control_type": null,
+    "hidden_from": null
   },
   {
     "name": "max_iter",
@@ -78,7 +94,9 @@
     "description": "Maximum number of iterations.",
     "required": false,
     "choices": null,
-    "additional_attributes": null
+    "additional_attributes": null,
+    "control_type": null,
+    "hidden_from": null
   },
   {
     "name": "shuffle",
@@ -87,7 +105,9 @@
     "description": "Whether to shuffle samples in each iteration.",
     "required": false,
     "choices": null,
-    "additional_attributes": null
+    "additional_attributes": null,
+    "control_type": null,
+    "hidden_from": null
   },
   {
     "name": "random_state",
@@ -96,7 +116,9 @@
     "description": "Determines random number generation for weights and bias initialization, train-test split if early stopping is used, and batch sampling when solver='sgd' or 'adam'.",
     "required": false,
     "choices": null,
-    "additional_attributes": null
+    "additional_attributes": null,
+    "control_type": null,
+    "hidden_from": null
   },
   {
     "name": "tol",
@@ -105,7 +127,9 @@
     "description": "Tolerance for the optimization.",
     "required": false,
     "choices": null,
-    "additional_attributes": null
+    "additional_attributes": null,
+    "control_type": null,
+    "hidden_from": null
   },
   {
     "name": "verbose",
@@ -114,7 +138,9 @@
     "description": "Whether to print progress messages to stdout.",
     "required": false,
     "choices": null,
-    "additional_attributes": null
+    "additional_attributes": null,
+    "control_type": null,
+    "hidden_from": null
   },
   {
     "name": "warm_start",
@@ -123,7 +149,9 @@
     "description": "When set to True, reuse the solution of the previous call to fit as initialization.",
     "required": false,
     "choices": null,
-    "additional_attributes": null
+    "additional_attributes": null,
+    "control_type": null,
+    "hidden_from": null
   },
   {
     "name": "momentum",
@@ -132,7 +160,9 @@
     "description": "Momentum for gradient descent update.",
     "required": false,
     "choices": null,
-    "additional_attributes": null
+    "additional_attributes": null,
+    "control_type": null,
+    "hidden_from": null
   },
   {
     "name": "nesterovs_momentum",
@@ -141,7 +171,9 @@
     "description": "Whether to use Nesterov's momentum.",
     "required": false,
     "choices": null,
-    "additional_attributes": null
+    "additional_attributes": null,
+    "control_type": null,
+    "hidden_from": null
   },
   {
     "name": "early_stopping",
@@ -150,7 +182,9 @@
     "description": "Whether to use early stopping to terminate training when validation score is not improving.",
     "required": false,
     "choices": null,
-    "additional_attributes": null
+    "additional_attributes": null,
+    "control_type": null,
+    "hidden_from": null
   },
   {
     "name": "validation_fraction",
@@ -159,7 +193,9 @@
     "description": "The proportion of training data to set aside as validation set for early stopping.",
     "required": false,
     "choices": null,
-    "additional_attributes": null
+    "additional_attributes": null,
+    "control_type": null,
+    "hidden_from": null
   },
   {
     "name": "beta_1",
@@ -168,7 +204,9 @@
     "description": "Exponential decay rate for estimates of first moment vector in adam.",
     "required": false,
     "choices": null,
-    "additional_attributes": null
+    "additional_attributes": null,
+    "control_type": null,
+    "hidden_from": null
   },
   {
     "name": "beta_2",
@@ -177,7 +215,9 @@
     "description": "Exponential decay rate for estimates of second moment vector in adam.",
     "required": false,
     "choices": null,
-    "additional_attributes": null
+    "additional_attributes": null,
+    "control_type": null,
+    "hidden_from": null
   },
   {
     "name": "epsilon",
@@ -186,7 +226,9 @@
     "description": "Value for numerical stability in adam.",
     "required": false,
     "choices": null,
-    "additional_attributes": null
+    "additional_attributes": null,
+    "control_type": null,
+    "hidden_from": null
   },
   {
     "name": "n_iter_no_change",
@@ -195,7 +237,9 @@
     "description": "Maximum number of epochs to not meet tol improvement.",
     "required": false,
     "choices": null,
-    "additional_attributes": null
+    "additional_attributes": null,
+    "control_type": null,
+    "hidden_from": null
   },
   {
     "name": "max_fun",
@@ -204,6 +248,8 @@
     "description": "Only used when solver='lbfgs'.",
     "required": false,
     "choices": null,
-    "additional_attributes": null
+    "additional_attributes": null,
+    "control_type": null,
+    "hidden_from": null
   }
 ]

--- a/nextmv-scikit-learn/tests/expected_random_forest_option_parameters.json
+++ b/nextmv-scikit-learn/tests/expected_random_forest_option_parameters.json
@@ -6,7 +6,9 @@
     "description": "The number of trees in the forest.",
     "required": false,
     "choices": null,
-    "additional_attributes": null
+    "additional_attributes": null,
+    "control_type": null,
+    "hidden_from": null
   },
   {
     "name": "criterion",
@@ -15,7 +17,9 @@
     "description": "The function to measure the quality of a split.",
     "required": false,
     "choices": ["squared_error", "absolute_error", "friedman_mse", "poisson"],
-    "additional_attributes": null
+    "additional_attributes": null,
+    "control_type": null,
+    "hidden_from": null
   },
   {
     "name": "max_depth",
@@ -24,7 +28,9 @@
     "description": "The maximum depth of the tree.",
     "required": false,
     "choices": null,
-    "additional_attributes": null
+    "additional_attributes": null,
+    "control_type": null,
+    "hidden_from": null
   },
   {
     "name": "min_samples_split",
@@ -33,7 +39,9 @@
     "description": "The minimum number of samples required to split an internal node.",
     "required": false,
     "choices": null,
-    "additional_attributes": null
+    "additional_attributes": null,
+    "control_type": null,
+    "hidden_from": null
   },
   {
     "name": "min_samples_leaf",
@@ -42,7 +50,9 @@
     "description": "The minimum number of samples required to be at a leaf node.",
     "required": false,
     "choices": null,
-    "additional_attributes": null
+    "additional_attributes": null,
+    "control_type": null,
+    "hidden_from": null
   },
   {
     "name": "min_weight_fraction_leaf",
@@ -51,7 +61,9 @@
     "description": "The minimum weighted fraction of the sum total of weights required to be at a leaf node.",
     "required": false,
     "choices": null,
-    "additional_attributes": null
+    "additional_attributes": null,
+    "control_type": null,
+    "hidden_from": null
   },
   {
     "name": "max_features",
@@ -60,7 +72,9 @@
     "description": "The number of features to consider when looking for the best split.",
     "required": false,
     "choices": null,
-    "additional_attributes": null
+    "additional_attributes": null,
+    "control_type": null,
+    "hidden_from": null
   },
   {
     "name": "max_leaf_nodes",
@@ -69,7 +83,9 @@
     "description": "Grow trees with max_leaf_nodes in best-first fashion.",
     "required": false,
     "choices": null,
-    "additional_attributes": null
+    "additional_attributes": null,
+    "control_type": null,
+    "hidden_from": null
   },
   {
     "name": "min_impurity_decrease",
@@ -78,7 +94,9 @@
     "description": "A node will be split if this split induces a decrease of the impurity greater than or equal to this value.",
     "required": false,
     "choices": null,
-    "additional_attributes": null
+    "additional_attributes": null,
+    "control_type": null,
+    "hidden_from": null
   },
   {
     "name": "bootstrap",
@@ -87,7 +105,9 @@
     "description": "Whether bootstrap samples are used when building trees.",
     "required": false,
     "choices": null,
-    "additional_attributes": null
+    "additional_attributes": null,
+    "control_type": null,
+    "hidden_from": null
   },
   {
     "name": "oob_score",
@@ -96,7 +116,9 @@
     "description": "Whether to use out-of-bag samples to estimate the generalization score.",
     "required": false,
     "choices": null,
-    "additional_attributes": null
+    "additional_attributes": null,
+    "control_type": null,
+    "hidden_from": null
   },
   {
     "name": "n_jobs",
@@ -105,7 +127,9 @@
     "description": "The number of jobs to run in parallel.",
     "required": false,
     "choices": null,
-    "additional_attributes": null
+    "additional_attributes": null,
+    "control_type": null,
+    "hidden_from": null
   },
   {
     "name": "random_state",
@@ -114,7 +138,9 @@
     "description": "Controls both the randomness of the bootstrapping of the samples used when building trees and the sampling of the features.",
     "required": false,
     "choices": null,
-    "additional_attributes": null
+    "additional_attributes": null,
+    "control_type": null,
+    "hidden_from": null
   },
   {
     "name": "verbose",
@@ -123,7 +149,9 @@
     "description": "Controls the verbosity when fitting and predicting.",
     "required": false,
     "choices": null,
-    "additional_attributes": null
+    "additional_attributes": null,
+    "control_type": null,
+    "hidden_from": null
   },
   {
     "name": "warm_start",
@@ -132,7 +160,9 @@
     "description": "When set to True, reuse the solution of the previous call to fit and add more estimators to the ensemble, otherwise, just erase the previous solution.",
     "required": false,
     "choices": null,
-    "additional_attributes": null
+    "additional_attributes": null,
+    "control_type": null,
+    "hidden_from": null
   },
   {
     "name": "ccp_alpha",
@@ -141,7 +171,9 @@
     "description": "Complexity parameter used for Minimal Cost-Complexity Pruning.",
     "required": false,
     "choices": null,
-    "additional_attributes": null
+    "additional_attributes": null,
+    "control_type": null,
+    "hidden_from": null
   },
   {
     "name": "max_samples",
@@ -150,7 +182,9 @@
     "description": "If bootstrap is True, the number of samples to draw from X to train each base estimator.",
     "required": false,
     "choices": null,
-    "additional_attributes": null
+    "additional_attributes": null,
+    "control_type": null,
+    "hidden_from": null
   },
   {
     "name": "monotonic_cst",
@@ -159,6 +193,8 @@
     "description": "Indicates the monotonicity constraint to enforce on each feature.",
     "required": false,
     "choices": null,
-    "additional_attributes": null
+    "additional_attributes": null,
+    "control_type": null,
+    "hidden_from": null
   }
 ]


### PR DESCRIPTION
Adds `control_type` and `hidden_from` attributes to the JSON schemas that describe options for various machine learning estimators. These attributes likely provide additional metadata or control over how these options are handled in a user interface or other tooling.

Adds a JSON schema for MLP Regressor options.