### PR TITLE
Add option formatting support to manifest

### DIFF
--- a/nextmv/nextmv/cloud/application.py
+++ b/nextmv/nextmv/cloud/application.py
@@ -3328,7 +3328,14 @@ class Application:
         }
 
         if manifest.configuration is not None and manifest.configuration.options is not None:
-            activation_request["requirements"]["options"] = manifest.configuration.options.to_dict()
+            options = manifest.configuration.options.to_dict()
+            if "format" in options and isinstance(options["format"], list):
+                # the endpoint expects a dictionary with a template key having a list of strings
+                # the app.yaml however defines format as a list of strings, so we need to convert it here
+                options["format"] = {
+                    "template": options["format"],
+                }
+            activation_request["requirements"]["options"] = options
 
         response = self.client.request(
             method="PUT",

--- a/nextmv/nextmv/cloud/manifest.py
+++ b/nextmv/nextmv/cloud/manifest.py
@@ -601,6 +601,10 @@ class ManifestOptions(BaseModel):
         is a parameter that configures the decision model.
     validation: Optional[ManifestValidation], default=None
         Optional validation rules for all options.
+    format: Optional[list[str]], default=None
+        A list of strings that define how options are transformed into command
+        line arguments. Use `{{name}}` to refer to the option name and
+        `{{value}}` to refer to the option value.
 
 
     Examples
@@ -629,9 +633,21 @@ class ManifestOptions(BaseModel):
 
     An option is a parameter that configures the decision model.
     """
+    format: Optional[list[str]] = None
+    """A list of strings that define how options are transformed into command line arguments.
+
+    Use `{{name}}` to refer to the option name and `{{value}}` to refer to the option value.
+    For example, `["-{{name}}", "{{value}}"]` will transform an option named `max_vehicles`
+    with a value of `10` into the command line argument `-max_vehicles 10`.
+    """
 
     @classmethod
-    def from_options(cls, options: Options, validation: OptionsEnforcement = None) -> "ManifestOptions":
+    def from_options(
+        cls,
+        options: Options,
+        validation: OptionsEnforcement = None,
+        format: Optional[list[str]] = None,
+        ) -> "ManifestOptions":
         """
         Create a `ManifestOptions` from a `nextmv.Options`.
 
@@ -642,6 +658,14 @@ class ManifestOptions(BaseModel):
         validation : Optional[OptionsEnforcement], default=None
             Optional validation rules for the options. If provided, it will be
             used to set the `validation` attribute of the `ManifestOptions`.
+        format : Optional[list[str]], default=None
+            A list of strings that define how options are transformed into
+            command line arguments. Use `{{name}}` to refer to the option name
+            and `{{value}}` to refer to the option value.
+
+            For example, `["-{{name}}", "{{value}}"]` will transform an option
+            named `max_vehicles` with a value of `10` into the command line
+            argument `-max_vehicles 10`.
 
         Returns
         -------
@@ -663,6 +687,7 @@ class ManifestOptions(BaseModel):
             strict=validation.strict if validation else False,
             validation=ManifestValidation(enforce="all" if validation and validation.validation_enforce else "none"),
             items=items,
+            format=format,
         )
 
 

--- a/nextmv/nextmv/cloud/manifest.py
+++ b/nextmv/nextmv/cloud/manifest.py
@@ -368,6 +368,7 @@ class ManifestOptionUI(BaseModel):
     the option more user-friendly in the UI.
     """
 
+
 class ManifestOption(BaseModel):
     """
     An option for the decision model that is recorded in the manifest.
@@ -647,7 +648,7 @@ class ManifestOptions(BaseModel):
         options: Options,
         validation: OptionsEnforcement = None,
         format: Optional[list[str]] = None,
-        ) -> "ManifestOptions":
+    ) -> "ManifestOptions":
         """
         Create a `ManifestOptions` from a `nextmv.Options`.
 

--- a/nextmv/nextmv/cloud/safe.py
+++ b/nextmv/nextmv/cloud/safe.py
@@ -82,6 +82,7 @@ def _name_and_id(prefix: str, entity_id: str) -> tuple[str, str]:
 
     return safe_name, safe_id
 
+
 def _safe_id(prefix: str) -> str:
     """
     Generate a safe ID from a prefix.
@@ -101,13 +102,11 @@ def _safe_id(prefix: str) -> str:
     # Space available for user text once prefix, random slug and separator "-"
     # are accounted for
     safe_id_max = (
-        ENTITY_ID_CHAR_COUNT_MAX
-        - INDEX_TAG_CHAR_COUNT
-        - (len(random_slug) + 1)  # +1 for the hyphen before the slug
+        ENTITY_ID_CHAR_COUNT_MAX - INDEX_TAG_CHAR_COUNT - (len(random_slug) + 1)  # +1 for the hyphen before the slug
     )
 
     if len(prefix) > safe_id_max:
-        return prefix[:safe_id_max - 1] + f"-{random_slug}"
+        return prefix[: safe_id_max - 1] + f"-{random_slug}"
 
     safe_id = f"{prefix}-{random_slug}"
 

--- a/nextmv/nextmv/model.py
+++ b/nextmv/nextmv/model.py
@@ -160,7 +160,6 @@ class ModelConfiguration:
     """Enforcement of options for the model."""
 
 
-
 class Model:
     """
     Base class for defining decision models that run in Nextmv Cloud.

--- a/nextmv/nextmv/options.py
+++ b/nextmv/nextmv/options.py
@@ -1064,6 +1064,7 @@ class Options:
         else:
             raise TypeError(f"expected an <Option> (or deprecated <Parameter>) object, but got {type(option)}")
 
+
 class OptionsEnforcement:
     """
     OptionsEnforcement is a class that provides rules for how the options

