### PR TITLE
Moves to macos-15-intel for deprecated macos-13 runner

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -7,7 +7,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
-        platform: [ubuntu-latest, windows-latest, macos-latest, macos-13]
+        platform: [ubuntu-latest, windows-latest, macos-latest, macos-15-intel]
         package: ["nextmv", "nextmv-gurobipy", "nextmv-scikit-learn"]
     steps:
       - name: git clone


### PR DESCRIPTION
# Description

Moves the test workflow to the newer `macos-15-intel` runner to get away from the deprecated `macos-13` runner. This is our runner for testing on darwin x64.

## Changes

- Move workflow to `macos-15-intel` (replacing `macos-13`).

Resolves ENG-6627