### PR TITLE
Adding full support for multi-file and csv-archive run management

### DIFF
--- a/docs/nextmv/tutorials/applications/runs.md
+++ b/docs/nextmv/tutorials/applications/runs.md
@@ -250,7 +250,7 @@ the method directly.
 
 ---
 
-You can use the `dir_path` argument to read inputs from the local filesystem.
+You can use the `input_dir_path` argument to read inputs from the local filesystem.
 The following input format are supported:
 
 * [`InputFormat.CSV_ARCHIVE`][inputformat]: one, or more, CSV files.
@@ -261,12 +261,12 @@ The following input format are supported:
 
 Please note the following:
 
-* The `dir_path` is the path to a directory containing input files. If
+* The `input_dir_path` is the path to a directory containing input files. If
   specified, the function will package the files in the directory into a tar
   file and upload it as a large input.
-* If both `input` and `dir_path` are specified, `input` is ignored, and the
-  files in the directory are used instead.
-* When `dir_path` is specified, the `configuration` argument _must_ be
+* If both `input` and `input_dir_path` are specified, `input` is ignored, and
+  the files in the directory are used instead.
+* When `input_dir_path` is specified, the `configuration` argument _must_ be
   provided. More specifically, the [`.input_type`][input-type-param] parameter
   dictates what kind of input is being submitted to the Nextmv Cloud.
 
@@ -276,7 +276,7 @@ Please note the following:
         `multi-file`.
 
   In both cases, the input files are read from the directory specified by
-  `dir_path`, tarred, and uploaded to Nextmv Cloud.
+  `input_dir_path`, tarred, and uploaded to Nextmv Cloud.
 * The output format is also specified in the configuration. It can be set to
   either `csv-archive` or `multi-file` (see
   [`.output_type`][output-type-param]), depending on the input format.
@@ -305,7 +305,7 @@ csv_run_id = app.new_run(
             ),
         )
     ),
-    dir_path="input", # Files are in the "input" directory.
+    input_dir_path="input", # Files are in the "input" directory.
 )
 print(f"CSV run ID: {csv_run_id}")
 
@@ -321,7 +321,7 @@ multi_file_run_id = app.new_run(
             ),
         )
     ),
