### PR TITLE
Adds content configuration via manifest

### DIFF
--- a/nextmv/nextmv/cloud/__init__.py
+++ b/nextmv/nextmv/cloud/__init__.py
@@ -37,6 +37,10 @@ from .instance import InstanceConfiguration as InstanceConfiguration
 from .manifest import MANIFEST_FILE_NAME as MANIFEST_FILE_NAME
 from .manifest import Manifest as Manifest
 from .manifest import ManifestBuild as ManifestBuild
+from .manifest import ManifestContent as ManifestContent
+from .manifest import ManifestContentMultiFile as ManifestContentMultiFile
+from .manifest import ManifestContentMultiFileInput as ManifestContentMultiFileInput
+from .manifest import ManifestContentMultiFileOutput as ManifestContentMultiFileOutput
 from .manifest import ManifestOption as ManifestOption
 from .manifest import ManifestPython as ManifestPython
 from .manifest import ManifestPythonModel as ManifestPythonModel

--- a/nextmv/nextmv/cloud/application.py
+++ b/nextmv/nextmv/cloud/application.py
@@ -3764,14 +3764,17 @@ class Application:
             io_config = {
                 "format": manifest.configuration.content.format,
             }
+            output_config = {}
+            if manifest.configuration.content.multi_file.output.statistics:
+                output_config["statistics_path"] = manifest.configuration.content.multi_file.output.statistics
+            if manifest.configuration.content.multi_file.output.assets:
+                output_config["assets_path"] = manifest.configuration.content.multi_file.output.assets
+            if manifest.configuration.content.multi_file.output.solutions:
+                output_config["solutions_path"] = manifest.configuration.content.multi_file.output.solutions
             if manifest.configuration.content.multi_file is not None:
                 io_config["multi_file"] = {
                     "input_path": manifest.configuration.content.multi_file.input.path,
-                    "output_configuration": {
-                        "statistics_path": manifest.configuration.content.multi_file.output.statistics,
-                        "assets_path": manifest.configuration.content.multi_file.output.assets,
-                        "solutions_path": manifest.configuration.content.multi_file.output.solutions,
-                    },
+                    "output_configuration": output_config,
                 }
             activation_request["io_configuration"] = io_config
 

--- a/nextmv/nextmv/cloud/application.py
+++ b/nextmv/nextmv/cloud/application.py
@@ -1919,6 +1919,8 @@ class Application:
             not `JSON`. If the final `options` are not of type `dict[str,str]`.
         """
 
+        self.__validate_input_dir_path_and_configuration(input_dir_path, configuration)
+
         tar_file = ""
         if input_dir_path is not None and input_dir_path != "":
             if not os.path.exists(input_dir_path):
@@ -3861,6 +3863,31 @@ class Application:
             return input_set
 
         raise ValueError(f"Unknown scenario input type: {scenario.scenario_input.scenario_input_type}")
+
+    def __validate_input_dir_path_and_configuration(
+        self,
+        input_dir_path: Optional[str],
+        configuration: Optional[RunConfiguration],
+    ) -> None:
+        """
+        Auxiliary function to validate the directory path and configuration.
+        """
+        if (
+            configuration is None
+            or configuration.format is None
+            or configuration.format.format_input is None
+            or configuration.format.format_input.input_type is None
+        ):
+            # No explicit input type set, so we cannot confirm it.
+            return
+
+        input_type = configuration.format.format_input.input_type
+        dir_types = (InputFormat.MULTI_FILE, InputFormat.CSV_ARCHIVE)
+        if input_type in dir_types and not input_dir_path:
+            raise ValueError(
+                f"If RunConfiguration.format.format_input.input_type is set to {input_type}, "
+                "then input_dir_path must be provided.",
+            )
 
     def __package_inputs(self, dir_path: str) -> str:
         """

--- a/nextmv/nextmv/cloud/application.py
+++ b/nextmv/nextmv/cloud/application.py
@@ -3763,21 +3763,22 @@ class Application:
         }
 
         if manifest.configuration is not None and manifest.configuration.content is not None:
+            content = manifest.configuration.content
             io_config = {
-                "format": manifest.configuration.content.format,
+                "format": content.format,
             }
