### PR TITLE
Returns the runs of a batch experiment, adds the `list_runs` methods for `Application` in `local` and `cloud`

### DIFF
--- a/docs/nextmv/reference/local/local.md
+++ b/docs/nextmv/reference/local/local.md
@@ -1,0 +1,6 @@
+# Local Module
+
+This section documents the local components of the Nextmv Python SDK -
+Local experience.
+
+::: nextmv.nextmv.local.local

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,6 +47,7 @@ nav:
               - application.py: nextmv/reference/local/application.md
               - executor.py: nextmv/reference/local/executor.md
               - geojson_handler.py: nextmv/reference/local/geojson_handler.md
+              - local.py: nextmv/reference/local/local.md
               - plotly_handler.py: nextmv/reference/local/plotly_handler.md
               - runner.py: nextmv/reference/local/runner.md
           - base_model.py: nextmv/reference/base_model.md

--- a/nextmv/nextmv/__init__.py
+++ b/nextmv/nextmv/__init__.py
@@ -3,8 +3,6 @@
 from .__about__ import __version__
 from .base_model import BaseModel as BaseModel
 from .base_model import from_dict as from_dict
-from .input import DEFAULT_INPUT_JSON_FILE as DEFAULT_INPUT_JSON_FILE
-from .input import INPUTS_KEY as INPUTS_KEY
 from .input import DataFile as DataFile
 from .input import Input as Input
 from .input import InputFormat as InputFormat
@@ -31,13 +29,6 @@ from .model import ModelConfiguration as ModelConfiguration
 from .options import Option as Option
 from .options import Options as Options
 from .options import Parameter as Parameter
-from .output import ASSETS_KEY as ASSETS_KEY
-from .output import DEFAULT_OUTPUT_JSON_FILE as DEFAULT_OUTPUT_JSON_FILE
-from .output import LOGS_FILE as LOGS_FILE
-from .output import LOGS_KEY as LOGS_KEY
-from .output import OUTPUTS_KEY as OUTPUTS_KEY
-from .output import SOLUTIONS_KEY as SOLUTIONS_KEY
-from .output import STATISTICS_KEY as STATISTICS_KEY
 from .output import Asset as Asset
 from .output import DataPoint as DataPoint
 from .output import LocalOutputWriter as LocalOutputWriter
@@ -66,13 +57,17 @@ from .run import Format as Format
 from .run import FormatInput as FormatInput
 from .run import FormatOutput as FormatOutput
 from .run import Metadata as Metadata
+from .run import OptionsSummaryItem as OptionsSummaryItem
+from .run import Run as Run
 from .run import RunConfiguration as RunConfiguration
 from .run import RunInformation as RunInformation
+from .run import RunInfoStatistics as RunInfoStatistics
 from .run import RunLog as RunLog
 from .run import RunQueuing as RunQueuing
 from .run import RunResult as RunResult
 from .run import RunType as RunType
 from .run import RunTypeConfiguration as RunTypeConfiguration
+from .run import StatisticsIndicator as StatisticsIndicator
 from .run import TrackedRun as TrackedRun
 from .run import TrackedRunStatus as TrackedRunStatus
 from .run import run_duration as run_duration

--- a/nextmv/nextmv/cloud/application.py
+++ b/nextmv/nextmv/cloud/application.py
@@ -64,6 +64,7 @@ from nextmv.run import (
     Format,
     FormatInput,
     FormatOutput,
+    Run,
     RunConfiguration,
     RunInformation,
     RunLog,
@@ -289,7 +290,8 @@ class Application:
 
     def batch_experiment(self, batch_id: str) -> BatchExperiment:
         """
-        Get a batch experiment.
+        Get a batch experiment. This method also returns the runs of the batch
+        experiment under the `.runs` attribute.
 
         Parameters
         ----------
@@ -318,7 +320,17 @@ class Application:
             endpoint=f"{self.experiments_endpoint}/batch/{batch_id}",
         )
 
-        return BatchExperiment.from_dict(response.json())
+        exp = BatchExperiment.from_dict(response.json())
+
+        runs_response = self.client.request(
+            method="GET",
+            endpoint=f"{self.experiments_endpoint}/batch/{batch_id}/runs",
+        )
+
+        runs = [Run.from_dict(run) for run in runs_response.json().get("runs", [])]
+        exp.runs = runs
+
+        return exp
 
     def batch_experiment_metadata(self, batch_id: str) -> BatchExperimentMetadata:
         """
@@ -817,6 +829,28 @@ class Application:
         )
 
         return [ManagedInput.from_dict(managed_input) for managed_input in response.json()]
+
+    def list_runs(self) -> list[Run]:
+        """
+        List all runs.
+
+        Returns
+        -------
+        list[Run]
+            List of runs.
+
+        Raises
+        ------
+        requests.HTTPError
+            If the response status code is not 2xx.
+        """
+
+        response = self.client.request(
+            method="GET",
+            endpoint=f"{self.endpoint}/runs",
+        )
+
+        return [Run.from_dict(run) for run in response.json().get("runs", [])]
 
     def list_scenario_tests(self) -> list[BatchExperimentMetadata]:
         """

--- a/nextmv/nextmv/cloud/batch_experiment.py
+++ b/nextmv/nextmv/cloud/batch_experiment.py
@@ -21,6 +21,7 @@ from typing import Any, Optional
 
 from nextmv.base_model import BaseModel
 from nextmv.cloud.input_set import InputSet
+from nextmv.run import Run
 
 
 class ExperimentStatus(str, Enum):
@@ -191,7 +192,10 @@ class BatchExperiment(BatchExperimentInformation):
     instance_ids : list[str]
         List of instance IDs used for the experiment.
     grouped_distributional_summaries : list[dict[str, Any]], optional
-        Grouped distributional summaries of the batch experiment. Defaults to None.
+        Grouped distributional summaries of the batch experiment. Defaults to
+        None.
+    runs : list[Run], optional
+        List of runs in the batch experiment. Defaults to None.
     """
 
     input_set_id: str
@@ -200,6 +204,8 @@ class BatchExperiment(BatchExperimentInformation):
     """List of instance IDs used for the experiment."""
     grouped_distributional_summaries: Optional[list[dict[str, Any]]] = None
     """Grouped distributional summaries of the batch experiment."""
+    runs: Optional[list[Run]] = None
+    """List of runs in the batch experiment."""
 
 
 class BatchExperimentRun(BaseModel):

--- a/nextmv/nextmv/input.py
+++ b/nextmv/nextmv/input.py
@@ -25,8 +25,6 @@ Constants
 ---------
 INPUTS_KEY : str
     Key used for identifying inputs in the run.
-DEFAULT_INPUT_JSON_FILE : str
-    Constant for the default input JSON file name.
 """
 
 import copy
@@ -46,10 +44,6 @@ from nextmv.options import Options
 INPUTS_KEY = "inputs"
 """
 Inputs key constant used for identifying inputs in the run.
-"""
-DEFAULT_INPUT_JSON_FILE = "input.json"
-"""
-Constant for the default input JSON file name.
 """
 
 

--- a/nextmv/nextmv/local/application.py
+++ b/nextmv/nextmv/local/application.py
@@ -33,15 +33,22 @@ from typing import Any, Optional, Union
 from nextmv import cloud
 from nextmv._serialization import deflated_serialize_json
 from nextmv.base_model import BaseModel
-from nextmv.input import DEFAULT_INPUT_JSON_FILE, INPUTS_KEY, Input, InputFormat
-from nextmv.local.executor import LOGS_FILE
+from nextmv.input import INPUTS_KEY, Input, InputFormat
+from nextmv.local.local import (
+    DEFAULT_INPUT_JSON_FILE,
+    DEFAULT_OUTPUT_JSON_FILE,
+    LOGS_FILE,
+    LOGS_KEY,
+    NEXTMV_DIR,
+    RUNS_KEY,
+)
 from nextmv.local.runner import run
 from nextmv.logger import log
 from nextmv.manifest import Manifest
 from nextmv.options import Options
-from nextmv.output import DEFAULT_OUTPUT_JSON_FILE, LOGS_KEY, OUTPUTS_KEY, SOLUTIONS_KEY, OutputFormat
+from nextmv.output import OUTPUTS_KEY, SOLUTIONS_KEY, OutputFormat
 from nextmv.polling import DEFAULT_POLLING_OPTIONS, PollingOptions, poll
-from nextmv.run import ErrorLog, Format, RunConfiguration, RunInformation, RunResult, TrackedRun, TrackedRunStatus
+from nextmv.run import ErrorLog, Format, Run, RunConfiguration, RunInformation, RunResult, TrackedRun, TrackedRunStatus
 from nextmv.safe import safe_id
 from nextmv.status import StatusV2
 
@@ -152,224 +159,35 @@ class Application:
             description=description,
         )
 
-    def run_metadata(self, run_id: str) -> RunInformation:
+    def list_runs(self) -> list[Run]:
         """