-    dir_path="inputs", # Files are in the "inputs" directory.
+    input_dir_path="inputs", # Files are in the "inputs" directory.
 )
 print(f"MULTI_FILE run ID: {multi_file_run_id}")
 ```

--- a/docs/nextmv/tutorials/applications/runs.md
+++ b/docs/nextmv/tutorials/applications/runs.md
@@ -277,6 +277,9 @@ Please note the following:
 
   In both cases, the input files are read from the directory specified by
   `dir_path`, tarred, and uploaded to Nextmv Cloud.
+* The output format is also specified in the configuration. It can be set to
+  either `csv-archive` or `multi-file` (see
+  [`.output_type`][output-type-param]), depending on the input format.
 
 Here is an example of how to run an app with a directory of input files:
 
@@ -297,6 +300,9 @@ csv_run_id = app.new_run(
             format_input=cloud.FormatInput(
                 input_type=nextmv.InputFormat.CSV_ARCHIVE,
             ),
+            format_output=cloud.FormatOutput(
+                output_type=nextmv.OutputFormat.CSV_ARCHIVE,
+            ),
         )
     ),
     dir_path="input", # Files are in the "input" directory.
@@ -309,6 +315,9 @@ multi_file_run_id = app.new_run(
         format=cloud.Format(
             format_input=cloud.FormatInput(
                 input_type=nextmv.InputFormat.MULTI_FILE,
+            ),
+            format_output=cloud.FormatOutput(
+                output_type=nextmv.OutputFormat.MULTI_FILE,
             ),
         )
     ),
@@ -353,4 +362,5 @@ app.cancel_run(run_id="<YOUR_RUN_ID>")
 [input]: ../../reference/input.md#nextmv.nextmv.input.Input
 [inputformat]: ../../reference/input.md#nextmv.nextmv.input.InputFormat
 [input-type-param]: ../../reference/cloud/run/#nextmv.nextmv.cloud.run.FormatInput
+[output-type-param]: ../../reference/cloud/run/#nextmv.nextmv.cloud.run.FormatOutput
 [queued-runs]: ./queuing.md

--- a/nextmv/nextmv/__about__.py
+++ b/nextmv/nextmv/__about__.py
@@ -1,1 +1,1 @@
-__version__ = "v0.29.4"
+__version__ = "v0.29.5.dev.0"

--- a/nextmv/nextmv/cloud/__init__.py
+++ b/nextmv/nextmv/cloud/__init__.py
@@ -46,6 +46,7 @@ from .run import ErrorLog as ErrorLog
 from .run import ExternalRunResult as ExternalRunResult
 from .run import Format as Format
 from .run import FormatInput as FormatInput
+from .run import FormatOutput as FormatOutput
 from .run import Metadata as Metadata
 from .run import RunConfiguration as RunConfiguration
 from .run import RunInformation as RunInformation

--- a/nextmv/nextmv/cloud/application.py
+++ b/nextmv/nextmv/cloud/application.py
@@ -1614,7 +1614,7 @@ class Application:
         batch_experiment_id: Optional[str] = None,
         external_result: Optional[Union[ExternalRunResult, dict[str, Any]]] = None,
         json_configurations: Optional[dict[str, Any]] = None,
-        dir_path: Optional[str] = None,
+        input_dir_path: Optional[str] = None,
     ) -> str:
         """
         Submit an input to start a new run of the application. Returns the
@@ -1712,17 +1712,17 @@ class Application:
             not `JSON`. If the final `options` are not of type `dict[str,str]`.
         """
 
-        self.__validate_dir_path_and_configuration(dir_path, configuration)
+        self.__validate_dir_path_and_configuration(input_dir_path, configuration)
 
         tar_file = ""
-        if dir_path is not None and dir_path != "":
-            if not os.path.exists(dir_path):
-                raise ValueError(f"Directory {dir_path} does not exist.")
+        if input_dir_path is not None and input_dir_path != "":
+            if not os.path.exists(input_dir_path):
+                raise ValueError(f"Directory {input_dir_path} does not exist.")
 
-            if not os.path.isdir(dir_path):
-                raise ValueError(f"Path {dir_path} is not a directory.")
+            if not os.path.isdir(input_dir_path):
+                raise ValueError(f"Path {input_dir_path} is not a directory.")
 
-            tar_file = self.__package_inputs(dir_path)
+            tar_file = self.__package_inputs(input_dir_path)
 
         input_data = None
         if isinstance(input, BaseModel):
@@ -1779,7 +1779,7 @@ class Application:
             )
         else:
             configuration = RunConfiguration()
-            configuration.resolve(input=input, dir_path=dir_path)
+            configuration.resolve(input=input, dir_path=input_dir_path)
             configuration_dict = configuration.to_dict()
 
         payload["configuration"] = configuration_dict
@@ -1819,6 +1819,7 @@ class Application:
         external_result: Optional[Union[ExternalRunResult, dict[str, Any]]] = None,
         json_configurations: Optional[dict[str, Any]] = None,
         dir_path: Optional[str] = None,
+        output_dir_path: Optional[str] = ".",
     ) -> RunResult:
         """
         Submit an input to start a new run of the application and poll for the
@@ -1940,12 +1941,13 @@ class Application:
             batch_experiment_id=batch_experiment_id,
             external_result=external_result,
             json_configurations=json_configurations,
-            dir_path=dir_path,
+            input_dir_path=dir_path,
         )
 
         return self.run_result_with_polling(
             run_id=run_id,
             polling_options=polling_options,
+            output_dir_path=output_dir_path,
         )
 
     def new_scenario_test(
@@ -2508,7 +2510,7 @@ class Application:
         )
         return RunLog.from_dict(response.json())
 
-    def run_result(self, run_id: str) -> RunResult:
+    def run_result(self, run_id: str, output_dir_path: Optional[str] = ".") -> RunResult:
         """
         Get the result of a run.
 
@@ -2518,6 +2520,10 @@ class Application:
         ----------
         run_id : str
             ID of the run to get results for.
+        output_dir_path : Optional[str], default="."
+            Path to a directory where non-JSON output files will be saved. This is
+            required if the output is non-JSON. If the directory does not exist, it
+            will be created. Uses the current directory by default.
 
         Returns
         -------
@@ -2538,12 +2544,17 @@ class Application:
 
         run_information = self.run_metadata(run_id=run_id)
 
-        return self.__run_result(run_id=run_id, run_information=run_information)
+        return self.__run_result(
+            run_id=run_id,
+            run_information=run_information,
+            output_dir_path=output_dir_path,
+        )
 
     def run_result_with_polling(
         self,
         run_id: str,
         polling_options: PollingOptions = _DEFAULT_POLLING_OPTIONS,
+        output_dir_path: Optional[str] = ".",
     ) -> RunResult:
         """
         Get the result of a run with polling.
@@ -2558,6 +2569,10 @@ class Application:
             ID of the run to retrieve the result for.
         polling_options : PollingOptions, default=_DEFAULT_POLLING_OPTIONS
             Options to use when polling for the run result.
+        output_dir_path : Optional[str], default="."
+            Path to a directory where non-JSON output files will be saved. This is
+            required if the output is non-JSON. If the directory does not exist, it
+            will be created. Uses the current directory by default.
 
         Returns
         -------
@@ -2599,7 +2614,11 @@ class Application:
 
         run_information = poll(polling_options=polling_options, polling_func=polling_func)
 
-        return self.__run_result(run_id=run_id, run_information=run_information)
+        return self.__run_result(
+            run_id=run_id,
+            run_information=run_information,
+            output_dir_path=output_dir_path,
+        )
 
     def scenario_test(self, scenario_test_id: str) -> BatchExperiment:
         """
@@ -2714,6 +2733,7 @@ class Application:
         tracked_run: TrackedRun,
         polling_options: PollingOptions = _DEFAULT_POLLING_OPTIONS,
         instance_id: Optional[str] = None,
+        output_dir_path: Optional[str] = ".",
     ) -> RunResult:
         """
         Track an external run and poll for the result. This is a convenience
@@ -2730,6 +2750,10 @@ class Application:
         instance_id: Optional[str]
             Optional instance ID if you want to associate your tracked run with
             an instance.
+        output_dir_path : Optional[str], default="."
+            Path to a directory where non-JSON output files will be saved. This is
+            required if the output is non-JSON. If the directory does not exist, it
+            will be created. Uses the current directory by default.
 
         Returns
         -------
@@ -2754,6 +2778,7 @@ class Application:
         return self.run_result_with_polling(
             run_id=run_id,
             polling_options=polling_options,
+            output_dir_path=output_dir_path,
         )
 
     def update_instance(
@@ -3267,6 +3292,7 @@ class Application:
         self,
         run_id: str,
         run_information: RunInformation,
+        output_dir_path: Optional[str] = ".",
     ) -> RunResult:
         """
         Get the result of a run.
@@ -3283,6 +3309,10 @@ class Application:
             ID of the run to retrieve the result for.
         run_information : RunInformation
             Information about the run, including metadata such as output size.
+        output_dir_path : Optional[str], default="."
+            Path to a directory where non-JSON output files will be saved. This is
+            required if the output is non-JSON. If the directory does not exist, it
+            will be created. Uses the current directory by default.
 
         Returns
         -------
@@ -3303,13 +3333,13 @@ class Application:
         a download URL and fetch the output data separately.
         """
         query_params = None
-        large_output = False
+        use_presigned_url = False
         if (
             run_information.metadata.format.format_output.output_type != OutputFormat.JSON
             or run_information.metadata.output_size > _MAX_RUN_SIZE
         ):
             query_params = {"format": "url"}
-            large_output = True
+            use_presigned_url = True
 
         response = self.client.request(
             method="GET",
@@ -3319,7 +3349,7 @@ class Application:
         result = RunResult.from_dict(response.json())
         result.console_url = self.__console_url(result.id)
 
-        if not large_output:
+        if not use_presigned_url or result.metadata.status_v2 != StatusV2.succeeded:
             return result
 
         download_url = DownloadURL.from_dict(response.json()["output"])
@@ -3328,7 +3358,24 @@ class Application:
             endpoint=download_url.url,
             headers={"Content-Type": "application/json"},
         )
-        result.output = download_response.json()
+
+        # See whether we can attach the output directly or need to save to the given
+        # directory
+        if run_information.metadata.format.format_output.output_type != OutputFormat.JSON:
+            if not output_dir_path or output_dir_path == "":
+                raise ValueError(
+                    "If the output format is not JSON, an output_dir_path must be provided.",
+                )
+            if not os.path.exists(output_dir_path):
+                os.makedirs(output_dir_path, exist_ok=True)
+            # Save .tar.gz file to a temp directory and extract contents to output_dir_path
+            with tempfile.TemporaryDirectory() as tmpdirname:
+                temp_tar_path = os.path.join(tmpdirname, f"{run_id}.tar.gz")
+                with open(temp_tar_path, "wb") as f:
+                    f.write(download_response.content)
+                shutil.unpack_archive(temp_tar_path, output_dir_path)
+        else:
+            result.output = download_response.json()
 
         return result
 
@@ -3480,18 +3527,6 @@ class Application:
             raise ValueError(
                 "If dir_path is provided, RunConfiguration.format.format_input.input_type must be set to a valid type."
                 f"Valid types are: {[InputFormat.CSV_ARCHIVE, InputFormat.MULTI_FILE]}",
-            )
-
-        if configuration.format.format_output is None:
-            raise ValueError(
-                "If dir_path is provided, RunConfiguration.format.format_output must also be provided.",
-            )
-
-        output_type = configuration.format.format_output.output_type
-        if output_type is None or output_type in (OutputFormat.JSON):
-            raise ValueError(
-                "If dir_path is provided, RunConfiguration.format.format_output must be set to a valid type."
-                f"Valid types are: {[OutputFormat.CSV_ARCHIVE, OutputFormat.MULTI_FILE]}",
             )
 
     def __package_inputs(self, dir_path: str) -> str:

--- a/nextmv/nextmv/cloud/application.py
+++ b/nextmv/nextmv/cloud/application.py
@@ -1631,14 +1631,14 @@ class Application:
             input data is extracted from the `.data` property.
 
             If you want to work with `nextmv.InputFormat.CSV_ARCHIVE` or
-            `nextmv.InputFormat.MULTI_FILE`, you should use the `dir_path`
+            `nextmv.InputFormat.MULTI_FILE`, you should use the `input_dir_path`
             argument instead. This argument takes precedence over the `input`.
-            If `dir_path` is specified, this function looks for files in that
+            If `input_dir_path` is specified, this function looks for files in that
             directory and tars them, to later be uploaded using the
-            `upload_large_input` method. If both the `dir_path` and `input`
+            `upload_large_input` method. If both the `input_dir_path` and `input`
             arguments are provided, the `input` is ignored.
 
-            When `dir_path` is specified, the `configuration` argument must
+            When `input_dir_path` is specified, the `configuration` argument must
             also be provided. More specifically, the
             `RunConfiguration.format.format_input.input_type` parameter
             dictates what kind of input is being submitted to the Nextmv Cloud.
@@ -1690,12 +1690,12 @@ class Application:
         json_configurations: Optional[dict[str, Any]]
             Optional configurations for JSON serialization. This is used to
             customize the serialization before data is sent.
-        dir_path: Optional[str]
+        input_dir_path: Optional[str]
             Path to a directory containing input files. If specified, the
             function will package the files in the directory into a tar file
             and upload it as a large input. This is useful for input formats
             like `nextmv.InputFormat.CSV_ARCHIVE` or `nextmv.InputFormat.MULTI_FILE`.
-            If both `input` and `dir_path` are specified, the `input` is
+            If both `input` and `input_dir_path` are specified, the `input` is
             ignored, and the files in the directory are used instead.
 
         Returns
@@ -1818,7 +1818,7 @@ class Application:
         batch_experiment_id: Optional[str] = None,
         external_result: Optional[Union[ExternalRunResult, dict[str, Any]]] = None,
         json_configurations: Optional[dict[str, Any]] = None,
-        dir_path: Optional[str] = None,
+        input_dir_path: Optional[str] = None,
         output_dir_path: Optional[str] = ".",
     ) -> RunResult:
         """
@@ -1838,14 +1838,14 @@ class Application:
             input data is extracted from the `.data` property.
 
             If you want to work with `nextmv.InputFormat.CSV_ARCHIVE` or
-            `nextmv.InputFormat.MULTI_FILE`, you should use the `dir_path`
+            `nextmv.InputFormat.MULTI_FILE`, you should use the `input_dir_path`
             argument instead. This argument takes precedence over the `input`.
-            If `dir_path` is specified, this function looks for files in that
+            If `input_dir_path` is specified, this function looks for files in that
             directory and tars them, to later be uploaded using the
-            `upload_large_input` method. If both the `dir_path` and `input`
+            `upload_large_input` method. If both the `input_dir_path` and `input`
             arguments are provided, the `input` is ignored.
 
-            When `dir_path` is specified, the `configuration` argument must
+            When `input_dir_path` is specified, the `configuration` argument must
             also be provided. More specifically, the
             `RunConfiguration.format.format_input.input_type` parameter
             dictates what kind of input is being submitted to the Nextmv Cloud.
@@ -1902,13 +1902,17 @@ class Application:
         json_configurations: Optional[dict[str, Any]]
             Optional configurations for JSON serialization. This is used to
             customize the serialization before data is sent.
-        dir_path: Optional[str]
+        input_dir_path: Optional[str]
             Path to a directory containing input files. If specified, the
             function will package the files in the directory into a tar file
             and upload it as a large input. This is useful for input formats
             like `nextmv.InputFormat.CSV_ARCHIVE` or `nextmv.InputFormat.MULTI_FILE`.
-            If both `input` and `dir_path` are specified, the `input` is
+            If both `input` and `input_dir_path` are specified, the `input` is
             ignored, and the files in the directory are used instead.
+        output_dir_path : Optional[str], default="."
+            Path to a directory where non-JSON output files will be saved. This is
+            required if the output is non-JSON. If the directory does not exist, it
+            will be created. Uses the current directory by default.
 
         Returns
         ----------
@@ -1941,7 +1945,7 @@ class Application:
             batch_experiment_id=batch_experiment_id,
             external_result=external_result,
             json_configurations=json_configurations,
-            input_dir_path=dir_path,
+            input_dir_path=input_dir_path,
         )
 
         return self.run_result_with_polling(

--- a/nextmv/nextmv/cloud/application.py
+++ b/nextmv/nextmv/cloud/application.py
@@ -56,6 +56,7 @@ from nextmv.cloud.run import (
     ExternalRunResult,
     Format,
     FormatInput,
+    FormatOutput,
     RunConfiguration,
     RunInformation,
     RunLog,
@@ -71,7 +72,7 @@ from nextmv.input import Input, InputFormat
 from nextmv.logger import log
 from nextmv.model import Model, ModelConfiguration
 from nextmv.options import Options
-from nextmv.output import Output
+from nextmv.output import Output, OutputFormat
 
 # Maximum size of the run input/output in bytes. This constant defines the
 # maximum allowed size for run inputs and outputs. When the size exceeds this
@@ -1588,7 +1589,10 @@ class Application:
         if format is not None:
             payload["format"] = format.to_dict() if isinstance(format, Format) else format
         else:
-            payload["format"] = Format(format_input=FormatInput(input_type=InputFormat.JSON)).to_dict()
+            payload["format"] = Format(
+                format_input=FormatInput(input_type=InputFormat.JSON),
+                format_output=FormatOutput(output_type=OutputFormat.JSON),
+            ).to_dict()
 
         response = self.client.request(
             method="POST",
@@ -3300,7 +3304,10 @@ class Application:
         """
         query_params = None
         large_output = False
-        if run_information.metadata.output_size > _MAX_RUN_SIZE:
+        if (
+            run_information.metadata.format.format_output.output_type != OutputFormat.JSON
+            or run_information.metadata.output_size > _MAX_RUN_SIZE
+        ):
             query_params = {"format": "url"}
             large_output = True
 
@@ -3473,6 +3480,18 @@ class Application:
             raise ValueError(
                 "If dir_path is provided, RunConfiguration.format.format_input.input_type must be set to a valid type."
                 f"Valid types are: {[InputFormat.CSV_ARCHIVE, InputFormat.MULTI_FILE]}",
+            )
+
+        if configuration.format.format_output is None:
+            raise ValueError(
+                "If dir_path is provided, RunConfiguration.format.format_output must also be provided.",
+            )
+
+        output_type = configuration.format.format_output.output_type
+        if output_type is None or output_type in (OutputFormat.JSON):
+            raise ValueError(
+                "If dir_path is provided, RunConfiguration.format.format_output must be set to a valid type."
+                f"Valid types are: {[OutputFormat.CSV_ARCHIVE, OutputFormat.MULTI_FILE]}",
             )
 
     def __package_inputs(self, dir_path: str) -> str:

--- a/nextmv/nextmv/cloud/run.py
+++ b/nextmv/nextmv/cloud/run.py
@@ -14,6 +14,8 @@ RunLog
     Log of a run.
 FormatInput
     Input format for a run configuration.
+FormatOutput
+    Output format for a run configuration.
 Format
     Format for a run configuration.
 RunType
@@ -110,6 +112,83 @@ def run_duration(start: Union[datetime, float], end: Union[datetime, float]) -> 
     raise TypeError("Start and end must be either datetime or float.")
 
 
+class FormatInput(BaseModel):
+    """
+    Input format for a run configuration.
+
+    You can import the `FormatInput` class directly from `cloud`:
+
+    ```python
+    from nextmv.cloud import FormatInput
+    ```
+
+    Parameters
+    ----------
+    input_type : InputFormat, optional
+        Type of the input format. Defaults to `InputFormat.JSON`.
+    """
+
+    input_type: InputFormat = Field(
+        serialization_alias="type",
+        validation_alias=AliasChoices("type", "input_type"),
+        default=InputFormat.JSON,
+    )
+    """Type of the input format."""
+
+
+class FormatOutput(BaseModel):
+    """
+    Output format for a run configuration.
+
+    You can import the `FormatOutput` class directly from `cloud`:
+
+    ```python
+    from nextmv.cloud import FormatOutput
+    ```
+
+    Parameters
+    ----------
+    output_type : OutputFormat, optional
+        Type of the output format. Defaults to `OutputFormat.JSON`.
+    """
+
+    output_type: OutputFormat = Field(
+        serialization_alias="type",
+        validation_alias=AliasChoices("type", "output_type"),
+        default=OutputFormat.JSON,
+    )
+    """Type of the output format."""
+
+
+class Format(BaseModel):
+    """
+    Format for a run configuration.
+
+    You can import the `Format` class directly from `cloud`:
+
+    ```python
+    from nextmv.cloud import Format
+    ```
+
+    Parameters
+    ----------
+    format_input : FormatInput
+        Input format for the run configuration.
+    """
+
+    format_input: FormatInput = Field(
+        serialization_alias="input",
+        validation_alias=AliasChoices("input", "format_input"),
+    )
+    """Input format for the run configuration."""
+    format_output: Optional[FormatOutput] = Field(
+        serialization_alias="output",
+        validation_alias=AliasChoices("output", "format_output"),
+        default=None,
+    )
+    """Output format for the run configuration."""
+
+
 class Metadata(BaseModel):
     """
     Metadata of a run, whether it was successful or not.
@@ -160,6 +239,8 @@ class Metadata(BaseModel):
     """Size of the input in bytes."""
     output_size: float
     """Size of the output in bytes."""
+    format: Format
+    """Format of the input and output of the run."""
     status: Status
     """Deprecated: use status_v2."""
     status_v2: StatusV2
@@ -277,53 +358,6 @@ class RunLog(BaseModel):
 
     log: str
     """Log of the run."""
-
-
-class FormatInput(BaseModel):
-    """
-    Input format for a run configuration.
-
-    You can import the `FormatInput` class directly from `cloud`:
-
-    ```python
-    from nextmv.cloud import FormatInput
-    ```
-
-    Parameters
-    ----------
-    input_type : InputFormat, optional
-        Type of the input format. Defaults to `InputFormat.JSON`.
-    """
-
-    input_type: InputFormat = Field(
-        serialization_alias="type",
-        validation_alias=AliasChoices("type", "input_type"),
-        default=InputFormat.JSON,
-    )
-    """Type of the input format."""
-
-
-class Format(BaseModel):
-    """
-    Format for a run configuration.
-
-    You can import the `Format` class directly from `cloud`:
-
-    ```python
-    from nextmv.cloud import Format
-    ```
-
-    Parameters
-    ----------
-    format_input : FormatInput
-        Input format for the run configuration.
-    """
-
-    format_input: FormatInput = Field(
-        serialization_alias="input",
-        validation_alias=AliasChoices("input", "format_input"),
-    )
-    """Input format for the run configuration."""
 
 
 class RunType(str, Enum):
@@ -491,7 +525,10 @@ class RunConfiguration(BaseModel):
         if self.format is not None:
             return
 
-        self.format = Format(format_input=FormatInput(input_type=InputFormat.JSON))
+        self.format = Format(
+            format_input=FormatInput(input_type=InputFormat.JSON),
+            format_output=FormatOutput(output_type=OutputFormat.JSON),
+        )
 
         if isinstance(input, dict):
             self.format.format_input.input_type = InputFormat.JSON
@@ -503,6 +540,19 @@ class RunConfiguration(BaseModel):
             self.format.format_input.input_type = InputFormat.MULTI_FILE
         elif isinstance(input, Input):
             self.format.format_input.input_type = input.input_format
+
+        # As input and output are symmetric, we set the output according to the input
+        # format.
+        if self.format.format_input.input_type == InputFormat.JSON:
+            self.format.format_output = FormatOutput(output_type=OutputFormat.JSON)
+        elif self.format.format_input.input_type == InputFormat.TEXT:  # Text still maps to json
+            self.format.format_output = FormatOutput(output_type=OutputFormat.JSON)
+        elif self.format.format_input.input_type == InputFormat.CSV_ARCHIVE:
+            self.format.format_output = FormatOutput(output_type=OutputFormat.CSV_ARCHIVE)
+        elif self.format.format_input.input_type == InputFormat.MULTI_FILE:
+            self.format.format_output = FormatOutput(output_type=OutputFormat.MULTI_FILE)
+        else:
+            self.format.format_output = FormatOutput(output_type=OutputFormat.JSON)
 
 
 class ExternalRunResult(BaseModel):

--- a/nextmv/tests/test_entrypoint/test_entrypoint.py
+++ b/nextmv/tests/test_entrypoint/test_entrypoint.py
@@ -5,8 +5,9 @@ import subprocess
 import sys
 import unittest
 
-import nextmv
 import nextmv.cloud
+
+import nextmv
 
 
 class SimpleDecisionModel(nextmv.Model):

--- a/nextmv/tests/test_model.py
+++ b/nextmv/tests/test_model.py
@@ -1,8 +1,9 @@
 import os
 import unittest
 
-import nextmv
 from nextmv.model import _cleanup_python_model
+
+import nextmv
 
 
 class ModelForTesting(nextmv.Model):

--- a/nextmv/tests/test_options.py
+++ b/nextmv/tests/test_options.py
@@ -3,8 +3,9 @@ import shutil
 import subprocess
 import unittest
 
-import nextmv
 import nextmv.options
+
+import nextmv
 
 
 class TestOptions(unittest.TestCase):

--- a/nextmv/tests/test_output.py
+++ b/nextmv/tests/test_output.py
@@ -8,9 +8,9 @@ from typing import Any, Optional
 from unittest.mock import patch
 
 import pandas as pd
+from nextmv.base_model import BaseModel
 
 import nextmv
-from nextmv.base_model import BaseModel
 
 
 class TestOutput(unittest.TestCase):


### PR DESCRIPTION
# Description

> [!WARNING]  
> This PR introduces a minor BREAKING change of renaming `dir_path` to `input_dir_path` to better align with the newly introduced `output_dir_path`. The impact of this should be very limited as the feature was not yet largely adopted (this PR actually completes it).

This PR completes the support for managing `multi-file` and `csv-archive` runs. I.e., this addresses the issue raised in #130 .

## Changes

- Adds support for handling `multi-file` and `csv-archive` run results.
  - Lets the user specify a `output_dir_path` as a an output destination for all the output files of non-JSON runs. E.g., when getting the run results of a `multi-file` run, the output files (_*.csv_, etc.) will be written to the given directory.

Resolves ENG-6521