-            output_config = {}
-            if manifest.configuration.content.multi_file.output.statistics:
-                output_config["statistics_path"] = manifest.configuration.content.multi_file.output.statistics
-            if manifest.configuration.content.multi_file.output.assets:
-                output_config["assets_path"] = manifest.configuration.content.multi_file.output.assets
-            if manifest.configuration.content.multi_file.output.solutions:
-                output_config["solutions_path"] = manifest.configuration.content.multi_file.output.solutions
-            if manifest.configuration.content.multi_file is not None:
-                io_config["multi_file"] = {
-                    "input_path": manifest.configuration.content.multi_file.input.path,
-                    "output_configuration": output_config,
-                }
+            if content.multi_file is not None:
+                multi_config = io_config["multi_file"] = {}
+                if content.multi_file.input is not None:
+                    multi_config["input_path"] = content.multi_file.input.path
+                if content.multi_file.output is not None:
+                    output_config = multi_config["output_configuration"] = {}
+                    if content.multi_file.output.statistics:
+                        output_config["statistics_path"] = content.multi_file.output.statistics
+                    if content.multi_file.output.assets:
+                        output_config["assets_path"] = content.multi_file.output.assets
+                    if content.multi_file.output.solutions:
+                        output_config["solutions_path"] = content.multi_file.output.solutions
             activation_request["io_configuration"] = io_config
 
         if manifest.configuration is not None and manifest.configuration.options is not None:

--- a/nextmv/nextmv/cloud/application.py
+++ b/nextmv/nextmv/cloud/application.py
@@ -3729,31 +3729,8 @@ class Application:
 
         return result
 
-    def __update_app_binary(
-        self,
-        tar_file: str,
-        manifest: Manifest,
-        verbose: bool = False,
-    ) -> None:
-        """Updates the application binary in Cloud."""
-
-        if verbose:
-            log(f'🌟 Pushing to application: "{self.id}".')
-
-        endpoint = f"{self.endpoint}/binary"
-        response = self.client.request(
-            method="GET",
-            endpoint=endpoint,
-        )
-        upload_url = response.json()["upload_url"]
-
-        with open(tar_file, "rb") as f:
-            response = self.client.request(
-                method="PUT",
-                endpoint=upload_url,
-                data=f,
-                headers={"Content-Type": "application/octet-stream"},
-            )
+    def __convert_manifest_to_payload(manifest: Manifest) -> dict[str, Any]:
+        """Converts a manifest to a payload dictionary for the API."""
 
         activation_request = {
             "requirements": {
@@ -3790,11 +3767,38 @@ class Application:
                     "template": options["format"],
                 }
             activation_request["requirements"]["options"] = options
+        return activation_request
+
+    def __update_app_binary(
+        self,
+        tar_file: str,
+        manifest: Manifest,
+        verbose: bool = False,
+    ) -> None:
+        """Updates the application binary in Cloud."""
+
+        if verbose:
+            log(f'🌟 Pushing to application: "{self.id}".')
+
+        endpoint = f"{self.endpoint}/binary"
+        response = self.client.request(
+            method="GET",
+            endpoint=endpoint,
+        )
+        upload_url = response.json()["upload_url"]
+
+        with open(tar_file, "rb") as f:
+            response = self.client.request(
+                method="PUT",
+                endpoint=upload_url,
+                data=f,
+                headers={"Content-Type": "application/octet-stream"},
+            )
 
         response = self.client.request(
             method="PUT",
             endpoint=endpoint,
-            payload=activation_request,
+            payload=Application.__convert_manifest_to_payload(manifest=manifest),
         )
 
         if verbose:

--- a/nextmv/nextmv/cloud/application.py
+++ b/nextmv/nextmv/cloud/application.py
@@ -3729,6 +3729,7 @@ class Application:
 
         return result
 
+    @staticmethod
     def __convert_manifest_to_payload(manifest: Manifest) -> dict[str, Any]:
         """Converts a manifest to a payload dictionary for the API."""
 

--- a/nextmv/nextmv/cloud/application.py
+++ b/nextmv/nextmv/cloud/application.py
@@ -3426,6 +3426,21 @@ class Application:
             },
         }
 