--- a/nextmv/tests/cloud/app.yaml
+++ b/nextmv/tests/cloud/app.yaml
@@ -24,6 +24,9 @@ configuration:
     strict: false
     validation:
       enforce: "all"
+    format:
+      - "-{{name}}"
+      - "{{value}}"
     items:
       - name: a string parameter
         option_type: string

--- a/nextmv/tests/cloud/test_manifest.py
+++ b/nextmv/tests/cloud/test_manifest.py
@@ -216,23 +216,13 @@ class TestManifest(unittest.TestCase):
                     default="default",
                     description="A description",
                     required=True,
-                    ui=None
+                    ui=None,
                 ),
                 ManifestOption(
-                    name="param2",
-                    option_type="bool",
-                    default=True,
-                    description="A description",
-                    required=True,
-                    ui=None
+                    name="param2", option_type="bool", default=True, description="A description", required=True, ui=None
                 ),
                 ManifestOption(
-                    name="param3",
-                    option_type="int",
-                    default=42,
-                    description="A description",
-                    required=True,
-                    ui=None
+                    name="param3", option_type="int", default=42, description="A description", required=True, ui=None
                 ),
                 ManifestOption(
                     name="param4",
@@ -240,7 +230,7 @@ class TestManifest(unittest.TestCase):
                     default=3.14,
                     description="A description",
                     required=True,
-                    ui=None
+                    ui=None,
                 ),
             ],
         )
@@ -255,14 +245,28 @@ class TestManifest(unittest.TestCase):
 
     def test_from_options_with_validation(self):
         options = Options(
-            Option("param1", str, "default", "A description",
-                    True, additional_attributes={"max_length": 100}, control_type="input"),
+            Option(
+                "param1",
+                str,
+                "default",
+                "A description",
+                True,
+                additional_attributes={"max_length": 100},
+                control_type="input",
+            ),
             Option("param2", bool, True, "A description", True),
             Option("param3", int, 42, "A description", True, additional_attributes={"min": 0, "max": 100, "step": 1}),
             Option("param4", float, 3.14, "A description", True, display_name="a float parameter"),
-            Option("param5", str, "default", "A description",
-                    True, additional_attributes={"values": ["option1", "option2"]},
-                    control_type="select", hidden_from=["operator"]),
+            Option(
+                "param5",
+                str,
+                "default",
+                "A description",
+                True,
+                additional_attributes={"values": ["option1", "option2"]},
+                control_type="select",
+                hidden_from=["operator"],
+            ),
         )
         manifest = Manifest.from_options(options, OptionsEnforcement(strict=True, validation_enforce=True))
 
@@ -282,7 +286,7 @@ class TestManifest(unittest.TestCase):
                     description="A description",
                     required=True,
                     additional_attributes={"max_length": 100},
-                    ui=ManifestOptionUI(control_type="input")
+                    ui=ManifestOptionUI(control_type="input"),
                 ),
                 ManifestOption(
                     name="param2",
@@ -290,7 +294,6 @@ class TestManifest(unittest.TestCase):
                     default=True,
                     description="A description",
                     required=True,
-
                 ),
                 ManifestOption(
                     name="param3",
@@ -299,7 +302,7 @@ class TestManifest(unittest.TestCase):
                     description="A description",
                     required=True,
                     additional_attributes={"min": 0, "max": 100, "step": 1},
-                    ui=None
+                    ui=None,
                 ),
                 ManifestOption(
                     name="param4",
@@ -307,7 +310,7 @@ class TestManifest(unittest.TestCase):
                     default=3.14,
                     description="A description",
                     required=True,
-                    ui=ManifestOptionUI(display_name="a float parameter")
+                    ui=ManifestOptionUI(display_name="a float parameter"),
                 ),
                 ManifestOption(
                     name="param5",
@@ -316,10 +319,11 @@ class TestManifest(unittest.TestCase):
                     description="A description",
                     required=True,
                     additional_attributes={"values": ["option1", "option2"]},
-                    ui=ManifestOptionUI(control_type="select", hidden_from=["operator"])
+                    ui=ManifestOptionUI(control_type="select", hidden_from=["operator"]),
                 ),
             ],
         )
+
 
 class TestManifestOption(unittest.TestCase):
     def test_from_option(self):

--- a/nextmv/tests/cloud/test_manifest.py
+++ b/nextmv/tests/cloud/test_manifest.py
@@ -152,6 +152,7 @@ class TestManifest(unittest.TestCase):
                 "EXTRA": "AWESOME",
             },
         )
+        self.assertEqual(manifest.configuration.options.format, ["-{{name}}", "{{value}}"])
 
     def test_extract_options(self):
         manifest = Manifest.from_yaml("tests/cloud")
@@ -243,6 +244,14 @@ class TestManifest(unittest.TestCase):
                 ),
             ],
         )
+
+    def test_manifest_options_from_options(self):
+        options = Options(
+            Option("param1", str, "default", "A description", True),
+        )
+        manifest_options = ManifestOptions.from_options(options, format=["-{{name}}", "{{value}}"])
+        self.assertEqual(manifest_options.format, ["-{{name}}", "{{value}}"])
+        self.assertEqual(manifest_options.strict, False)
 
     def test_from_options_with_validation(self):
         options = Options(


### PR DESCRIPTION
Adds option formatting support to the app manifest, allowing users to specify how options are transformed into command line arguments.