-        Get the metadata of a local run.
-
-        This method is the local equivalent to
-        `cloud.Application.run_metadata`, which retrieves the metadata of a
-        remote run in Nextmv Cloud. This method is used to get the metadata of
-        a run that was executed locally using the `new_run` or
-        `new_run_with_result` method.
-
-        Retrieves information about a run without including the run output.
-        This is useful when you only need the run's status and metadata.
-
-        Parameters
-        ----------
-        run_id : str
-            ID of the run to retrieve metadata for.
+        List all runs for the application.
 
         Returns
         -------
-        RunInformation
-            Metadata of the run (run information without output).
-
-        Raises
-        ------
-        ValueError
-            If the `.nextmv/runs` directory does not exist at the application
-            source, or if the specified run ID does not exist.
-
-        Examples
-        --------
-        >>> metadata = app.run_metadata("run-789")
-        >>> print(metadata.metadata.status_v2)
-        StatusV2.succeeded
+        list[Run]
+            A list of all runs associated with the application.
         """
 
-        runs_dir = os.path.join(self.src, ".nextmv", "runs")
+        runs_dir = os.path.join(self.src, NEXTMV_DIR, RUNS_KEY)
         if not os.path.exists(runs_dir):
             raise ValueError(f"`.nextmv/runs` dir does not exist at app source: {self.src}")
 
-        run_dir = os.path.join(runs_dir, run_id)
-        if not os.path.exists(run_dir):
-            raise ValueError(f"`{run_id}` run dir does not exist at: {runs_dir}")
+        dirs = os.listdir(runs_dir)
+        if not dirs:
+            return []
 
-        info_file = os.path.join(run_dir, f"{run_id}.json")
-        if not os.path.exists(info_file):
-            raise ValueError(f"`{info_file}` file does not exist at: {run_dir}")
+        run_ids = [d for d in dirs if os.path.isdir(os.path.join(runs_dir, d))]
+        if not run_ids:
+            return []
 
-        with open(info_file) as f:
-            info_dict = json.load(f)
+        runs = []
+        for run_id in run_ids:
+            info = self.run_metadata(run_id=run_id)
+            run = info.to_run()
+            runs.append(run)
 
-        info = RunInformation.from_dict(info_dict)
-
-        return info
-
-    def run_result(self, run_id: str, output_dir_path: Optional[str] = ".") -> RunResult:
-        """
-        Get the local result of a run.
-
-        This method is the local equivalent to `cloud.Application.run_result`,
-        which retrieves the result of a remote run in Nextmv Cloud. This method
-        is used to get the result of a run that was executed locally using the
-        `new_run` or `new_run_with_result` method.
-
-        Retrieves the complete result of a run, including the run output.
-
-        Parameters
-        ----------
-        run_id : str
-            ID of the run to get results for.
-        output_dir_path : Optional[str], default="."
-            Path to a directory where non-JSON output files will be saved. This
-            is required if the output is non-JSON. If the directory does not
-            exist, it will be created. Uses the current directory by default.
-
-        Returns
-        -------
-        RunResult
-            Result of the run, including output.
-
-        Raises
-        ------
-        ValueError
-            If the `.nextmv/runs` directory does not exist at the application
-            source, or if the specified run ID does not exist.
-
-        Examples
-        --------
-        >>> result = app.run_result("run-123")
-        >>> print(result.metadata.status_v2)
-        'succeeded'
-        """
-
-        run_information = self.run_metadata(run_id=run_id)
-
-        return self.__run_result(
-            run_id=run_id,
-            run_information=run_information,
-            output_dir_path=output_dir_path,
-        )
-
-    def run_result_with_polling(
-        self,
-        run_id: str,
-        polling_options: PollingOptions = DEFAULT_POLLING_OPTIONS,
-        output_dir_path: Optional[str] = ".",
-    ) -> RunResult:
-        """
-        Get the result of a local run with polling.
-
-        This method is the local equivalent to
-        `cloud.Application.run_result_with_polling`, which retrieves the result
-        of a remote run in Nextmv Cloud. This method is used to get the result
-        of a run that was executed locally using the `new_run` or
-        `new_run_with_result` method.
-
-        Retrieves the result of a run including the run output. This method
-        polls for the result until the run finishes executing or the polling
-        strategy is exhausted.
-
-        Parameters
-        ----------
-        run_id : str
-            ID of the run to retrieve the result for.
-        polling_options : PollingOptions, default=_DEFAULT_POLLING_OPTIONS
-            Options to use when polling for the run result.
-        output_dir_path : Optional[str], default="."
-            Path to a directory where non-JSON output files will be saved. This
-            is required if the output is non-JSON. If the directory does not
-            exist, it will be created. Uses the current directory by default.
-
-        Returns
-        -------
-        RunResult
-            Complete result of the run including output data.
-
-        Raises
-        ------
-        requests.HTTPError
-            If the response status code is not 2xx.
-        TimeoutError
-            If the run does not complete after the polling strategy is
-            exhausted based on time duration.
-        RuntimeError
-            If the run does not complete after the polling strategy is
-            exhausted based on number of tries.
-
-        Examples
-        --------
-        >>> from nextmv.cloud import PollingOptions
-        >>> # Create custom polling options
-        >>> polling_opts = PollingOptions(max_tries=50, max_duration=600)
-        >>> # Get run result with polling
-        >>> result = app.run_result_with_polling("run-123", polling_opts)
-        >>> print(result.output)
-        {'solution': {...}}
-        """
-
-        def polling_func() -> tuple[Any, bool]:
-            run_information = self.run_metadata(run_id=run_id)
-            if run_information.metadata.status_v2 in {
-                StatusV2.succeeded,
-                StatusV2.failed,
-                StatusV2.canceled,
-            }:
-                return run_information, True
-
-            return None, False
-
-        run_information = poll(polling_options=polling_options, polling_func=polling_func)
-
-        return self.__run_result(
-            run_id=run_id,
-            run_information=run_information,
-            output_dir_path=output_dir_path,
-        )
-
-    def run_visuals(self, run_id: str) -> None:
-        """
-        Open the local run visuals in a web browser.
-
-        This method opens the visual representation of a locally executed run
-        in the default web browser. It assumes that the run was executed locally
-        using the `new_run` or `new_run_with_result` method and that
-        the necessary visualization files are present.
-
-        If the run was correctly configured to produce visual assets, then the
-        run will contain a `visuals` directory with one or more HTML files.
-        Each file is opened in a new tab in the default web browser.
-
-        Parameters
-        ----------
-        run_id : str
-            ID of the local run to visualize.
-
-        Raises
-        ------
-        ValueError
-            If the `.nextmv/runs` directory does not exist at the application
-            source, or if the specified run ID does not exist.
-        """
-
-        runs_dir = os.path.join(self.src, ".nextmv", "runs")
-        if not os.path.exists(runs_dir):
-            raise ValueError(f"`.nextmv/runs` dir does not exist at app source: {self.src}")
-
-        run_dir = os.path.join(runs_dir, run_id)
-        if not os.path.exists(run_dir):
-            raise ValueError(f"`{run_id}` run dir does not exist at: {runs_dir}")
-
-        visuals_dir = os.path.join(run_dir, "visuals")
-        if not os.path.exists(visuals_dir):
-            raise ValueError(f"`visuals` dir does not exist at: {run_dir}")
-
-        for file in os.listdir(visuals_dir):
-            if file.endswith(".html"):
-                file_path = os.path.join(visuals_dir, file)
-                webbrowser.open_new_tab(f"file://{os.path.realpath(file_path)}")
+        return runs
 
     def new_run(
         self,
@@ -642,6 +460,225 @@ class Application:
             output_dir_path=output_dir_path,
         )
 
+    def run_metadata(self, run_id: str) -> RunInformation:
+        """
+        Get the metadata of a local run.
+
+        This method is the local equivalent to
+        `cloud.Application.run_metadata`, which retrieves the metadata of a
+        remote run in Nextmv Cloud. This method is used to get the metadata of
+        a run that was executed locally using the `new_run` or
+        `new_run_with_result` method.
+
+        Retrieves information about a run without including the run output.
+        This is useful when you only need the run's status and metadata.
+
+        Parameters
+        ----------
+        run_id : str
+            ID of the run to retrieve metadata for.
+
+        Returns
+        -------
+        RunInformation
+            Metadata of the run (run information without output).
+
+        Raises
+        ------
+        ValueError
+            If the `.nextmv/runs` directory does not exist at the application
+            source, or if the specified run ID does not exist.
+
+        Examples
+        --------
+        >>> metadata = app.run_metadata("run-789")
+        >>> print(metadata.metadata.status_v2)
+        StatusV2.succeeded
+        """
+
+        runs_dir = os.path.join(self.src, NEXTMV_DIR, RUNS_KEY)
+        if not os.path.exists(runs_dir):
+            raise ValueError(f"`.nextmv/runs` dir does not exist at app source: {self.src}")
+
+        run_dir = os.path.join(runs_dir, run_id)
+        if not os.path.exists(run_dir):
+            raise ValueError(f"`{run_id}` run dir does not exist at: {runs_dir}")
+
+        info_file = os.path.join(run_dir, f"{run_id}.json")
+        if not os.path.exists(info_file):
+            raise ValueError(f"`{info_file}` file does not exist at: {run_dir}")
+
+        with open(info_file) as f:
+            info_dict = json.load(f)
+
+        info = RunInformation.from_dict(info_dict)
+
+        return info
+
+    def run_result(self, run_id: str, output_dir_path: Optional[str] = ".") -> RunResult:
+        """
+        Get the local result of a run.
+
+        This method is the local equivalent to `cloud.Application.run_result`,
+        which retrieves the result of a remote run in Nextmv Cloud. This method
+        is used to get the result of a run that was executed locally using the
+        `new_run` or `new_run_with_result` method.
+
+        Retrieves the complete result of a run, including the run output.
+
+        Parameters
+        ----------
+        run_id : str
+            ID of the run to get results for.
+        output_dir_path : Optional[str], default="."
+            Path to a directory where non-JSON output files will be saved. This
+            is required if the output is non-JSON. If the directory does not
+            exist, it will be created. Uses the current directory by default.
+
+        Returns
+        -------
+        RunResult
+            Result of the run, including output.
+
+        Raises
+        ------
+        ValueError
+            If the `.nextmv/runs` directory does not exist at the application
+            source, or if the specified run ID does not exist.
+
+        Examples
+        --------
+        >>> result = app.run_result("run-123")
+        >>> print(result.metadata.status_v2)
+        'succeeded'
+        """
+
+        run_information = self.run_metadata(run_id=run_id)
+
+        return self.__run_result(
+            run_id=run_id,
+            run_information=run_information,
+            output_dir_path=output_dir_path,
+        )
+
+    def run_result_with_polling(
+        self,
+        run_id: str,
+        polling_options: PollingOptions = DEFAULT_POLLING_OPTIONS,
+        output_dir_path: Optional[str] = ".",
+    ) -> RunResult:
+        """
+        Get the result of a local run with polling.
+
+        This method is the local equivalent to
+        `cloud.Application.run_result_with_polling`, which retrieves the result
+        of a remote run in Nextmv Cloud. This method is used to get the result
+        of a run that was executed locally using the `new_run` or
+        `new_run_with_result` method.
+
+        Retrieves the result of a run including the run output. This method
+        polls for the result until the run finishes executing or the polling
+        strategy is exhausted.
+
+        Parameters
+        ----------
+        run_id : str
+            ID of the run to retrieve the result for.
+        polling_options : PollingOptions, default=_DEFAULT_POLLING_OPTIONS
+            Options to use when polling for the run result.
+        output_dir_path : Optional[str], default="."
+            Path to a directory where non-JSON output files will be saved. This
+            is required if the output is non-JSON. If the directory does not
+            exist, it will be created. Uses the current directory by default.
+
+        Returns
+        -------
+        RunResult
+            Complete result of the run including output data.
+
+        Raises
+        ------
+        requests.HTTPError
+            If the response status code is not 2xx.
+        TimeoutError
+            If the run does not complete after the polling strategy is
+            exhausted based on time duration.
+        RuntimeError
+            If the run does not complete after the polling strategy is
+            exhausted based on number of tries.
+
+        Examples
+        --------
+        >>> from nextmv.cloud import PollingOptions
+        >>> # Create custom polling options
+        >>> polling_opts = PollingOptions(max_tries=50, max_duration=600)
+        >>> # Get run result with polling
+        >>> result = app.run_result_with_polling("run-123", polling_opts)
+        >>> print(result.output)
+        {'solution': {...}}
+        """
+
+        def polling_func() -> tuple[Any, bool]:
+            run_information = self.run_metadata(run_id=run_id)
+            if run_information.metadata.status_v2 in {
+                StatusV2.succeeded,
+                StatusV2.failed,
+                StatusV2.canceled,
+            }:
+                return run_information, True
+
+            return None, False
+
+        run_information = poll(polling_options=polling_options, polling_func=polling_func)
+
+        return self.__run_result(
+            run_id=run_id,
+            run_information=run_information,
+            output_dir_path=output_dir_path,
+        )
+
+    def run_visuals(self, run_id: str) -> None:
+        """
+        Open the local run visuals in a web browser.
+
+        This method opens the visual representation of a locally executed run
+        in the default web browser. It assumes that the run was executed locally
+        using the `new_run` or `new_run_with_result` method and that
+        the necessary visualization files are present.
+
+        If the run was correctly configured to produce visual assets, then the
+        run will contain a `visuals` directory with one or more HTML files.
+        Each file is opened in a new tab in the default web browser.
+
+        Parameters
+        ----------
+        run_id : str
+            ID of the local run to visualize.
+
+        Raises
+        ------
+        ValueError
+            If the `.nextmv/runs` directory does not exist at the application
+            source, or if the specified run ID does not exist.
+        """
+
+        runs_dir = os.path.join(self.src, NEXTMV_DIR, RUNS_KEY)
+        if not os.path.exists(runs_dir):
+            raise ValueError(f"`.nextmv/runs` dir does not exist at app source: {self.src}")
+
+        run_dir = os.path.join(runs_dir, run_id)
+        if not os.path.exists(run_dir):
+            raise ValueError(f"`{run_id}` run dir does not exist at: {runs_dir}")
+
+        visuals_dir = os.path.join(run_dir, "visuals")
+        if not os.path.exists(visuals_dir):
+            raise ValueError(f"`visuals` dir does not exist at: {run_dir}")
+
+        for file in os.listdir(visuals_dir):
+            if file.endswith(".html"):
+                file_path = os.path.join(visuals_dir, file)
+                webbrowser.open_new_tab(f"file://{os.path.realpath(file_path)}")
+
     def sync(  # noqa: C901
         self,
         target: cloud.Application,
@@ -714,7 +751,7 @@ class Application:
         # ".". During the sync process, we don't need to keep these outputs, so
         # we can use a temp dir that will be deleted after the sync is done.
         with tempfile.TemporaryDirectory(prefix="nextmv-sync-run-") as temp_results_dir:
-            runs_dir = os.path.join(self.src, ".nextmv", "runs")
+            runs_dir = os.path.join(self.src, NEXTMV_DIR, RUNS_KEY)
             if run_ids is None:
                 # If runs are not specified, by default we sync all local runs that
                 # can be found.
@@ -800,7 +837,7 @@ class Application:
                 "The output format is not JSON: an `output_dir_path` must be provided.",
             )
 
-        runs_dir = os.path.join(self.src, ".nextmv", "runs")
+        runs_dir = os.path.join(self.src, NEXTMV_DIR, RUNS_KEY)
         solutions_dir = os.path.join(runs_dir, run_id, OUTPUTS_KEY, SOLUTIONS_KEY)
 
         if output_type == OutputFormat.JSON:

--- a/nextmv/nextmv/local/executor.py
+++ b/nextmv/nextmv/local/executor.py
@@ -38,22 +38,17 @@ from typing import Any, Optional, Union
 
 from nextmv.input import INPUTS_KEY, InputFormat, load
 from nextmv.local.geojson_handler import handle_geojson_visual
-from nextmv.local.plotly_handler import handle_plotly_visual
-from nextmv.local.runner import calculate_files_size
-from nextmv.manifest import Manifest
-from nextmv.output import (
-    ASSETS_KEY,
+from nextmv.local.local import (
     DEFAULT_OUTPUT_JSON_FILE,
     LOGS_FILE,
     LOGS_KEY,
+    NEXTMV_DIR,
     OUTPUT_KEY,
-    OUTPUTS_KEY,
-    SOLUTIONS_KEY,
-    STATISTICS_KEY,
-    Asset,
-    OutputFormat,
-    VisualSchema,
+    calculate_files_size,
 )
+from nextmv.local.plotly_handler import handle_plotly_visual
+from nextmv.manifest import Manifest
+from nextmv.output import ASSETS_KEY, OUTPUTS_KEY, SOLUTIONS_KEY, STATISTICS_KEY, Asset, OutputFormat, VisualSchema
 from nextmv.status import StatusV2
 
 
@@ -123,7 +118,7 @@ def execute_run(
         # place to work from, and be cleaned up afterwards.
         with tempfile.TemporaryDirectory() as temp_dir:
             temp_src = os.path.join(temp_dir, "src")
-            shutil.copytree(src, temp_src, ignore=shutil.ignore_patterns(".nextmv"))
+            shutil.copytree(src, temp_src, ignore=shutil.ignore_patterns(NEXTMV_DIR))
 
             manifest = Manifest.from_dict(manifest_dict)
 

--- a/nextmv/nextmv/local/local.py
+++ b/nextmv/nextmv/local/local.py
@@ -84,8 +84,9 @@ def calculate_files_size(run_dir: str, run_id: str, dir_path: str, metadata_key:
         for f in filenames:
             fp = os.path.join(dirpath, f)
             # Skip if it is a symbolic link
-            if not os.path.islink(fp):
-                total_size += os.path.getsize(fp)
+            if os.path.islink(fp):
+                continue
+            total_size += os.path.getsize(fp)
 
     info_file = os.path.join(run_dir, f"{run_id}.json")
     with open(info_file, "r+") as f:

--- a/nextmv/nextmv/local/local.py
+++ b/nextmv/nextmv/local/local.py
@@ -1,0 +1,96 @@
+"""
+Local module to hold convenience functions used in the `local` package.
+
+Functions
+---------
+calculate_files_size
+    Function to calculate the total size of files in a directory.
+
+Constants
+---------
+OUTPUT_KEY
+    Output key constant used for identifying output in the run output.
+LOGS_KEY
+    Logs key constant used for identifying logs in the run output.
+LOGS_FILE
+    Constant used for identifying the file used for logging.
+DEFAULT_OUTPUT_JSON_FILE
+    Constant for the default output JSON file name.
+RUNS_KEY
+    Runs key constant used for identifying the runs directory in the nextmv
+    location.
+NEXTMV_DIR
+    Constant for the Nextmv directory name.
+DEFAULT_INPUT_JSON_FILE : str
+    Constant for the default input JSON file name.
+"""
+
+import json
+import os
+
+OUTPUT_KEY = "output"
+"""
+Output key constant used for identifying output in the run output.
+"""
+LOGS_KEY = "logs"
+"""
+Logs key constant used for identifying logs in the run output.
+"""
+LOGS_FILE = "stderr.log"
+"""
+Constant used for identifying the file used for logging.
+"""
+DEFAULT_OUTPUT_JSON_FILE = "solution.json"
+"""
+Constant for the default output JSON file name.
+"""
+RUNS_KEY = "runs"
+"""
+Runs key constant used for identifying the runs directory in the nextmv
+location.
+"""
+NEXTMV_DIR = ".nextmv"
+"""
+Constant for the Nextmv directory name.
+"""
+DEFAULT_INPUT_JSON_FILE = "input.json"
+"""
+Constant for the default input JSON file name.
+"""
+
+
+def calculate_files_size(run_dir: str, run_id: str, dir_path: str, metadata_key: str) -> None:
+    """
+    Calculates the total size of the files in a directory, in bytes.
+
+    The calculated size is stored in the run information metadata under the
+    specified key.
+
+    Parameters
+    ----------
+    run_dir : str
+        The path to the run directory.
+    run_id : str
+        The ID of the run.
+    dir_path : str
+        The path to the directory whose size is to be calculated.
+    metadata_key : str
+        The key under which to store the calculated size in the run information
+        metadata.
+    """
+
+    total_size = 0
+    for dirpath, _, filenames in os.walk(dir_path):
+        for f in filenames:
+            fp = os.path.join(dirpath, f)
+            # Skip if it is a symbolic link
+            if not os.path.islink(fp):
+                total_size += os.path.getsize(fp)
+
+    info_file = os.path.join(run_dir, f"{run_id}.json")
+    with open(info_file, "r+") as f:
+        info = json.load(f)
+        info["metadata"][metadata_key] = total_size
+        f.seek(0)
+        json.dump(info, f, indent=2)
+        f.truncate()

--- a/nextmv/nextmv/local/runner.py
+++ b/nextmv/nextmv/local/runner.py
@@ -11,8 +11,6 @@ new_run
     Function to initialize a new run.
 record_input
     Function to write the input to the appropriate location.
-calculate_files_size
-    Function to calculate the total size of files in a directory.
 """
 
 import importlib.util
