### PR TITLE
Aligns default instance behavior around new 'latest' convention

### DIFF
--- a/nextmv/nextmv/cloud/application.py
+++ b/nextmv/nextmv/cloud/application.py
@@ -275,7 +275,7 @@ class Application:
         Client to use for interacting with the Nextmv Cloud API.
     id : str
         ID of the application.
-    default_instance_id : str, default="devint"
+    default_instance_id : str, default=None
         Default instance ID to use for submitting runs.
     endpoint : str, default="v1/applications/{id}"
         Base endpoint for the application.
@@ -296,7 +296,7 @@ class Application:
     id: str
     """ID of the application."""
 
-    default_instance_id: str = "devint"
+    default_instance_id: str = None
     """Default instance ID to use for submitting runs."""
     endpoint: str = "v1/applications/{id}"
     """Base endpoint for the application."""
@@ -1788,9 +1788,9 @@ class Application:
             )
             payload["result"] = external_dict
 
-        query_params = {
-            "instance_id": instance_id if instance_id is not None else self.default_instance_id,
-        }
+        query_params = {}
+        if instance_id is not None or self.default_instance_id is not None:
+            query_params["instance_id"] = instance_id if instance_id is not None else self.default_instance_id
         response = self.client.request(
             method="POST",
             endpoint=f"{self.endpoint}/runs",
@@ -3340,7 +3340,7 @@ class Application:
                     {
                         "app_id": self.id,
                         "endpoint": self.client.url,
-                        "instance_url": f"{self.endpoint}/runs?instance_id=devint",
+                        "instance_url": f"{self.endpoint}/runs?instance_id=latest",
                     },
                     indent=2,
                 )


### PR DESCRIPTION
# Description

Removes the `devint` default set by nextmv-py in order to allow fallback to actual default instance AND no default instance behavior in Nextmv Platform. I.e., for all app types (marketplace, custom, workflow) the default instance specified in platform will be used, or, the latest pushed binary if no such default instance is configured.
This for example allows marketplace and custom apps to be used in the same way, as their instances created by default differed in the past (_latest_ vs. _devint_).

## Changes

- Removes `devint` as the default instance for apps set by nextmv-py, to allow fallback to the actual default in platform.