### PR TITLE
Refactor batch exp creation with instance ids

### DIFF
--- a/docs/nextmv/tutorials/experiments/batch-experiments.md
+++ b/docs/nextmv/tutorials/experiments/batch-experiments.md
@@ -4,6 +4,11 @@
 
     Find more information about batch experiments in this [section of the Nextmv docs](https://docs.nextmv.io/docs/using-nextmv/experiments/batch).
 
+!!! tip
+
+    [Scenario tests](./scenario-tests.md) are a more flexible form of batch experiments. Consider using
+    them instead.
+
 Batch experiments are used to analyze the output from one or more decision
 models on a fixed [input set][input-sets]. They are generally used as an
 exploratory test to understand the impacts to business metrics (or KPIs) when
@@ -11,31 +16,54 @@ updating a model with a new feature, such as an additional constraint. They can
 also be used to validate that a model is ready for further testing and likely to
 make an intended business impact.
 
-Define the desired batch experiment ID and name. After, create the batch
-experiment.
+To create a batch experiment, you need to build the underlying runs, using an
+input set and instances. After, define the desired batch experiment ID and name.
 
 ```python
 import os
 
-from nextmv.cloud import Application, Client
+from nextmv import cloud
 
-client = Client(api_key=os.getenv("NEXTMV_API_KEY"))
+client = cloud.Client(api_key=os.getenv("NEXTMV_API_KEY"))
 app = Application(client=client, id="<YOUR_APP_ID>")
-batch_experiment_id = app.new_batch_experiment(
+
+# Define the input set to use for the batch experiment.
+input_set = app.input_set(input_set_id="<YOUR_INPUT_SET_ID>")
+
+# Define the instances to run the batch experiment on.
+instances = ["<SAMPLE_INSTANCE_ID_1>", "<SAMPLE_INSTANCE_ID_2>"]
+
+# Build the batch experiment runs.
+input_ids = input_set.input_ids
+if len(input_set.input_ids) == 0:
+    input_ids = [input.id for input in input_set.inputs]
+
+runs = []
+for instance in instances:
+    for input_id in input_ids:
+        run = cloud.BatchExperimentRun(
+            input_id=input_id,
+            instance_id=instance,
+            input_set_id=input_set.id,
+        )
+        runs.append(run)
+
+
+# Create the batch experiment with the defined runs.
+batch_exp_id = app.new_batch_experiment(
     id="<YOUR_BATCH_EXPERIMENT_ID>",
     name="<YOUR_BATCH_EXPERIMENT_ID>",
-    input_set_id="<YOUR_INPUT_SET_ID>",
-    instance_ids=["latest", "latest-2"],
+    runs=runs,
     description="An optional description",
 )
-print(batch_experiment_id)
+print(batch_exp_id)
 ```  
 
 ```bash
 experiment-1
 ```  
 
-Defining `runs` and `option_sets` is supported as well.
+Defining `option_sets` is supported as well.
 
 ## Delete a batch experiment
 

--- a/nextmv/nextmv/cloud/application.py
+++ b/nextmv/nextmv/cloud/application.py
@@ -45,6 +45,7 @@ from nextmv.cloud.batch_experiment import (
     BatchExperimentInformation,
     BatchExperimentMetadata,
     BatchExperimentRun,
+    to_runs,
 )
 from nextmv.cloud.client import Client, get_size
 from nextmv.cloud.input_set import InputSet, ManagedInput
@@ -65,6 +66,7 @@ from nextmv.cloud.scenario import Scenario, ScenarioInputType, _option_sets, _sc
 from nextmv.cloud.secrets import Secret, SecretsCollection, SecretsCollectionSummary
 from nextmv.cloud.status import StatusV2
 from nextmv.cloud.version import Version
+from nextmv.deprecated import deprecated
 from nextmv.input import Input, InputFormat
 from nextmv.logger import log
 from nextmv.model import Model, ModelConfiguration
@@ -1027,12 +1029,21 @@ class Application:
                     f"batch experiment {id} does not exist, input_set_id must be defined to create a new one"
                 ) from e
         else:
+            runs = [
+                BatchExperimentRun(
+                    instance_id=candidate_instance_id,
+                    input_set_id=input_set_id,
+                ),
+                BatchExperimentRun(
+                    instance_id=baseline_instance_id,
+                    input_set_id=input_set_id,
+                ),
+            ]
             batch_experiment_id = self.new_batch_experiment(
                 name=name,
-                input_set_id=input_set_id,
-                instance_ids=[candidate_instance_id, baseline_instance_id],
                 description=description,
                 id=id,
+                runs=runs,
             )
 
         if batch_experiment_id != id:
@@ -1174,7 +1185,8 @@ class Application:
         input_set_id: str
             ID of the input set to use for the batch experiment.
         instance_ids: list[str]
-            List of instance IDs to use for the batch experiment.
+            DEPRECATED. List of instance IDs to use for the batch experiment.
+            This argument is deprecated, use `runs` instead.
         description: Optional[str]
             Optional description of the batch experiment.
         id: Optional[str]
@@ -1207,7 +1219,14 @@ class Application:
         if input_set_id is not None:
             payload["input_set_id"] = input_set_id
         if instance_ids is not None:
-            payload["instance_ids"] = instance_ids
+            deprecated(
+                name="new_batch_experiment.instance_ids",
+                reason="using argument `instance_ids` is deprecated, use `runs` instead",
+            )
+            input_set = self.input_set(input_set_id)
+            runs = to_runs(instance_ids, input_set)
+            payload_runs = [run.to_dict() for run in runs]
+            payload["runs"] = payload_runs
         if description is not None:
             payload["description"] = description
         if id is not None:

--- a/nextmv/nextmv/cloud/batch_experiment.py
+++ b/nextmv/nextmv/cloud/batch_experiment.py
@@ -17,6 +17,7 @@ from datetime import datetime
 from typing import Any, Optional
 
 from nextmv.base_model import BaseModel
+from nextmv.cloud.input_set import InputSet
 
 
 class BatchExperimentInformation(BaseModel):
@@ -143,10 +144,10 @@ class BatchExperimentRun(BaseModel):
 
     Parameters
     ----------
-    option_set : str
-        Option set used for the experiment.
     input_id : str
         ID of the input used for the experiment.
+    option_set : str
+        Option set used for the experiment. Defaults to None.
     instance_id : str, optional
         ID of the instance used for the experiment. Defaults to None.
     version_id : str, optional
@@ -162,11 +163,11 @@ class BatchExperimentRun(BaseModel):
         Run number of the experiment. Defaults to None.
     """
 
-    option_set: str
-    """Option set used for the experiment."""
     input_id: str
     """ID of the input used for the experiment."""
 
+    option_set: Optional[str] = None
+    """Option set used for the experiment."""
     instance_id: Optional[str] = None
     """ID of the instance used for the experiment."""
     version_id: Optional[str] = None
@@ -177,8 +178,6 @@ class BatchExperimentRun(BaseModel):
     """If the batch experiment is a scenario test, this is the ID of that test."""
     repetition: Optional[int] = None
     """Repetition number of the experiment."""
-    run_number: Optional[str] = None
-    """Run number of the experiment."""
 
     def __post_init_post_parse__(self):
         """
@@ -215,3 +214,37 @@ class BatchExperimentMetadata(BatchExperimentInformation):
 
     app_id: Optional[str] = None
     """ID of the application used for the batch experiment."""
+
+
+def to_runs(instance_ids: list[str], input_set: InputSet) -> list[BatchExperimentRun]:
+    """
+    Translate a legacy batch experiment list of instance ids to runs.
+
+    Parameters
+    ----------
+    instance_ids : list[str]
+        List of instance IDs to be converted into runs.
+    input_set : InputSet
+        Input set associated with the runs.
+
+    Returns
+    -------
+    list[BatchExperimentRun]
+        A list of `BatchExperimentRun` objects created from the instance IDs.
+    """
+
+    input_ids = input_set.input_ids
+    if len(input_set.input_ids) == 0:
+        input_ids = [i.id for i in input_set.inputs]
+
+    runs = []
+    for instance_id in instance_ids:
+        for input_id in input_ids:
+            run = BatchExperimentRun(
+                input_id=input_id,
+                instance_id=instance_id,
+                input_set_id=input_set.id,
+            )
+            runs.append(run)
+
+    return runs


### PR DESCRIPTION
# Description

The backend will soon drop support for a list of instance ids when creating a batch experiment. When using `instance_ids` in batch experiment creation, we now emit a deprecation warning and instead of using them, we translate them to `runs`, with help of the input set.