@@ -24,7 +22,8 @@ import sys
 from datetime import datetime, timezone
 from typing import Any, Optional, Union
 
-from nextmv.input import DEFAULT_INPUT_JSON_FILE, INPUTS_KEY
+from nextmv.input import INPUTS_KEY
+from nextmv.local.local import DEFAULT_INPUT_JSON_FILE, NEXTMV_DIR, RUNS_KEY, calculate_files_size
 from nextmv.manifest import Manifest
 from nextmv.run import Format, FormatInput, Metadata, RunInformation, StatusV2
 from nextmv.safe import safe_id
@@ -176,7 +175,7 @@ def new_run(
     """
 
     # First, ensure the runs directory exists.
-    runs_dir = os.path.join(src, ".nextmv", "runs")
+    runs_dir = os.path.join(src, NEXTMV_DIR, RUNS_KEY)
     os.makedirs(runs_dir, exist_ok=True)
 
     # Create a new run directory.
@@ -273,40 +272,3 @@ def record_input(
 
     # Update the input size in the run information file.
     calculate_files_size(run_dir, run_id, run_inputs_dir, metadata_key="input_size")
-
-
-def calculate_files_size(run_dir: str, run_id: str, dir_path: str, metadata_key: str) -> None:
-    """
-    Calculates the total size of the files in a directory, in bytes.
-
-    The calculated size is stored in the run information metadata under the
-    specified key.
-
-    Parameters
-    ----------
-    run_dir : str
-        The path to the run directory.
-    run_id : str
-        The ID of the run.
-    dir_path : str
-        The path to the directory whose size is to be calculated.
-    metadata_key : str
-        The key under which to store the calculated size in the run information
-        metadata.
-    """
-
-    total_size = 0
-    for dirpath, _, filenames in os.walk(dir_path):
-        for f in filenames:
-            fp = os.path.join(dirpath, f)
-            # Skip if it is a symbolic link
-            if not os.path.islink(fp):
-                total_size += os.path.getsize(fp)
-
-    info_file = os.path.join(run_dir, f"{run_id}.json")
-    with open(info_file, "r+") as f:
-        info = json.load(f)
-        info["metadata"][metadata_key] = total_size
-        f.seek(0)
-        json.dump(info, f, indent=2)
-        f.truncate()

--- a/nextmv/nextmv/output.py
+++ b/nextmv/nextmv/output.py
@@ -51,10 +51,6 @@ SOLUTIONS_KEY
     Solutions key constant used for identifying solutions in the run output.
 OUTPUTS_KEY
     Outputs key constant used for identifying outputs in the run output.
-LOGS_FILE
-    Constant used for identifying the file used for logging.
-DEFAULT_OUTPUT_JSON_FILE
-    Constant for the default output JSON file name.
 """
 
 import copy
@@ -89,22 +85,6 @@ Solutions key constant used for identifying solutions in the run output.
 OUTPUTS_KEY = "outputs"
 """
 Outputs key constant used for identifying outputs in the run output.
-"""
-OUTPUT_KEY = "output"
-"""
-Output key constant used for identifying output in the run output.
-"""
-LOGS_KEY = "logs"
-"""
-Logs key constant used for identifying logs in the run output.
-"""
-LOGS_FILE = "stderr.log"
-"""
-Constant used for identifying the file used for logging.
-"""
-DEFAULT_OUTPUT_JSON_FILE = "solution.json"
-"""
-Constant for the default output JSON file name.
 """
 
 

--- a/nextmv/nextmv/run.py
+++ b/nextmv/nextmv/run.py
@@ -47,7 +47,7 @@ from datetime import datetime
 from enum import Enum
 from typing import Any, Optional, Union
 
-from pydantic import AliasChoices, Field
+from pydantic import AliasChoices, Field, field_validator
 
 from nextmv._serialization import serialize_json
 from nextmv.base_model import BaseModel
@@ -226,6 +226,406 @@ class Format(BaseModel):
     """Output format for the run configuration."""
 
 
+class RunType(str, Enum):
+    """
+    The actual type of the run.
+
+    You can import the `RunType` class directly from `nextmv`:
+
+    ```python
+    from nextmv import RunType
+    ```
+
+    Parameters
+    ----------
+    STANDARD : str
+        Standard run type.
+    EXTERNAL : str
+        External run type.
+    ENSEMBLE : str
+        Ensemble run type.
+
+    Examples
+    --------
+    >>> from nextmv import RunType
+    >>> run_type = RunType.STANDARD
+    >>> run_type
+    <RunType.STANDARD: 'standard'>
+    >>> run_type.value
+    'standard'
+
+    >>> # Creating from string
+    >>> external_type = RunType("external")
+    >>> external_type
+    <RunType.EXTERNAL: 'external'>
+
+    >>> # All available types
+    >>> list(RunType)
+    [<RunType.STANDARD: 'standard'>, <RunType.EXTERNAL: 'external'>, <RunType.ENSEMBLE: 'ensemble'>]
+    """
+
+    STANDARD = "standard"
+    """Standard run type."""
+    EXTERNAL = "external"
+    """External run type."""
+    ENSEMBLE = "ensemble"
+    """Ensemble run type."""
+
+
+class RunTypeConfiguration(BaseModel):
+    """
+    Defines the configuration for the type of the run that is being executed
+    on an application.
+
+    You can import the `RunTypeConfiguration` class directly from `nextmv`:
+
+    ```python
+    from nextmv import RunTypeConfiguration
+    ```
+
+    Parameters
+    ----------
+    run_type : RunType
+        Type of the run.
+    definition_id : str, optional
+        ID of the definition for the run type. Defaults to None.
+    reference_id : str, optional
+        ID of the reference for the run type. Defaults to None.
+
+    Examples
+    --------
+    >>> from nextmv import RunTypeConfiguration, RunType
+    >>> config = RunTypeConfiguration(run_type=RunType.STANDARD)
+    >>> config.run_type
+    <RunType.STANDARD: 'standard'>
+    >>> config.definition_id is None
+    True
+
+    >>> # External run with reference
+    >>> external_config = RunTypeConfiguration(
+    ...     run_type=RunType.EXTERNAL,
+    ...     reference_id="ref-12345"
+    ... )
+    >>> external_config.run_type
+    <RunType.EXTERNAL: 'external'>
+    >>> external_config.reference_id
+    'ref-12345'
+
+    >>> # Ensemble run with definition
+    >>> ensemble_config = RunTypeConfiguration(
+    ...     run_type=RunType.ENSEMBLE,
+    ...     definition_id="def-67890"
+    ... )
+    >>> ensemble_config.run_type
+    <RunType.ENSEMBLE: 'ensemble'>
+    >>> ensemble_config.definition_id
+    'def-67890'
+    """
+
+    run_type: Optional[RunType] = Field(
+        serialization_alias="type",
+        validation_alias=AliasChoices("type", "run_type"),
+        default=None,
+    )
+    """Type of the run."""
+    definition_id: Optional[str] = None
+    """ID of the definition for the run type."""
+    reference_id: Optional[str] = None
+    """ID of the reference for the run type."""
+
+    @field_validator("run_type", mode="before")
+    @classmethod
+    def validate_run_type(cls, v):
+        """Convert empty string to None for run_type validation."""
+        if v == "":
+            return None
+        return v
+
+
+class StatisticsIndicator(BaseModel):
+    """
+    Statistics indicator of a run.
+
+    You can import the `StatisticsIndicator` class directly from `nextmv`:
+
+    ```python
+    from nextmv import StatisticsIndicator
+    ```
+
+    Parameters
+    ----------
+    name : str
+        Name of the indicator.
+    value : Any
+        Value of the indicator.
+
+    Examples
+    --------
+    >>> from nextmv import StatisticsIndicator
+    >>> indicator = StatisticsIndicator(name="total_cost", value=1250.75)
+    >>> indicator.name
+    'total_cost'
+    >>> indicator.value
+    1250.75
+
+    >>> # Boolean indicator
+    >>> bool_indicator = StatisticsIndicator(name="optimal", value=True)
+    >>> bool_indicator.name
+    'optimal'
+    >>> bool_indicator.value
+    True
+    """
+
+    name: str
+    """Name of the indicator."""
+    value: Any
+    """Value of the indicator."""
+
+
+class RunInfoStatistics(BaseModel):
+    """
+    Statistics information for a run.
+
+    You can import the `RunInfoStatistics` class directly from `nextmv`:
+
+    ```python
+    from nextmv import RunInfoStatistics
+    ```
+
+    Parameters
+    ----------
+    status : str
+        Status of the statistics in the run.
+    error : str, optional
+        Error message if the statistics could not be retrieved. Defaults to None.
+    indicators : list[StatisticsIndicator], optional
+        List of statistics indicators. Defaults to None.
+
+    Examples
+    --------
+    >>> from nextmv import RunInfoStatistics, StatisticsIndicator
+    >>> indicators = [
+    ...     StatisticsIndicator(name="total_cost", value=1250.75),
+    ...     StatisticsIndicator(name="optimal", value=True)
+    ... ]
+    >>> stats = RunInfoStatistics(status="success", indicators=indicators)
+    >>> stats.status
+    'success'
+    >>> len(stats.indicators)
+    2
+
+    >>> # Statistics with error
+    >>> error_stats = RunInfoStatistics(
+    ...     status="error",
+    ...     error="Failed to calculate statistics"
+    ... )
+    >>> error_stats.status
+    'error'
+    >>> error_stats.error
+    'Failed to calculate statistics'
+    """
+
+    status: str
+    """Status of the statistics in the run."""
+
+    error: Optional[str] = None
+    """Error message if the statistics could not be retrieved."""
+    indicators: Optional[list[StatisticsIndicator]] = None
+    """List of statistics indicators."""
+
+
+class OptionsSummaryItem(BaseModel):
+    """
+    Summary item for options used in a run.
+
+    You can import the `OptionsSummaryItem` class directly from `nextmv`:
+
+    ```python
+    from nextmv import OptionsSummaryItem
+    ```
+
+    Parameters
+    ----------
+    name : str
+        Name of the option.
+    value : Any
+        Value of the option.
+    source : str
+        Source of the option.
+
+    Examples
+    --------
+    >>> from nextmv import OptionsSummaryItem
+    >>> option = OptionsSummaryItem(
+    ...     name="time_limit",
+    ...     value=30,
+    ...     source="config"
+    ... )
+    >>> option.name
+    'time_limit'
+    >>> option.value
+    30
+    >>> option.source
+    'config'
+
+    >>> # Option from environment variable
+    >>> env_option = OptionsSummaryItem(
+    ...     name="solver_type",
+    ...     value="gurobi",
+    ...     source="environment"
+    ... )
+    >>> env_option.source
+    'environment'
+    """
+
+    name: str
+    """Name of the option."""
+    value: Any
+    """Value of the option."""
+    source: str
+    """Source of the option."""
+
+
+class Run(BaseModel):
+    """
+    Information about a run in the Nextmv platform.
+
+    You can import the `Run` class directly from `nextmv`:
+
+    ```python
+    from nextmv import Run
+    ```
+
+    Parameters
+    ----------
+    id : str
+        ID of the run.
+    user_email : str
+        Email of the user who initiated the run.
+    name : str
+        Name of the run.
+    description : str
+        Description of the run.
+    created_at : datetime
+        Timestamp when the run was created.
+    application_id : str
+        ID of the application associated with the run.
+    application_instance_id : str
+        ID of the application instance associated with the run.
+    application_version_id : str
+        ID of the application version associated with the run.
+    run_type : RunTypeConfiguration
+        Configuration for the type of the run.
+    execution_class : str
+        Class name for the execution of a job.
+    runtime : str
+        Runtime environment for the run.
+    status : Status
+        Deprecated, use status_v2 instead.
+    status_v2 : StatusV2
+        Status of the run.
+    queuing_priority : int, optional
+        Priority of the run in the queue. Defaults to None.
+    queuing_disabled : bool, optional
+        Whether the run is disabled from queuing. Defaults to None.
+    experiment_id : str, optional
+        ID of the experiment associated with the run. Defaults to None.
+    statistics : RunInfoStatistics, optional
+        Statistics of the run. Defaults to None.
+    input_id : str, optional
+        ID of the input associated with the run. Defaults to None.
+    option_set : str, optional
+        ID of the option set associated with the run. Defaults to None.
+    options : dict[str, str], optional
+        Options associated with the run. Defaults to None.
+    request_options : dict[str, str], optional
+        Request options associated with the run. Defaults to None.
+    options_summary : list[OptionsSummaryItem], optional
+        Summary of options used in the run. Defaults to None.
+    scenario_id : str, optional
+        ID of the scenario associated with the run. Defaults to None.
+    repetition : int, optional
+        Repetition number of the run. Defaults to None.
+    input_set_id : str, optional
+        ID of the input set associated with the run. Defaults to None.
+
+    Examples
+    --------
+    >>> from nextmv import Run, RunTypeConfiguration, RunType, StatusV2
+    >>> from datetime import datetime
+    >>> run = Run(
+    ...     id="run-12345",
+    ...     user_email="user@example.com",
+    ...     name="Test Run",
+    ...     description="A test optimization run",
+    ...     created_at=datetime.now(),
+    ...     application_id="app-123",
+    ...     application_instance_id="instance-456",
+    ...     application_version_id="version-789",
+    ...     run_type=RunTypeConfiguration(run_type=RunType.STANDARD),
+    ...     execution_class="small",
+    ...     runtime="python",
+    ...     status_v2=StatusV2.SUCCEEDED
+    ... )
+    >>> run.id
+    'run-12345'
+    >>> run.name
+    'Test Run'
+    """
+
+    id: str
+    """ID of the run."""
+    user_email: str
+    """Email of the user who initiated the run."""
+    name: str
+    """Name of the run."""
+    description: str
+    """Description of the run."""
+    created_at: datetime
+    """Timestamp when the run was created."""
+    application_id: str
+    """ID of the application associated with the run."""
+    application_instance_id: str
+    """ID of the application instance associated with the run."""
+    application_version_id: str
+    """ID of the application version associated with the run."""
+    run_type: RunTypeConfiguration
+    """Configuration for the type of the run."""
+    execution_class: str
+    """Class name for the execution of a job."""
+    runtime: str
+    """Runtime environment for the run."""
+    status: Status
+    """Deprecated, use status_v2 instead."""
+    status_v2: StatusV2
+    """Status of the run."""
+
+    queuing_priority: Optional[int] = None
+    """Priority of the run in the queue."""
+    queuing_disabled: Optional[bool] = None
+    """Whether the run is disabled from queuing."""
+    experiment_id: Optional[str] = None
+    """ID of the experiment associated with the run."""
+    statistics: Optional[RunInfoStatistics] = None
+    """Statistics of the run."""
+    input_id: Optional[str] = None
+    """ID of the input associated with the run."""
+    option_set: Optional[str] = None
+    """ID of the option set associated with the run."""
+    options: Optional[dict[str, str]] = None
+    """Options associated with the run."""
+    request_options: Optional[dict[str, str]] = None
+    """Request options associated with the run."""
+    options_summary: Optional[list[OptionsSummaryItem]] = None
+    """Summary of options used in the run."""
+    scenario_id: Optional[str] = None
+    """ID of the scenario associated with the run."""
+    repetition: Optional[int] = None
+    """Repetition number of the run."""
+    input_set_id: Optional[str] = None
+    """ID of the input set associated with the run."""
+
+
 class Metadata(BaseModel):
     """
     Metadata of a run, whether it was successful or not.
@@ -342,6 +742,81 @@ class RunInformation(BaseModel):
     has not been synced yet.
     """
 
+    def to_run(self) -> Run:
+        """
+        Transform this `RunInformation` instance into a `Run` instance.
+
+        This method maps all available attributes from the `RunInformation`
+        and its metadata to create a `Run` instance. Attributes that are not
+        available in RunInformation are set to None or appropriate defaults.
+
+        Returns
+        -------
+        Run
+            A Run instance with attributes populated from this RunInformation.
+
+        Examples
+        --------
+        >>> from nextmv import RunInformation, Metadata, Format, FormatInput, FormatOutput
+        >>> from nextmv import StatusV2, RunTypeConfiguration, RunType
+        >>> from datetime import datetime
+        >>> metadata = Metadata(
+        ...     application_id="app-123",
+        ...     application_instance_id="instance-456",
+        ...     application_version_id="version-789",
+        ...     created_at=datetime.now(),
+        ...     duration=5000.0,
+        ...     error="",
+        ...     input_size=1024.0,
+        ...     output_size=2048.0,
+        ...     format=Format(
+        ...         format_input=FormatInput(),
+        ...         format_output=FormatOutput()
+        ...     ),
+        ...     status_v2=StatusV2.SUCCEEDED
+        ... )
+        >>> run_info = RunInformation(
+        ...     id="run-123",
+        ...     description="Test run",
+        ...     name="Test",
+        ...     user_email="user@example.com",
+        ...     metadata=metadata
+        ... )
+        >>> run = run_info.to_run()
+        >>> run.id
+        'run-123'
+        >>> run.application_id
+        'app-123'
+        """
+        return Run(
+            id=self.id,
+            user_email=self.user_email,
+            name=self.name,
+            description=self.description,
+            created_at=self.metadata.created_at,
+            application_id=self.metadata.application_id,
+            application_instance_id=self.metadata.application_instance_id,
+            application_version_id=self.metadata.application_version_id,
+            run_type=RunTypeConfiguration(),  # Default empty configuration
+            execution_class="",  # Not available in RunInformation
+            runtime="",  # Not available in RunInformation
+            status=self.metadata.status,
+            status_v2=self.metadata.status_v2,
+            # Optional fields that are not available in RunInformation
+            queuing_priority=None,
+            queuing_disabled=None,
+            experiment_id=None,
+            statistics=None,
+            input_id=None,
+            option_set=None,
+            options=None,
+            request_options=None,
+            options_summary=None,
+            scenario_id=None,
+            repetition=None,
+            input_set_id=None,
+        )
+
 
 class ErrorLog(BaseModel):
     """
@@ -427,113 +902,6 @@ class RunLog(BaseModel):
 
     log: str
     """Log of the run."""
-
-
-class RunType(str, Enum):
-    """
-    The actual type of the run.
-
-    You can import the `RunType` class directly from `nextmv`:
-
-    ```python
-    from nextmv import RunType
-    ```
-
-    Parameters
-    ----------
-    STANDARD : str
-        Standard run type.
-    EXTERNAL : str
-        External run type.
-    ENSEMBLE : str
-        Ensemble run type.
-
-    Examples
-    --------
-    >>> from nextmv import RunType
-    >>> run_type = RunType.STANDARD
-    >>> run_type
-    <RunType.STANDARD: 'standard'>
-    >>> run_type.value
-    'standard'
-
-    >>> # Creating from string
-    >>> external_type = RunType("external")
-    >>> external_type
-    <RunType.EXTERNAL: 'external'>
-
-    >>> # All available types
-    >>> list(RunType)
-    [<RunType.STANDARD: 'standard'>, <RunType.EXTERNAL: 'external'>, <RunType.ENSEMBLE: 'ensemble'>]
-    """
-
-    STANDARD = "standard"
-    """Standard run type."""
-    EXTERNAL = "external"
-    """External run type."""
-    ENSEMBLE = "ensemble"
-    """Ensemble run type."""
-
-
-class RunTypeConfiguration(BaseModel):
-    """
-    Defines the configuration for the type of the run that is being executed
-    on an application.
-
-    You can import the `RunTypeConfiguration` class directly from `nextmv`:
-
-    ```python
-    from nextmv import RunTypeConfiguration
-    ```
-
-    Parameters
-    ----------
-    run_type : RunType
-        Type of the run.
-    definition_id : str, optional
-        ID of the definition for the run type. Defaults to None.
-    reference_id : str, optional
-        ID of the reference for the run type. Defaults to None.
-
-    Examples
-    --------
-    >>> from nextmv import RunTypeConfiguration, RunType
-    >>> config = RunTypeConfiguration(run_type=RunType.STANDARD)
-    >>> config.run_type
-    <RunType.STANDARD: 'standard'>
-    >>> config.definition_id is None
-    True
-
-    >>> # External run with reference
-    >>> external_config = RunTypeConfiguration(
-    ...     run_type=RunType.EXTERNAL,
-    ...     reference_id="ref-12345"
-    ... )
-    >>> external_config.run_type
-    <RunType.EXTERNAL: 'external'>
-    >>> external_config.reference_id
-    'ref-12345'
-
-    >>> # Ensemble run with definition
-    >>> ensemble_config = RunTypeConfiguration(
-    ...     run_type=RunType.ENSEMBLE,
-    ...     definition_id="def-67890"
-    ... )
-    >>> ensemble_config.run_type
-    <RunType.ENSEMBLE: 'ensemble'>
-    >>> ensemble_config.definition_id
-    'def-67890'
-    """
-
-    run_type: RunType = Field(
-        serialization_alias="type",
-        validation_alias=AliasChoices("type", "run_type"),
-    )
-    """Type of the run."""
-    definition_id: Optional[str] = None
-    """ID of the definition for the run type."""
-    reference_id: Optional[str] = None
-    """ID of the reference for the run type."""
 
 
 class RunQueuing(BaseModel):

--- a/nextmv/tests/local/test_application.py
+++ b/nextmv/tests/local/test_application.py
@@ -8,6 +8,7 @@ from unittest.mock import Mock, patch
 import yaml
 from nextmv.input import Input, InputFormat
 from nextmv.local.application import Application
+from nextmv.local.local import NEXTMV_DIR, RUNS_KEY
 from nextmv.options import Options
 from nextmv.output import OutputFormat
 from nextmv.polling import DEFAULT_POLLING_OPTIONS, PollingOptions
@@ -378,7 +379,7 @@ class TestApplicationLocalRunMethods(unittest.TestCase):
         os.makedirs(self.app_src)
 
         # Create .nextmv/runs directory structure
-        self.runs_dir = os.path.join(self.app_src, ".nextmv", "runs")
+        self.runs_dir = os.path.join(self.app_src, NEXTMV_DIR, RUNS_KEY)
         os.makedirs(self.runs_dir)
 
         # Create test application

--- a/nextmv/tests/local/test_executor.py
+++ b/nextmv/tests/local/test_executor.py
@@ -10,10 +10,6 @@ import unittest
 from unittest.mock import Mock, patch
 
 from nextmv.local.executor import (
-    ASSETS_KEY,
-    OUTPUTS_KEY,
-    SOLUTIONS_KEY,
-    STATISTICS_KEY,
     execute_run,
     main,
     options_args,
@@ -25,7 +21,7 @@ from nextmv.local.executor import (
     process_run_statistics,
 )
 from nextmv.manifest import Manifest
-from nextmv.output import OutputFormat
+from nextmv.output import ASSETS_KEY, OUTPUTS_KEY, SOLUTIONS_KEY, STATISTICS_KEY, OutputFormat
 
 
 class TestLocalExecutor(unittest.TestCase):

--- a/nextmv/tests/local/test_runner.py
+++ b/nextmv/tests/local/test_runner.py
@@ -10,6 +10,7 @@ import tempfile
 import unittest
 from unittest.mock import Mock, patch
 
+from nextmv.local.local import NEXTMV_DIR, RUNS_KEY
 from nextmv.local.runner import new_run, record_input, run
 from nextmv.manifest import Manifest, ManifestRuntime
 
@@ -70,7 +71,7 @@ print(json.dumps(output))
 
         result_dir = new_run(app_id="sample-app", src=self.test_src, run_id=run_id, run_config=run_config)
 
-        expected_dir = os.path.join(self.test_src, ".nextmv", "runs", run_id)
+        expected_dir = os.path.join(self.test_src, NEXTMV_DIR, RUNS_KEY, run_id)
         self.assertEqual(result_dir, expected_dir)
         self.assertTrue(os.path.exists(expected_dir))
         self.assertTrue(os.path.isdir(expected_dir))
@@ -81,7 +82,7 @@ print(json.dumps(output))
         run_config = {"format": {"input": {"type": "json"}, "output": {"type": "json"}}}
 
         # Ensure .nextmv/runs doesn't exist
-        runs_dir = os.path.join(self.test_src, ".nextmv", "runs")
+        runs_dir = os.path.join(self.test_src, NEXTMV_DIR, RUNS_KEY)
         self.assertFalse(os.path.exists(runs_dir))
 
         result_dir = new_run(app_id="sample-app", src=self.test_src, run_id=run_id, run_config=run_config)

--- a/nextmv/tests/test_run.py
+++ b/nextmv/tests/test_run.py
@@ -2,7 +2,17 @@ import datetime
 import time
 import unittest
 
-from nextmv.run import run_duration
+from nextmv.run import (
+    Format,
+    FormatInput,
+    FormatOutput,
+    Metadata,
+    Run,
+    RunInformation,
+    RunTypeConfiguration,
+    run_duration,
+)
+from nextmv.status import Status, StatusV2
 
 
 class TestRunDuration(unittest.TestCase):
@@ -16,3 +26,183 @@ class TestRunDuration(unittest.TestCase):
         self.assertAlmostEqual(duration_dt, 250.0, delta=1.0)
         self.assertIsInstance(duration_t, int)
         self.assertIsInstance(duration_dt, int)
+
+
+class TestRunInformationToRun(unittest.TestCase):
+    def setUp(self):
+        """Set up test data for RunInformation to_run() tests."""
+        self.created_at = datetime.datetime(2023, 10, 15, 14, 30, 0)
+
+        # Create a complete metadata object
+        self.metadata = Metadata(
+            application_id="app-12345",
+            application_instance_id="instance-67890",
+            application_version_id="version-11111",
+            created_at=self.created_at,
+            duration=5000.0,
+            error="",
+            input_size=1024.0,
+            output_size=2048.0,
+            format=Format(format_input=FormatInput(), format_output=FormatOutput()),
+            status_v2=StatusV2.succeeded,
+            status=Status.succeeded,
+        )
+
+        # Create a RunInformation instance
+        self.run_info = RunInformation(
+            id="run-98765",
+            description="Test optimization run",
+            name="Test Run",
+            user_email="test@example.com",
+            metadata=self.metadata,
+            console_url="https://console.nextmv.io/run/run-98765",
+            synced_run_id="synced-12345",
+            synced_at=datetime.datetime(2023, 10, 15, 15, 0, 0),
+        )
+
+    def test_to_run_basic_transformation(self):
+        """Test basic transformation from RunInformation to Run."""
+        run = self.run_info.to_run()
+
+        # Test that the result is a Run instance
+        self.assertIsInstance(run, Run)
+
+        # Test direct mappings from RunInformation
+        self.assertEqual(run.id, self.run_info.id)
+        self.assertEqual(run.user_email, self.run_info.user_email)
+        self.assertEqual(run.name, self.run_info.name)
+        self.assertEqual(run.description, self.run_info.description)
+
+        # Test mappings from metadata
+        self.assertEqual(run.created_at, self.metadata.created_at)
+        self.assertEqual(run.application_id, self.metadata.application_id)
+        self.assertEqual(run.application_instance_id, self.metadata.application_instance_id)
+        self.assertEqual(run.application_version_id, self.metadata.application_version_id)
+        self.assertEqual(run.status, self.metadata.status)
+        self.assertEqual(run.status_v2, self.metadata.status_v2)
+
+    def test_to_run_default_values(self):
+        """Test that unavailable attributes are set to appropriate defaults."""
+        run = self.run_info.to_run()
+
+        # Test default RunTypeConfiguration
+        self.assertIsInstance(run.run_type, RunTypeConfiguration)
+        self.assertIsNone(run.run_type.run_type)
+        self.assertIsNone(run.run_type.definition_id)
+        self.assertIsNone(run.run_type.reference_id)
+
+        # Test empty string defaults
+        self.assertEqual(run.execution_class, "")
+        self.assertEqual(run.runtime, "")
+
+        # Test None defaults for optional fields
+        self.assertIsNone(run.queuing_priority)
+        self.assertIsNone(run.queuing_disabled)
+        self.assertIsNone(run.experiment_id)
+        self.assertIsNone(run.statistics)
+        self.assertIsNone(run.input_id)
+        self.assertIsNone(run.option_set)
+        self.assertIsNone(run.options)
+        self.assertIsNone(run.request_options)
+        self.assertIsNone(run.options_summary)
+        self.assertIsNone(run.scenario_id)
+        self.assertIsNone(run.repetition)
+        self.assertIsNone(run.input_set_id)
+
+    def test_to_run_with_minimal_metadata(self):
+        """Test transformation with minimal metadata (only status without deprecated status)."""
+        minimal_metadata = Metadata(
+            application_id="app-minimal",
+            application_instance_id="instance-minimal",
+            application_version_id="version-minimal",
+            created_at=self.created_at,
+            duration=1000.0,
+            error="Test error",
+            input_size=512.0,
+            output_size=1024.0,
+            format=Format(format_input=FormatInput(), format_output=FormatOutput()),
+            status_v2=StatusV2.failed,
+            status=Status.failed,  # Add required status field
+        )
+
+        run_info_minimal = RunInformation(
+            id="run-minimal",
+            description="Minimal test",
+            name="Minimal",
+            user_email="minimal@example.com",
+            metadata=minimal_metadata,
+        )
+
+        run = run_info_minimal.to_run()
+
+        # Test that transformation works with minimal data
+        self.assertEqual(run.id, "run-minimal")
+        self.assertEqual(run.application_id, "app-minimal")
+        self.assertEqual(run.status_v2, StatusV2.failed)
+        self.assertEqual(run.status, Status.failed)  # Status is now provided
+
+    def test_to_run_preserves_datetime_objects(self):
+        """Test that datetime objects are properly preserved during transformation."""
+        run = self.run_info.to_run()
+
+        # Test that datetime objects are preserved and are the same instance
+        self.assertIs(run.created_at, self.metadata.created_at)
+        self.assertEqual(run.created_at, self.created_at)
+        self.assertIsInstance(run.created_at, datetime.datetime)
+
+    def test_to_run_multiple_transformations(self):
+        """Test that multiple transformations from the same RunInformation work correctly."""
+        run1 = self.run_info.to_run()
+        run2 = self.run_info.to_run()
+
+        # Test that both transformations produce equivalent results
+        self.assertEqual(run1.id, run2.id)
+        self.assertEqual(run1.user_email, run2.user_email)
+        self.assertEqual(run1.name, run2.name)
+        self.assertEqual(run1.description, run2.description)
+        self.assertEqual(run1.created_at, run2.created_at)
+        self.assertEqual(run1.application_id, run2.application_id)
+        self.assertEqual(run1.status_v2, run2.status_v2)
+
+        # Test that they are different instances
+        self.assertIsNot(run1, run2)
+        self.assertIsNot(run1.run_type, run2.run_type)
+
+    def test_to_run_with_different_status_values(self):
+        """Test transformation with different status values."""
+        # Test with different StatusV2 values
+        status_values = [StatusV2.succeeded, StatusV2.failed, StatusV2.running, StatusV2.queued]
+
+        for status_v2 in status_values:
+            with self.subTest(status_v2=status_v2):
+                # Map StatusV2 to Status for compatibility
+                status_mapping = {
+                    StatusV2.succeeded: Status.succeeded,
+                    StatusV2.failed: Status.failed,
+                    StatusV2.running: Status.running,
+                    StatusV2.queued: Status.running,  # Map queued to running since Status doesn't have queued
+                }
+                metadata = Metadata(
+                    application_id="app-test",
+                    application_instance_id="instance-test",
+                    application_version_id="version-test",
+                    created_at=self.created_at,
+                    duration=2000.0,
+                    error="",
+                    input_size=256.0,
+                    output_size=512.0,
+                    format=Format(format_input=FormatInput(), format_output=FormatOutput()),
+                    status_v2=status_v2,
+                    status=status_mapping[status_v2],
+                )
+
+                run_info = RunInformation(
+                    id=f"run-{status_v2.value}",
+                    description=f"Test with {status_v2.value}",
+                    name="Status Test",
+                    user_email="status@example.com",
+                    metadata=metadata,
+                )
+
+                run = run_info.to_run()
+                self.assertEqual(run.status_v2, status_v2)


### PR DESCRIPTION
# Description

When using the `batch_experiment` methods to retrieve the results of a batch experiment, a new `runs` property was added to `BatchExperiment`, to access the runs of that batch exp. Behind the covers, the separate `/runs` endpoint is used.

Because a new `Run` class was introduced to capture the information about a run, iI took the chance to introduce the `list_runs` method, which uses that exact class. This method is added to both applications: in `cloud` and `local`.