### PR TITLE
Add `format` field to `Metadata`

### DIFF
--- a/nextmv/nextmv/cloud/run.py
+++ b/nextmv/nextmv/cloud/run.py
@@ -217,6 +217,8 @@ class Metadata(BaseModel):
         Size of the input in bytes.
     output_size : float
         Size of the output in bytes.
+    format : Format
+        Format of the input and output of the run.
     status : Status
         Deprecated: use status_v2.
     status_v2 : StatusV2


### PR DESCRIPTION
# Description

Adds missing format field in metadata.

## Changes

- Adds format field in run metadata.