### PR TITLE
Fix local Python command

### DIFF
--- a/nextmv/nextmv/__about__.py
+++ b/nextmv/nextmv/__about__.py
@@ -1,1 +1,1 @@
-__version__ = "v0.32.0"
+__version__ = "v0.33.0.dev0"

--- a/nextmv/nextmv/local/executor.py
+++ b/nextmv/nextmv/local/executor.py
@@ -32,6 +32,7 @@ import json
 import os
 import shutil
 import subprocess
+import sys
 import tempfile
 from datetime import datetime, timezone
 from typing import Any, Optional, Union
@@ -143,7 +144,7 @@ def execute_run(
             # supporting a Python-first experience, so we are not summoning
             # applications that are not Python-based.
             entrypoint = os.path.join(temp_src, manifest.entrypoint)
-            args = ["python", entrypoint] + options_args(options)
+            args = [sys.executable, entrypoint] + options_args(options)
 
             result = subprocess.run(
                 args,

--- a/nextmv/tests/local/test_executor.py
+++ b/nextmv/tests/local/test_executor.py
@@ -5,6 +5,7 @@ Unit tests for the nextmv.local.executor module.
 import json
 import os
 import shutil
+import sys
 import tempfile
 import unittest
 from unittest.mock import Mock, patch
@@ -597,7 +598,7 @@ class TestLocalExecutor(unittest.TestCase):
         # Verify subprocess.run was called
         mock_subprocess_run.assert_called_once()
         call_args = mock_subprocess_run.call_args
-        self.assertEqual(call_args[0][0][:2], ["python", os.path.join(temp_src, "main.py")])
+        self.assertEqual(call_args[0][0][:2], [sys.executable, os.path.join(temp_src, "main.py")])
         self.assertIn("-duration", call_args[0][0])
         self.assertIn("10s", call_args[0][0])
 


### PR DESCRIPTION
Use the system's executable instead of the `python` cmd.