### PR TITLE
Supports Python apps targeting amd64 platform or custom Python version

### DIFF
--- a/nextmv/nextmv/__init__.py
+++ b/nextmv/nextmv/__init__.py
@@ -21,6 +21,7 @@ from .manifest import Manifest as Manifest
 from .manifest import ManifestBuild as ManifestBuild
 from .manifest import ManifestOption as ManifestOption
 from .manifest import ManifestPython as ManifestPython
+from .manifest import ManifestPythonArch as ManifestPythonArch
 from .manifest import ManifestPythonModel as ManifestPythonModel
 from .manifest import ManifestRuntime as ManifestRuntime
 from .manifest import ManifestType as ManifestType

--- a/nextmv/nextmv/cloud/package.py
+++ b/nextmv/nextmv/cloud/package.py
@@ -222,7 +222,7 @@ def __handle_python(
     __install_dependencies(manifest, app_dir, temp_dir)
 
 
-def __install_dependencies(
+def __install_dependencies(  # noqa: C901 # complexity
     manifest: Manifest,
     app_dir: str,
     temp_dir: str,

--- a/nextmv/nextmv/cloud/package.py
+++ b/nextmv/nextmv/cloud/package.py
@@ -411,7 +411,7 @@ def __confirm_python_version(output: str) -> None:
 def __confirm_python_bundling_version(version: str) -> None:
     # Only accept versions in the form "major.minor" where both are integers
     re_version = re.compile(r"^(\d+)\.(\d+)$")
-    match = re_version.match(version)
+    match = re_version.fullmatch(version)
     if match:
         major, minor = int(match.group(1)), int(match.group(2))
         if major == 3 and minor >= 9:

--- a/nextmv/nextmv/cloud/package.py
+++ b/nextmv/nextmv/cloud/package.py
@@ -253,6 +253,30 @@ def __install_dependencies(
         if not os.path.isfile(os.path.join(app_dir, pip_requirements)):
             raise FileNotFoundError(f"pip requirements file '{pip_requirements}' not found in '{app_dir}'")
 
+    platform_filter = []
+    if not manifest.python.arch or manifest.python.arch == "arm64":
+        platform_filter.extend(
+            [
+                "--platform=manylinux2014_aarch64",
+                "--platform=manylinux_2_17_aarch64",
+                "--platform=manylinux_2_24_aarch64",
+                "--platform=manylinux_2_28_aarch64",
+                "--platform=linux_aarch64",
+            ]
+        )
+    elif manifest.python.arch == "amd64":
+        platform_filter.extend(
+            [
+                "--platform=manylinux2014_x86_64",
+                "--platform=manylinux_2_17_x86_64",
+                "--platform=manylinux_2_24_x86_64",
+                "--platform=manylinux_2_28_x86_64",
+                "--platform=linux_x86_64",
+            ]
+        )
+    else:
+        raise Exception(f"unknown architecture '{manifest.python.arch}' specified in manifest")
+
     py_cmd = __get_python_command()
     dep_dir = os.path.join(".nextmv", "python", "deps")
     command = [
@@ -262,11 +286,6 @@ def __install_dependencies(
         "install",
         "-r",
         pip_requirements,
-        "--platform=manylinux2014_aarch64",
-        "--platform=manylinux_2_17_aarch64",
-        "--platform=manylinux_2_24_aarch64",
-        "--platform=manylinux_2_28_aarch64",
-        "--platform=linux_aarch64",
         "--only-binary=:all:",
         "--python-version=3.11",
         "--implementation=cp",
@@ -277,7 +296,7 @@ def __install_dependencies(
         "--no-user",  # We explicitly avoid user mode (mainly to fix issues with Windows store Python installations)
         "--no-input",
         "--quiet",
-    ]
+    ] + platform_filter
     result = subprocess.run(
         command,
         cwd=app_dir,

--- a/nextmv/nextmv/cloud/package.py
+++ b/nextmv/nextmv/cloud/package.py
@@ -277,26 +277,34 @@ def __install_dependencies(
     else:
         raise Exception(f"unknown architecture '{manifest.python.arch}' specified in manifest")
 
+    version_filter = ["--python-version=3.11"]
+    if manifest.python.version:
+        __confirm_python_bundling_version(manifest.python.version)
+        version_filter = [f"--python-version={manifest.python.version}"]
+
     py_cmd = __get_python_command()
     dep_dir = os.path.join(".nextmv", "python", "deps")
-    command = [
-        py_cmd,
-        "-m",
-        "pip",
-        "install",
-        "-r",
-        pip_requirements,
-        "--only-binary=:all:",
-        "--python-version=3.11",
-        "--implementation=cp",
-        "--upgrade",
-        "--no-warn-conflicts",
-        "--target",
-        os.path.join(temp_dir, dep_dir),
-        "--no-user",  # We explicitly avoid user mode (mainly to fix issues with Windows store Python installations)
-        "--no-input",
-        "--quiet",
-    ] + platform_filter
+    command = (
+        [
+            py_cmd,
+            "-m",
+            "pip",
+            "install",
+            "-r",
+            pip_requirements,
+            "--only-binary=:all:",
+            "--implementation=cp",
+            "--upgrade",
+            "--no-warn-conflicts",
+            "--target",
+            os.path.join(temp_dir, dep_dir),
+            "--no-user",  # We explicitly avoid user mode (mainly to fix issues with Windows store Python installations)
+            "--no-input",
+            "--quiet",
+        ]
+        + platform_filter
+        + version_filter
+    )
     result = subprocess.run(
         command,
         cwd=app_dir,
@@ -398,6 +406,20 @@ def __confirm_python_version(output: str) -> None:
             return
 
     raise Exception("python version 3.9 or higher is required")
+
+
+def __confirm_python_bundling_version(version: str) -> None:
+    re_version = re.compile(r"\d+\.\d+")
+    if re_version.match(version):
+        try:
+            major, minor = map(int, version.split("."))
+        except ValueError:
+            (major,) = map(int, version.split("."))
+
+        if major == 3 and minor >= 9:
+            return
+
+    raise Exception(f"python version 3.9 or higher is required for bundling, got {version}")
 
 
 def __compress_tar(source: str, target: str) -> tuple[str, int]:

--- a/nextmv/nextmv/cloud/package.py
+++ b/nextmv/nextmv/cloud/package.py
@@ -409,16 +409,13 @@ def __confirm_python_version(output: str) -> None:
 
 
 def __confirm_python_bundling_version(version: str) -> None:
-    re_version = re.compile(r"\d+\.\d+")
-    if re_version.match(version):
-        try:
-            major, minor = map(int, version.split("."))
-        except ValueError:
-            (major,) = map(int, version.split("."))
-
+    # Only accept versions in the form "major.minor" where both are integers
+    re_version = re.compile(r"^(\d+)\.(\d+)$")
+    match = re_version.match(version)
+    if match:
+        major, minor = int(match.group(1)), int(match.group(2))
         if major == 3 and minor >= 9:
             return
-
     raise Exception(f"python version 3.9 or higher is required for bundling, got {version}")
 
 

--- a/nextmv/nextmv/manifest.py
+++ b/nextmv/nextmv/manifest.py
@@ -172,6 +172,39 @@ class ManifestRuntime(str, Enum):
     """
 
 
+class ManifestPythonArch(str, Enum):
+    """
+    Target architecture for bundling Python apps.
+
+    You can import the `ManifestPythonArch` class directly from `nextmv`:
+
+    ```python
+    from nextmv import ManifestPythonArch
+    ```
+
+    Attributes
+    ----------
+    ARM64 : str
+        ARM 64-bit architecture.
+    AMD64 : str
+        AMD 64-bit architecture.
+
+    Examples
+    --------
+    >>> from nextmv import ManifestPythonArch
+    >>> arch = ManifestPythonArch.ARM64
+    >>> arch
+    <ManifestPythonArch.ARM64: 'arm64'>
+    >>> str(arch)
+    'arm64'
+    """
+
+    ARM64 = "arm64"
+    """ARM 64-bit architecture."""
+    AMD64 = "amd64"
+    """AMD 64-bit architecture."""
+
+
 class ManifestBuild(BaseModel):
     """
     Build-specific attributes.
@@ -329,7 +362,7 @@ class ManifestPython(BaseModel):
     Contains (additional) Python dependencies that will be bundled with the
     app.
     """
-    arch: Optional[str] = None
+    arch: Optional[ManifestPythonArch] = None
     """The architecture this model is meant to run on. One of "arm64" or "amd64". Uses
     "arm64" if not specified."""
     version: Optional[Union[str, float]] = None

--- a/nextmv/nextmv/manifest.py
+++ b/nextmv/nextmv/manifest.py
@@ -166,6 +166,10 @@ class ManifestRuntime(str, Enum):
     Based on the python runtime, it provisions (pre-installs) the Hexaly solver
     to run Python applications.
     """
+    CUOPT = "ghcr.io/nextmv-io/runtime/cuopt:latest"
+    """
+    A runtime providing the NVIDIA cuOpt solver.
+    """
 
 
 class ManifestBuild(BaseModel):

--- a/nextmv/nextmv/manifest.py
+++ b/nextmv/nextmv/manifest.py
@@ -328,6 +328,9 @@ class ManifestPython(BaseModel):
     arch: Optional[str] = None
     """The architecture this model is meant to run on. One of "arm64" or "amd64". Uses
     "arm64" if not specified."""
+    version: Optional[str] = None
+    """The Python version this model is meant to run with. Uses "3.11" if not specified.
+    """
     model: Optional[ManifestPythonModel] = None
     """Information about an encoded decision model.
 

--- a/nextmv/nextmv/manifest.py
+++ b/nextmv/nextmv/manifest.py
@@ -49,7 +49,7 @@ from enum import Enum
 from typing import Any, Optional, Union
 
 import yaml
-from pydantic import AliasChoices, Field
+from pydantic import AliasChoices, Field, field_validator
 
 from nextmv.base_model import BaseModel
 from nextmv.input import InputFormat
@@ -332,7 +332,7 @@ class ManifestPython(BaseModel):
     arch: Optional[str] = None
     """The architecture this model is meant to run on. One of "arm64" or "amd64". Uses
     "arm64" if not specified."""
-    version: Optional[str] = None
+    version: Optional[Union[str, float]] = None
     """The Python version this model is meant to run with. Uses "3.11" if not specified.
     """
     model: Optional[ManifestPythonModel] = None
@@ -341,6 +341,17 @@ class ManifestPython(BaseModel):
     As handled via mlflow. This information is used to load the decision model
     from the app bundle.
     """
+
+    @field_validator("version", mode="before")
+    @classmethod
+    def validate_version(cls, v: Optional[Union[str, float]]) -> Optional[str]:
+        # We allow the version to be a float in the manifest for convenience, but we want
+        # to store it as a string internally.
+        if v is None:
+            return None
+        if isinstance(v, float):
+            return str(v)
+        return v
 
 
 class ManifestOptionUI(BaseModel):
@@ -1035,7 +1046,12 @@ class Manifest(BaseModel):
 
     def model_post_init(self, __context) -> None:
         if self.entrypoint is None:
-            if self.runtime in (ManifestRuntime.PYTHON, ManifestRuntime.HEXALY, ManifestRuntime.PYOMO):
+            if self.runtime in (
+                ManifestRuntime.PYTHON,
+                ManifestRuntime.HEXALY,
+                ManifestRuntime.PYOMO,
+                ManifestRuntime.CUOPT,
+            ):
                 self.entrypoint = "./main.py"
             elif self.runtime == ManifestRuntime.DEFAULT:
                 self.entrypoint = "./main"

--- a/nextmv/nextmv/manifest.py
+++ b/nextmv/nextmv/manifest.py
@@ -325,6 +325,9 @@ class ManifestPython(BaseModel):
     Contains (additional) Python dependencies that will be bundled with the
     app.
     """
+    arch: Optional[str] = None
+    """The architecture this model is meant to run on. One of "arm64" or "amd64". Uses
+    "arm64" if not specified."""
     model: Optional[ManifestPythonModel] = None
     """Information about an encoded decision model.
 

--- a/nextmv/tests/test_manifest.py
+++ b/nextmv/tests/test_manifest.py
@@ -10,6 +10,7 @@ from nextmv.manifest import (
     ManifestOptions,
     ManifestOptionUI,
     ManifestPython,
+    ManifestPythonArch,
     ManifestRuntime,
     ManifestType,
     ManifestValidation,
@@ -100,6 +101,8 @@ class TestManifest(unittest.TestCase):
     def test_manifest_python_from_dict(self):
         manifest_python_dict = {
             "pip-requirements": "foo_requirements.txt",
+            "version": 3.11,
+            "arch": "amd64",
             "model": {
                 "name": "foo_model",
             },
@@ -108,6 +111,8 @@ class TestManifest(unittest.TestCase):
         manifest_python = ManifestPython.from_dict(manifest_python_dict)
 
         self.assertEqual(manifest_python.pip_requirements, "foo_requirements.txt")
+        self.assertEqual(manifest_python.version, "3.11")
+        self.assertEqual(manifest_python.arch, ManifestPythonArch.AMD64)
         self.assertEqual(manifest_python.model.name, "foo_model")
 
     def test_manifest_python_direct_instantiation(self):


### PR DESCRIPTION
# Description

Adds support for `amd64` target platform / execution class for Python apps. I.e., when pushing an app that is meant to run on one of the new amd64 ECs, we need to bundle the wheels for that target platform as well.
Furthermore, it also lets the user specify the target Python version the app is meant to work with.

It is now possible to modify the target arch and Python version for a Python app in the manifest like this:

```yaml
type: python
runtime: ghcr.io/nextmv-io/runtime/python:3.11
files:
  - main.py
python:
  pip-requirements: requirements.txt
  arch: amd64  # <-- target arch; defaults to arm64 when omitted
  version: 3.12  # <-- target Python version defaults to 3.11 when omitted
```

## Changes

* Adds support for pushing Python apps for `amd64` execution classes.
* Adds support for pushing Python apps for custom Python versions.

Resolves ENG-6689