+        if manifest.configuration is not None and manifest.configuration.content is not None:
+            io_config = {
+                "format": manifest.configuration.content.format,
+            }
+            if manifest.configuration.content.multi_file is not None:
+                io_config["multi_file"] = {
+                    "input_path": manifest.configuration.content.multi_file.input.path,
+                    "output_configuration": {
+                        "statistics_path": manifest.configuration.content.multi_file.output.statistics,
+                        "assets_path": manifest.configuration.content.multi_file.output.assets,
+                        "solutions_path": manifest.configuration.content.multi_file.output.solutions,
+                    },
+                }
+            activation_request["io_configuration"] = io_config
+
         if manifest.configuration is not None and manifest.configuration.options is not None:
             options = manifest.configuration.options.to_dict()
             if "format" in options and isinstance(options["format"], list):

--- a/nextmv/nextmv/cloud/application.py
+++ b/nextmv/nextmv/cloud/application.py
@@ -256,6 +256,47 @@ class UploadURL(BaseModel):
     """URL to use for uploading the file."""
 
 
+def __convert_manifest_to_payload(manifest: Manifest) -> dict[str, Any]:
+    """Auxiliary function that converts a manifest to a payload dictionary for the API."""
+
+    activation_request = {
+        "requirements": {
+            "executable_type": manifest.type,
+            "runtime": manifest.runtime,
+        },
+    }
+
+    if manifest.configuration is not None and manifest.configuration.content is not None:
+        content = manifest.configuration.content
+        io_config = {
+            "format": content.format,
+        }
+        if content.multi_file is not None:
+            multi_config = io_config["multi_file"] = {}
+            if content.multi_file.input is not None:
+                multi_config["input_path"] = content.multi_file.input.path
+            if content.multi_file.output is not None:
+                output_config = multi_config["output_configuration"] = {}
+                if content.multi_file.output.statistics:
+                    output_config["statistics_path"] = content.multi_file.output.statistics
+                if content.multi_file.output.assets:
+                    output_config["assets_path"] = content.multi_file.output.assets
+                if content.multi_file.output.solutions:
+                    output_config["solutions_path"] = content.multi_file.output.solutions
+        activation_request["io_configuration"] = io_config
+
+    if manifest.configuration is not None and manifest.configuration.options is not None:
+        options = manifest.configuration.options.to_dict()
+        if "format" in options and isinstance(options["format"], list):
+            # the endpoint expects a dictionary with a template key having a list of strings
+            # the app.yaml however defines format as a list of strings, so we need to convert it here
+            options["format"] = {
+                "template": options["format"],
+            }
+        activation_request["requirements"]["options"] = options
+    return activation_request
+
+
 @dataclass
 class Application:
     """
@@ -3729,47 +3770,6 @@ class Application:
 
         return result
 
-    @staticmethod
-    def __convert_manifest_to_payload(manifest: Manifest) -> dict[str, Any]:
-        """Converts a manifest to a payload dictionary for the API."""
-
-        activation_request = {
-            "requirements": {
-                "executable_type": manifest.type,
-                "runtime": manifest.runtime,
-            },
-        }
-
-        if manifest.configuration is not None and manifest.configuration.content is not None:
-            content = manifest.configuration.content
-            io_config = {
-                "format": content.format,
-            }
-            if content.multi_file is not None:
-                multi_config = io_config["multi_file"] = {}
-                if content.multi_file.input is not None:
-                    multi_config["input_path"] = content.multi_file.input.path
-                if content.multi_file.output is not None:
-                    output_config = multi_config["output_configuration"] = {}
-                    if content.multi_file.output.statistics:
-                        output_config["statistics_path"] = content.multi_file.output.statistics
-                    if content.multi_file.output.assets:
-                        output_config["assets_path"] = content.multi_file.output.assets
-                    if content.multi_file.output.solutions:
-                        output_config["solutions_path"] = content.multi_file.output.solutions
-            activation_request["io_configuration"] = io_config
-
-        if manifest.configuration is not None and manifest.configuration.options is not None:
-            options = manifest.configuration.options.to_dict()
-            if "format" in options and isinstance(options["format"], list):
-                # the endpoint expects a dictionary with a template key having a list of strings
-                # the app.yaml however defines format as a list of strings, so we need to convert it here
-                options["format"] = {
-                    "template": options["format"],
-                }
-            activation_request["requirements"]["options"] = options
-        return activation_request
-
     def __update_app_binary(
         self,
         tar_file: str,
@@ -3799,7 +3799,7 @@ class Application:
         response = self.client.request(
             method="PUT",
             endpoint=endpoint,
-            payload=Application.__convert_manifest_to_payload(manifest=manifest),
+            payload=__convert_manifest_to_payload(manifest=manifest),
         )
 
         if verbose:

--- a/nextmv/nextmv/cloud/application.py
+++ b/nextmv/nextmv/cloud/application.py
@@ -256,47 +256,6 @@ class UploadURL(BaseModel):
     """URL to use for uploading the file."""
 
 
-def __convert_manifest_to_payload(manifest: Manifest) -> dict[str, Any]:
-    """Auxiliary function that converts a manifest to a payload dictionary for the API."""
-
-    activation_request = {
-        "requirements": {
-            "executable_type": manifest.type,
-            "runtime": manifest.runtime,
-        },
-    }
-
-    if manifest.configuration is not None and manifest.configuration.content is not None:
-        content = manifest.configuration.content
-        io_config = {
-            "format": content.format,
-        }
-        if content.multi_file is not None:
-            multi_config = io_config["multi_file"] = {}
-            if content.multi_file.input is not None:
-                multi_config["input_path"] = content.multi_file.input.path
-            if content.multi_file.output is not None:
-                output_config = multi_config["output_configuration"] = {}
-                if content.multi_file.output.statistics:
-                    output_config["statistics_path"] = content.multi_file.output.statistics
-                if content.multi_file.output.assets:
-                    output_config["assets_path"] = content.multi_file.output.assets
-                if content.multi_file.output.solutions:
-                    output_config["solutions_path"] = content.multi_file.output.solutions
-        activation_request["io_configuration"] = io_config
-
-    if manifest.configuration is not None and manifest.configuration.options is not None:
-        options = manifest.configuration.options.to_dict()
-        if "format" in options and isinstance(options["format"], list):
-            # the endpoint expects a dictionary with a template key having a list of strings
-            # the app.yaml however defines format as a list of strings, so we need to convert it here
-            options["format"] = {
-                "template": options["format"],
-            }
-        activation_request["requirements"]["options"] = options
-    return activation_request
-
-
 @dataclass
 class Application:
     """
