### PR TITLE
Release v0.30.0

### DIFF
--- a/nextmv/nextmv/__about__.py
+++ b/nextmv/nextmv/__about__.py
@@ -1,1 +1,1 @@
-__version__ = "v0.29.5.dev.1"
+__version__ = "v0.30.0"


### PR DESCRIPTION
# Description

The reason why this is `v0.30.0` and not `v0.29.5` is because of the new methods introduced to create experiments with polling.