@@ -3770,6 +3729,47 @@ class Application:
 
         return result
 
+    @staticmethod
+    def __convert_manifest_to_payload(manifest: Manifest) -> dict[str, Any]:
+        """Converts a manifest to a payload dictionary for the API."""
+
+        activation_request = {
+            "requirements": {
+                "executable_type": manifest.type,
+                "runtime": manifest.runtime,
+            },
+        }
+
+        if manifest.configuration is not None and manifest.configuration.content is not None:
+            content = manifest.configuration.content
+            io_config = {
+                "format": content.format,
+            }
+            if content.multi_file is not None:
+                multi_config = io_config["multi_file"] = {}
+                if content.multi_file.input is not None:
+                    multi_config["input_path"] = content.multi_file.input.path
+                if content.multi_file.output is not None:
+                    output_config = multi_config["output_configuration"] = {}
+                    if content.multi_file.output.statistics:
+                        output_config["statistics_path"] = content.multi_file.output.statistics
+                    if content.multi_file.output.assets:
+                        output_config["assets_path"] = content.multi_file.output.assets
+                    if content.multi_file.output.solutions:
+                        output_config["solutions_path"] = content.multi_file.output.solutions
+            activation_request["requirements"]["io_configuration"] = io_config
+
+        if manifest.configuration is not None and manifest.configuration.options is not None:
+            options = manifest.configuration.options.to_dict()
+            if "format" in options and isinstance(options["format"], list):
+                # the endpoint expects a dictionary with a template key having a list of strings
+                # the app.yaml however defines format as a list of strings, so we need to convert it here
+                options["format"] = {
+                    "template": options["format"],
+                }
+            activation_request["requirements"]["options"] = options
+        return activation_request
+
     def __update_app_binary(
         self,
         tar_file: str,
@@ -3799,7 +3799,7 @@ class Application:
         response = self.client.request(
             method="PUT",
             endpoint=endpoint,
-            payload=__convert_manifest_to_payload(manifest=manifest),
+            payload=Application.__convert_manifest_to_payload(manifest=manifest),
         )
 
         if verbose:

--- a/nextmv/nextmv/cloud/application.py
+++ b/nextmv/nextmv/cloud/application.py
@@ -1919,8 +1919,6 @@ class Application:
             not `JSON`. If the final `options` are not of type `dict[str,str]`.
         """
 
-        self.__validate_dir_path_and_configuration(input_dir_path, configuration)
-
         tar_file = ""
         if input_dir_path is not None and input_dir_path != "":
             if not os.path.exists(input_dir_path):
@@ -3860,39 +3858,6 @@ class Application:
             return input_set
 
         raise ValueError(f"Unknown scenario input type: {scenario.scenario_input.scenario_input_type}")
-
-    def __validate_dir_path_and_configuration(
-        self,
-        dir_path: Optional[str],
-        configuration: Optional[RunConfiguration],
-    ) -> None:
-        """
-        Auxiliary function to validate the directory path and configuration.
-        """
-        if dir_path is None or dir_path == "":
-            return
-
-        if configuration is None:
-            raise ValueError(
-                "If dir_path is provided, a RunConfiguration must also be provided.",
-            )
-
-        if configuration.format is None:
-            raise ValueError(
-                "If dir_path is provided, RunConfiguration.format must also be provided.",
-            )
-
-        if configuration.format.format_input is None:
-            raise ValueError(
-                "If dir_path is provided, RunConfiguration.format.format_input must also be provided.",
-            )
-
-        input_type = configuration.format.format_input.input_type
-        if input_type is None or input_type in (InputFormat.JSON, InputFormat.TEXT):
-            raise ValueError(
-                "If dir_path is provided, RunConfiguration.format.format_input.input_type must be set to a valid type."
-                f"Valid types are: {[InputFormat.CSV_ARCHIVE, InputFormat.MULTI_FILE]}",
-            )
 
     def __package_inputs(self, dir_path: str) -> str:
         """

--- a/nextmv/nextmv/cloud/manifest.py
+++ b/nextmv/nextmv/cloud/manifest.py
@@ -880,7 +880,7 @@ class ManifestConfiguration(BaseModel):
     'debug_mode'
     """
 
-    options: ManifestOptions
+    options: Optional[ManifestOptions] = None
     """Options for the decision model."""
     content: Optional[ManifestContent] = None
     """Content configuration for specifying how the app input/output is handled."""

--- a/nextmv/nextmv/cloud/manifest.py
+++ b/nextmv/nextmv/cloud/manifest.py
@@ -692,6 +692,160 @@ class ManifestOptions(BaseModel):
         )
 
 
+class ManifestContentMultiFileInput(BaseModel):
+    """
+    Configuration for multi-file content format input.
+
+    You can import the `ManifestContentMultiFileInput` class directly from `cloud`:
+
+    ```python
+    from nextmv.cloud import ManifestContentMultiFileInput
+    ```
+
+    Parameters
+    ----------
+    path : str
+        The path to the input file or directory.
+
+
+    Examples
+    --------
+    >>> from nextmv.cloud import ManifestContentMultiFileInput
+    >>> input_config = ManifestContentMultiFileInput(path="data/input/")
+    >>> input_config.path
+    'data/input/'
+    """
+
+    path: str
+    """The path to the input file or directory."""
+
+
+class ManifestContentMultiFileOutput(BaseModel):
+    """
+    Configuration for multi-file content format output.
+
+    You can import the `ManifestContentMultiFileOutput` class directly from `cloud`:
+
+    ```python
+    from nextmv.cloud import ManifestContentMultiFileOutput
+    ```
+
+    Parameters
+    ----------
+    statistics : str
+        The path to the statistics file.
+    assets : str
+        The path to the assets file.
+    solutions : str
+        The path to the solutions directory.
+
+    Examples
+    --------
+    >>> from nextmv.cloud import ManifestContentMultiFileOutput
+    >>> output_config = ManifestContentMultiFileOutput(
+    ...     statistics="my-outputs/statistics.json",
+    ...     assets="my-outputs/assets.json",
+    ...     solutions="my-outputs/solutions/"
+    ... )
+    >>> output_config.statistics
+    'my-outputs/statistics.json'
+    """
+
+    statistics: str
+    """The path to the statistics file."""
+    assets: str
+    """The path to the assets file."""
+    solutions: str
+    """The path to the solutions directory."""
+
+
+class ManifestContentMultiFile(BaseModel):
+    """
+    Configuration for multi-file content format.
+
+    You can import the `ManifestContentMultiFile` class directly from `cloud`:
+
+    ```python
+    from nextmv.cloud import ManifestContentMultiFile
+    ```
+
+    Parameters
+    ----------
+    input : ManifestContentMultiFileInput
+        Configuration for multi-file content format input.
+    output : ManifestContentMultiFileOutput
+        Configuration for multi-file content format output.
+
+    Examples
+    --------
+    >>> from nextmv.cloud import ManifestContentMultiFile, ManifestContentMultiFileInput, ManifestContentMultiFileOutput
+    >>> multi_file_config = ManifestContentMultiFile(
+    ...     input=ManifestContentMultiFileInput(path="data/input/"),
+    ...     output=ManifestContentMultiFileOutput(
+    ...         statistics="my-outputs/statistics.json",
+    ...         assets="my-outputs/assets.json",
+    ...         solutions="my-outputs/solutions/"
+    ...     )
+    ... )
+    >>> multi_file_config.input.path
+    'data/input/'
+
+    """
+
+    input: ManifestContentMultiFileInput
+    """Configuration for multi-file content format input."""
+    output: ManifestContentMultiFileOutput
+    """Configuration for multi-file content format output."""
+
+
+class ManifestContent(BaseModel):
+    """
+    Content configuration for specifying how the app input/output is handled.
+
+    You can import the `ManifestContent` class directly from `cloud`:
+
+    ```python
+    from nextmv.cloud import ManifestContent
+    ```
+
+    Parameters
+    ----------
+    format : str
+        The format of the content. Must be one of "json", "multi-file", or "csv-archive".
+    multi_file : Optional[ManifestContentMultiFile], default=None
+        Configuration for multi-file content format.
+
+    Examples
+    --------
+    >>> from nextmv.cloud import ManifestContent
+    >>> content_config = ManifestContent(
+    ...     format="multi-file",
+    ...     multi_file=ManifestContentMultiFile(
+    ...         input=ManifestContentMultiFileInput(path="data/input/"),
+    ...         output=ManifestContentMultiFileOutput(
+    ...             statistics="my-outputs/statistics.json",
+    ...             assets="my-outputs/assets.json",
+    ...             solutions="my-outputs/solutions/"
+    ...         )
+    ...     )
+    ... )
+    >>> content_config.format
+    'multi-file'
+    >>> content_config.multi_file.input.path
+    'data/input/'
+    """
+
+    format: str
+    """The format of the content. Must be one of "json", "multi-file",
+    or "csv-archive"."""
+    multi_file: Optional[ManifestContentMultiFile] = Field(
+        serialization_alias="multi-file",
+        validation_alias=AliasChoices("multi-file", "multi_file"),
+        default=None,
+    )
+    """Configuration for multi-file content format."""
+
+
 class ManifestConfiguration(BaseModel):
     """
     Configuration for the decision model.
@@ -721,6 +875,8 @@ class ManifestConfiguration(BaseModel):
 
     options: ManifestOptions
     """Options for the decision model."""
+    content: Optional[ManifestContent] = None
+    """Content configuration for specifying how the app input/output is handled."""
 
 
 class Manifest(BaseModel):

--- a/nextmv/nextmv/cloud/manifest.py
+++ b/nextmv/nextmv/cloud/manifest.py
@@ -43,6 +43,7 @@ import yaml
 from pydantic import AliasChoices, Field
 
 from nextmv.base_model import BaseModel
+from nextmv.input import InputFormat
 from nextmv.model import _REQUIREMENTS_FILE, ModelConfiguration
 from nextmv.options import Option, Options, OptionsEnforcement
 
@@ -844,6 +845,12 @@ class ManifestContent(BaseModel):
         default=None,
     )
     """Configuration for multi-file content format."""
+
+    def __post_init__(self):
+        """Post-initialization to validate fields."""
+        acceptable_formats = [InputFormat.JSON, InputFormat.MULTI_FILE, InputFormat.CSV_ARCHIVE]
+        if self.format not in acceptable_formats:
+            raise ValueError(f"Invalid format: {self.format}. Must be one of {acceptable_formats}.")
 
 
 class ManifestConfiguration(BaseModel):

--- a/nextmv/nextmv/cloud/manifest.py
+++ b/nextmv/nextmv/cloud/manifest.py
@@ -733,11 +733,11 @@ class ManifestContentMultiFileOutput(BaseModel):
 
     Parameters
     ----------
-    statistics : str
+    statistics : Optional[str], default=""
         The path to the statistics file.
-    assets : str
+    assets : Optional[str], default=""
         The path to the assets file.
-    solutions : str
+    solutions : Optional[str], default=""
         The path to the solutions directory.
 
     Examples
@@ -752,11 +752,11 @@ class ManifestContentMultiFileOutput(BaseModel):
     'my-outputs/statistics.json'
     """
 
-    statistics: str
+    statistics: Optional[str] = ""
     """The path to the statistics file."""
-    assets: str
+    assets: Optional[str] = ""
     """The path to the assets file."""
-    solutions: str
+    solutions: Optional[str] = ""
     """The path to the solutions directory."""
 
 

--- a/nextmv/tests/cloud/app.yaml
+++ b/nextmv/tests/cloud/app.yaml
@@ -64,3 +64,12 @@ configuration:
           control_type: select
           hidden_from:
             - operator
+  content:
+    format: "multi-file"
+    multi-file:
+      input:
+        path: "my-inputs"
+      output:
+        statistics: "my-outputs/statistics.json"
+        assets: "my-outputs/assets.json"
+        solutions: "my-outputs/solutions"

--- a/nextmv/tests/cloud/test_manifest.py
+++ b/nextmv/tests/cloud/test_manifest.py
@@ -2,6 +2,10 @@ import unittest
 
 from nextmv.cloud.manifest import (
     Manifest,
+    ManifestContent,
+    ManifestContentMultiFile,
+    ManifestContentMultiFileInput,
+    ManifestContentMultiFileOutput,
     ManifestOption,
     ManifestOptions,
     ManifestOptionUI,
@@ -154,6 +158,23 @@ class TestManifest(unittest.TestCase):
         )
         self.assertEqual(manifest.configuration.options.format, ["-{{name}}", "{{value}}"])
 
+        self.assertDictEqual(
+            manifest.configuration.content.to_dict(),
+            {
+                "format": "multi-file",
+                "multi-file": {
+                    "input": {
+                        "path": "my-inputs",
+                    },
+                    "output": {
+                        "statistics": "my-outputs/statistics.json",
+                        "assets": "my-outputs/assets.json",
+                        "solutions": "my-outputs/solutions",
+                    },
+                },
+            },
+        )
+
     def test_extract_options(self):
         manifest = Manifest.from_yaml("tests/cloud")
         options = manifest.extract_options()
@@ -242,6 +263,32 @@ class TestManifest(unittest.TestCase):
         manifest_options = ManifestOptions.from_options(options, format=["-{{name}}", "{{value}}"])
         self.assertEqual(manifest_options.format, ["-{{name}}", "{{value}}"])
         self.assertEqual(manifest_options.strict, False)
+
+    def test_manifest_content_from_dict(self):
+        manifest_content_dict = {
+            "format": "multi-file",
+            "multi-file": {
+                "input": {
+                    "path": "data/input_data",
+                },
+                "output": {
+                    "statistics": "data/output/stats.json",
+                    "assets": "data/output/assets.json",
+                    "solutions": "data/output/solutions",
+                },
+            },
+        }
+
+        manifest_content = ManifestContent.from_dict(manifest_content_dict)
+
+        self.assertEqual(manifest_content.format, "multi-file")
+        self.assertIsInstance(manifest_content.multi_file, ManifestContentMultiFile)
+        self.assertIsInstance(manifest_content.multi_file.input, ManifestContentMultiFileInput)
+        self.assertIsInstance(manifest_content.multi_file.output, ManifestContentMultiFileOutput)
+        self.assertEqual(manifest_content.multi_file.input.path, "data/input_data")
+        self.assertEqual(manifest_content.multi_file.output.statistics, "data/output/stats.json")
+        self.assertEqual(manifest_content.multi_file.output.assets, "data/output/assets.json")
+        self.assertEqual(manifest_content.multi_file.output.solutions, "data/output/solutions")
 
     def test_from_options_with_validation(self):
         options = Options(


### PR DESCRIPTION
# Description

Adds support for configuring input/output handling via manifest. I.e., the content-type/format that the app processes can be configured via manifest now (e.g.: `json`, `multi-file`), including further fine tuning depending on the specific content-type/format.

Example of such a content configuration:

```python
configuration:
  // ...
  content:
    format: "multi-file"
    multi-file:
      input:
        path: "my-inputs"
      output:
        statistics: "my-outputs/statistics.json"
        assets: "my-outputs/assets.json"
        solutions: "my-outputs/solutions"
```

## Changes

- Adds support for configuring content (input/output) via manifest.