### PR TITLE
Enhance local multi-file experience & release v0.34.0

### DIFF
--- a/nextmv/nextmv/__about__.py
+++ b/nextmv/nextmv/__about__.py
@@ -1,1 +1,1 @@
-__version__ = "v0.34.0.dev1"
+__version__ = "v0.34.0.dev2"

--- a/nextmv/nextmv/__about__.py
+++ b/nextmv/nextmv/__about__.py
@@ -1,1 +1,1 @@
-__version__ = "v0.34.0.dev3"
+__version__ = "v0.34.0"

--- a/nextmv/nextmv/__about__.py
+++ b/nextmv/nextmv/__about__.py
@@ -1,1 +1,1 @@
-__version__ = "v0.33.0"
+__version__ = "v0.34.0.dev0"

--- a/nextmv/nextmv/__about__.py
+++ b/nextmv/nextmv/__about__.py
@@ -1,1 +1,1 @@
-__version__ = "v0.34.0.dev0"
+__version__ = "v0.34.0.dev1"

--- a/nextmv/nextmv/__about__.py
+++ b/nextmv/nextmv/__about__.py
@@ -1,1 +1,1 @@
-__version__ = "v0.34.0.dev2"
+__version__ = "v0.34.0.dev3"

--- a/nextmv/nextmv/__init__.py
+++ b/nextmv/nextmv/__init__.py
@@ -25,6 +25,7 @@ from .manifest import ManifestPythonArch as ManifestPythonArch
 from .manifest import ManifestPythonModel as ManifestPythonModel
 from .manifest import ManifestRuntime as ManifestRuntime
 from .manifest import ManifestType as ManifestType
+from .manifest import default_python_manifest as default_python_manifest
 from .model import Model as Model
 from .model import ModelConfiguration as ModelConfiguration
 from .options import Option as Option

--- a/nextmv/nextmv/local/application.py
+++ b/nextmv/nextmv/local/application.py
@@ -1045,7 +1045,7 @@ class Application:
         # Read the logs of the run and place each line as an element in a list
         run_dir = os.path.join(runs_dir, run_id)
         with open(os.path.join(run_dir, LOGS_KEY, LOGS_FILE)) as f:
-            stderr_logs = [line.rstrip("\n") for line in f.readlines()]
+            stderr_logs = f.read()
 
         # Create the tracked run object and start configuring it.
         tracked_run = TrackedRun(

--- a/nextmv/nextmv/local/application.py
+++ b/nextmv/nextmv/local/application.py
@@ -33,13 +33,14 @@ from nextmv.local.local import (
 )
 from nextmv.local.runner import run
 from nextmv.logger import log
-from nextmv.manifest import Manifest
+from nextmv.manifest import Manifest, default_python_manifest
 from nextmv.options import Options
 from nextmv.output import ASSETS_KEY, OUTPUTS_KEY, SOLUTIONS_KEY, STATISTICS_KEY, OutputFormat
 from nextmv.polling import DEFAULT_POLLING_OPTIONS, PollingOptions, poll
 from nextmv.run import (
     ErrorLog,
     Format,
+    FormatInput,
     Run,
     RunConfiguration,
     RunInformation,
@@ -93,6 +94,39 @@ class Application:
 
     description: Optional[str] = None
     """Description of the application."""
+    manifest: Optional[Manifest] = None
+    """
+    Manifest of the application. A manifest is a file named `app.yaml` that
+    must be present at the root of the application's `src` directory. If the
+    app is initialized, and a manifest is not present, a default Python
+    manifest will be created, using the `nextmv.default_python_manifest`
+    function. If you specify this argument, and a manifest file is already
+    present in the `src` directory, the provided manifest will override the
+    existing one.
+    """
+
+    def __post_init__(self):
+        """
+        Validate the presence of the manifest in the application.
+        """
+
+        if self.manifest is not None:
+            self.manifest.to_yaml(self.src)
+
+            return
+
+        try:
+            manifest = Manifest.from_yaml(self.src)
+            self.manifest = manifest
+
+            return
+
+        except Exception:
+            manifest = default_python_manifest()
+            self.manifest = manifest
+            manifest.to_yaml(self.src)
+
+            return
 
     @classmethod
     def initialize(
@@ -293,7 +327,7 @@ class Application:
         >>> print(f"Local run completed with ID: {run_id}")
         """
 
-        self.__validate_input_dir_path_and_configuration(input_dir_path, configuration)
+        configuration = self.__validate_input_dir_path_and_configuration(input_dir_path, configuration)
 
         if self.src is None:
             raise ValueError("`src` property for the `Application` must be specified to run the application locally")
@@ -853,7 +887,7 @@ class Application:
         self,
         input_dir_path: Optional[str],
         configuration: Optional[Union[RunConfiguration, dict[str, Any]]],
-    ) -> None:
+    ) -> RunConfiguration:
         """
         Auxiliary function to validate the directory path and configuration.
         """
@@ -862,60 +896,45 @@ class Application:
             return
 
         if configuration is None:
-            raise ValueError(
-                "If dir_path is provided, a RunConfiguration must also be provided.",
-            )
+            if self.manifest.configuration is not None and self.manifest.configuration.content is not None:
+                configuration = RunConfiguration(
+                    format=Format(
+                        format_input=FormatInput(
+                            input_type=self.manifest.configuration.content.format,
+                        ),
+                    ),
+                )
+            else:
+                raise ValueError(
+                    "If `dir_path` is provided, either a `RunConfiguration` must also be provided or "
+                    "the application's manifest (app.yaml) must include the format under "
+                    "`configuration.content.format`.",
+                )
 
-        config_format = self.__extract_config_format(configuration)
+        # Forcefully turn the configuration into a RunConfiguration object to
+        # make it easier to deal with in the other functions.
+        if isinstance(configuration, dict):
+            configuration = RunConfiguration.from_dict(configuration)
 
+        config_format = configuration.format
         if config_format is None:
             raise ValueError(
-                "If dir_path is provided, RunConfiguration.format must also be provided.",
+                "If `dir_path` is provided, `RunConfiguration.format` must also be provided.",
             )
 
-        input_type = self.__extract_input_type(config_format)
+        input_type = config_format.format_input
+        if input_type is None:
+            raise ValueError(
+                "If `dir_path` is provided, `RunConfiguration.format.format_input` must also be provided.",
+            )
 
         if input_type is None or input_type in (InputFormat.JSON, InputFormat.TEXT):
             raise ValueError(
-                "If dir_path is provided, RunConfiguration.format.format_input.input_type must be set to a valid type. "
-                f"Valid types are: {[InputFormat.CSV_ARCHIVE, InputFormat.MULTI_FILE]}",
+                "If `dir_path` is provided, `RunConfiguration.format.format_input.input_type` must be set to "
+                f"a valid type. Valid types are: {[InputFormat.CSV_ARCHIVE, InputFormat.MULTI_FILE]}",
             )
 
-    def __extract_config_format(self, configuration: Union[RunConfiguration, dict[str, Any]]) -> Any:
-        """Extract format from configuration, handling both RunConfiguration objects and dicts."""
-        if isinstance(configuration, RunConfiguration):
-            return configuration.format
-
-        if isinstance(configuration, dict):
-            config_format = configuration.get("format")
-            if config_format is not None and isinstance(config_format, dict):
-                return Format.from_dict(config_format) if hasattr(Format, "from_dict") else config_format
-
-            return config_format
-
-        raise ValueError("Configuration must be a RunConfiguration object or a dict.")
-
-    def __extract_input_type(self, config_format: Any) -> Any:
-        """Extract input type from config format."""
-        if isinstance(config_format, dict):
-            format_input = config_format.get("format_input") or config_format.get("input")
-            if format_input is None:
-                raise ValueError(
-                    "If dir_path is provided, RunConfiguration.format.format_input must also be provided.",
-                )
-
-            if isinstance(format_input, dict):
-                return format_input.get("input_type") or format_input.get("type")
-
-            return getattr(format_input, "input_type", None)
-
-        # Handle Format object
-        if config_format.format_input is None:
-            raise ValueError(
-                "If dir_path is provided, RunConfiguration.format.format_input must also be provided.",
-            )
-
-        return config_format.format_input.input_type
+        return configuration
 
     def __extract_input_data(
         self,

--- a/nextmv/nextmv/local/application.py
+++ b/nextmv/nextmv/local/application.py
@@ -892,9 +892,6 @@ class Application:
         Auxiliary function to validate the directory path and configuration.
         """
 
-        if input_dir_path is None or input_dir_path == "":
-            return
-
         if configuration is None:
             if self.manifest.configuration is not None and self.manifest.configuration.content is not None:
                 configuration = RunConfiguration(
@@ -904,17 +901,20 @@ class Application:
                         ),
                     ),
                 )
-            else:
-                raise ValueError(
-                    "If `dir_path` is provided, either a `RunConfiguration` must also be provided or "
-                    "the application's manifest (app.yaml) must include the format under "
-                    "`configuration.content.format`.",
-                )
-
-        # Forcefully turn the configuration into a RunConfiguration object to
-        # make it easier to deal with in the other functions.
-        if isinstance(configuration, dict):
+        elif isinstance(configuration, dict):
+            # Forcefully turn the configuration into a RunConfiguration object to
+            # make it easier to deal with in the other functions.
             configuration = RunConfiguration.from_dict(configuration)
+
+        if input_dir_path is None or input_dir_path == "":
+            return configuration
+
+        if configuration is None:
+            raise ValueError(
+                "If `dir_path` is provided, either a `RunConfiguration` must also be provided or "
+                "the application's manifest (app.yaml) must include the format under "
+                "`configuration.content.format`.",
+            )
 
         config_format = configuration.format
         if config_format is None:

--- a/nextmv/nextmv/local/executor.py
+++ b/nextmv/nextmv/local/executor.py
@@ -907,6 +907,9 @@ def _copy_new_or_modified_files(
     3. Files that are NOT present in the original source directory (if provided)
     4. Files that are NOT present in any of the exclusion directories (if provided)
 
+    Empty directories are not created or are removed after copying to avoid
+    cluttering the output with empty folders.
+
     Parameters
     ----------
     src_dir : str
@@ -927,11 +930,12 @@ def _copy_new_or_modified_files(
     if exclusion_dirs is not None:
         exclusion_directories.extend(exclusion_dirs)
 
+    files_copied = False
     for root, _dirs, files in os.walk(src_dir):
         rel_root = os.path.relpath(root, src_dir)
         dst_root = dst_dir if rel_root == "." else os.path.join(dst_dir, rel_root)
-        os.makedirs(dst_root, exist_ok=True)
 
+        files_to_copy = []
         for file in files:
             # Skip if file exists in any exclusion directory
             if exclusion_directories and _file_exists_in_exclusion_dirs(file, rel_root, exclusion_directories):
@@ -941,7 +945,45 @@ def _copy_new_or_modified_files(
             dst_file = os.path.join(dst_root, file)
 
             if _should_copy_file(src_file, dst_file):
+                files_to_copy.append((src_file, dst_file))
+
+        # Only create directory if there are files to copy
+        if files_to_copy:
+            os.makedirs(dst_root, exist_ok=True)
+            for src_file, dst_file in files_to_copy:
                 shutil.copy2(src_file, dst_file)
+                files_copied = True
+
+    # Clean up empty directories after copying
+    if files_copied:
+        _remove_empty_directories(dst_dir)
+
+
+def _remove_empty_directories(directory: str) -> None:
+    """
+    Recursively remove empty directories starting from the given directory.
+
+    This function walks the directory tree bottom-up and removes any directories
+    that are empty after all files have been processed. It preserves the root
+    directory even if it's empty.
+
+    Parameters
+    ----------
+    directory : str
+        The root directory path to start cleaning from.
+    """
+    for root, dirs, files in os.walk(directory, topdown=False):
+        # Skip the root directory itself
+        if root == directory:
+            continue
+
+        # If directory is empty (no files and no subdirectories), remove it
+        if not files and not dirs:
+            try:
+                os.rmdir(root)
+            except OSError:
+                # Directory might not be empty due to hidden files or permissions
+                pass
 
 
 def _should_copy_file(src_file: str, dst_file: str) -> bool:

--- a/nextmv/nextmv/local/executor.py
+++ b/nextmv/nextmv/local/executor.py
@@ -16,6 +16,10 @@ process_run_input
     Function to process the run input based on the format.
 process_run_output
     Function to process the run output and handle results.
+resolve_output_format
+    Function to determine the output format from manifest or directory structure.
+process_run_information
+    Function to update run metadata including duration and status.
 process_run_logs
     Function to process and save run logs.
 process_run_statistics
@@ -26,8 +30,13 @@ process_run_solutions
     Function to process and save run solutions.
 process_run_visuals
     Function to process and save run visuals.
+resolve_stdout
+    Function to parse subprocess stdout output.
+ignore_patterns
+    Function to filter files and directories during source code copying.
 """
 
+import hashlib
 import json
 import os
 import shutil
@@ -84,25 +93,26 @@ def execute_run(
     input_data: Optional[Union[dict[str, Any], str]] = None,
 ) -> None:
     """
-    This function actually executes the decision model run, using a
-    subprocess to call the entrypoint script with the appropriate input and
-    options.
+    Executes the decision model run using a subprocess to call the entrypoint
+    script with the appropriate input and options.
 
     Parameters
     ----------
+    run_id : str
+        The unique identifier for the run.
     src : str
         The path to the application source code.
-    manifest_entrypoint : str
-        The entrypoint script as defined in the application manifest.
+    manifest_dict : dict[str, Any]
+        The manifest dictionary containing application configuration.
     run_dir : str
-        The path to the run directory.
+        The path to the run directory where outputs will be stored.
     run_config : dict[str, Any]
-        The run configuration.
+        The run configuration containing format and other settings.
     inputs_dir_path : Optional[str], optional
         The path to the directory containing input files, by default None. If
         provided, this parameter takes precedence over `input_data`.
     options : Optional[dict[str, Any]], optional
-        Additional options for the run, by default None.
+        Additional command-line options for the run, by default None.
     input_data : Optional[Union[dict[str, Any], str]], optional
         The input data for the run, by default None. If `inputs_dir_path` is
         provided, this parameter is ignored.
@@ -119,7 +129,7 @@ def execute_run(
         # place to work from, and be cleaned up afterwards.
         with tempfile.TemporaryDirectory() as temp_dir:
             temp_src = os.path.join(temp_dir, "src")
-            shutil.copytree(src, temp_src, ignore=shutil.ignore_patterns(NEXTMV_DIR))
+            shutil.copytree(src, temp_src, ignore=ignore_patterns)
 
             manifest = Manifest.from_dict(manifest_dict)
 
@@ -162,6 +172,7 @@ def execute_run(
                 temp_src=temp_src,
                 result=result,
                 run_dir=run_dir,
+                src=src,
             )
 
     except Exception as e:
@@ -290,29 +301,30 @@ def process_run_output(
     temp_src: str,
     result: subprocess.CompletedProcess[str],
     run_dir: str,
+    src: str,
 ) -> None:
     """
     Processes the result of the subprocess run. This function is in charge of
     handling the run results, including solutions, statistics, logs, assets,
-    etc.
+    and visuals.
 
     Parameters
     ----------
     manifest : Manifest
-        The application manifest.
+        The application manifest containing configuration details.
+    run_id : str
+        The unique identifier for the run.
     temp_src : str
         The path to the temporary source directory.
     result : subprocess.CompletedProcess[str]
-        The result of the subprocess run.
+        The result of the subprocess run containing stdout, stderr, and return code.
     run_dir : str
-        The path to the run directory.
+        The path to the run directory where outputs will be stored.
+    src : str
+        The path to the application source code.
     """
 
-    # Parse stdout as JSON, if possible.
-    stdout_output = {}
-    raw_output = result.stdout
-    if raw_output.strip() != "":
-        stdout_output = json.loads(raw_output)
+    stdout_output = resolve_stdout(result)
 
     # Create outputs directory.
     outputs_dir = os.path.join(run_dir, OUTPUTS_KEY)
@@ -324,7 +336,6 @@ def process_run_output(
         temp_run_outputs_dir=temp_run_outputs_dir,
         temp_src=temp_src,
     )
-
     process_run_information(
         run_id=run_id,
         run_dir=run_dir,
@@ -342,6 +353,7 @@ def process_run_output(
         stdout_output=stdout_output,
         temp_src=temp_src,
         manifest=manifest,
+        src=src,
     )
     process_run_assets(
         temp_run_outputs_dir=temp_run_outputs_dir,
@@ -349,6 +361,7 @@ def process_run_output(
         stdout_output=stdout_output,
         temp_src=temp_src,
         manifest=manifest,
+        src=src,
     )
     process_run_solutions(
         run_id=run_id,
@@ -359,6 +372,7 @@ def process_run_output(
         stdout_output=stdout_output,
         output_format=output_format,
         manifest=manifest,
+        src=src,
     )
     process_run_visuals(
         run_dir=run_dir,
@@ -381,11 +395,16 @@ def resolve_output_format(
     Parameters
     ----------
     manifest : Manifest
-        The application manifest.
+        The application manifest containing configuration details.
     temp_run_outputs_dir : str
         The path to the temporary outputs directory.
     temp_src : str
         The path to the temporary source directory.
+
+    Returns
+    -------
+    OutputFormat
+        The determined output format (JSON, CSV_ARCHIVE, or MULTI_FILE).
     """
 
     if manifest.configuration is not None and manifest.configuration.content is not None:
@@ -449,29 +468,34 @@ def process_run_logs(
     output_format: OutputFormat,
     run_dir: str,
     result: subprocess.CompletedProcess[str],
-    stdout_output: dict[str, Any],
+    stdout_output: Union[str, dict[str, Any]],
 ) -> None:
     """
     Processes the logs of the run. Writes the logs to a logs directory.
+    For multi-file format, stdout is written to logs if present.
 
     Parameters
     ----------
     output_format : OutputFormat
-        The output format of the run.
+        The output format of the run (JSON, CSV_ARCHIVE, or MULTI_FILE).
     run_dir : str
-        The path to the run directory.
+        The path to the run directory where logs will be stored.
     result : subprocess.CompletedProcess[str]
-        The result of the subprocess run.
-    stdout_output : dict[str, Any]
-        The stdout output of the run, parsed as a dictionary.
+        The result of the subprocess run containing stderr output.
+    stdout_output : Union[str, dict[str, Any]]
+        The stdout output of the run, either as raw string or parsed dictionary.
     """
 
     logs_dir = os.path.join(run_dir, LOGS_KEY)
     os.makedirs(logs_dir, exist_ok=True)
     std_err = result.stderr
     with open(os.path.join(logs_dir, LOGS_FILE), "w") as f:
-        if output_format == OutputFormat.MULTI_FILE and stdout_output != {}:
-            f.write(json.dumps(stdout_output))
+        if output_format == OutputFormat.MULTI_FILE and bool(stdout_output):
+            if isinstance(stdout_output, dict):
+                f.write(json.dumps(stdout_output))
+            elif isinstance(stdout_output, str):
+                f.write(stdout_output)
+
             if std_err:
                 f.write("\n")
 
@@ -481,14 +505,15 @@ def process_run_logs(
 def process_run_statistics(
     temp_run_outputs_dir: str,
     outputs_dir: str,
-    stdout_output: dict[str, Any],
+    stdout_output: Union[str, dict[str, Any]],
     temp_src: str,
     manifest: Manifest,
+    src: str,
 ) -> None:
     """
-    Processes the statistics of the run. Check for an outputs/statistics folder
-    being created by the run. If it exists, copy it to the run directory. If it
-    doesn't exist, attempt to get the stats from stdout.
+    Processes the statistics of the run. Checks for an outputs/statistics folder
+    or custom statistics file location from manifest. If found, copies to run
+    directory. Otherwise, attempts to extract statistics from stdout.
 
     Parameters
     ----------
@@ -496,12 +521,15 @@ def process_run_statistics(
         The path to the temporary outputs directory.
     outputs_dir : str
         The path to the outputs directory in the run directory.
-    stdout_output : dict[str, Any]
-        The stdout output of the run, parsed as a dictionary.
+    stdout_output : Union[str, dict[str, Any]]
+        The stdout output of the run, either as raw string or parsed dictionary.
     temp_src : str
         The path to the temporary source directory.
     manifest : Manifest
-        The application manifest.
+        The application manifest containing configuration and custom paths.
+    src : str
+        The path to the original application source code, used to avoid copying
+        files that are already part of the source.
     """
 
     stats_dst = os.path.join(outputs_dir, STATISTICS_KEY)
@@ -525,7 +553,10 @@ def process_run_statistics(
 
     stats_src = os.path.join(temp_run_outputs_dir, STATISTICS_KEY)
     if os.path.exists(stats_src) and os.path.isdir(stats_src):
-        shutil.copytree(stats_src, stats_dst, dirs_exist_ok=True)
+        _copy_new_or_modified_files(stats_src, stats_dst, src)
+        return
+
+    if not isinstance(stdout_output, dict):
         return
 
     if STATISTICS_KEY not in stdout_output:
@@ -539,14 +570,15 @@ def process_run_statistics(
 def process_run_assets(
     temp_run_outputs_dir: str,
     outputs_dir: str,
-    stdout_output: dict[str, Any],
+    stdout_output: Union[str, dict[str, Any]],
     temp_src: str,
     manifest: Manifest,
+    src: str,
 ) -> None:
     """
-    Processes the assets of the run. Check for an outputs/assets folder being
-    created by the run. If it exists, copy it to the run directory. If it
-    doesn't exist, attempt to get the assets from stdout.
+    Processes the assets of the run. Checks for an outputs/assets folder or
+    custom assets file location from manifest. If found, copies to run directory.
+    Otherwise, attempts to extract assets from stdout.
 
     Parameters
     ----------
@@ -554,12 +586,15 @@ def process_run_assets(
         The path to the temporary outputs directory.
     outputs_dir : str
         The path to the outputs directory in the run directory.
-    stdout_output : dict[str, Any]
-        The stdout output of the run, parsed as a dictionary.
+    stdout_output : Union[str, dict[str, Any]]
+        The stdout output of the run, either as raw string or parsed dictionary.
     temp_src : str
         The path to the temporary source directory.
     manifest : Manifest
-        The application manifest.
+        The application manifest containing configuration and custom paths.
+    src : str
+        The path to the original application source code, used to avoid copying
+        files that are already part of the source.
     """
 
     assets_dst = os.path.join(outputs_dir, ASSETS_KEY)
@@ -583,7 +618,10 @@ def process_run_assets(
 
     assets_src = os.path.join(temp_run_outputs_dir, ASSETS_KEY)
     if os.path.exists(assets_src) and os.path.isdir(assets_src):
-        shutil.copytree(assets_src, assets_dst, dirs_exist_ok=True)
+        _copy_new_or_modified_files(assets_src, assets_dst, src)
+        return
+
+    if not isinstance(stdout_output, dict):
         return
 
     if ASSETS_KEY not in stdout_output:
@@ -600,37 +638,42 @@ def process_run_solutions(
     temp_run_outputs_dir: str,
     temp_src: str,
     outputs_dir: str,
-    stdout_output: dict[str, Any],
+    stdout_output: Union[str, dict[str, Any]],
     output_format: OutputFormat,
     manifest: Manifest,
+    src: str,
 ) -> None:
     """
-    Processes the solutions (output) of the run. This method has the handle all
-    the different formats for processing solutions. This includes looking for
-    an `output` directory (`csv-archive`), an `outputs/solutions` directory
-    (`multi-file`), or looking for solutions in the stdout output (`json` or
-    `text`). For flexibility, we copy whatever is in the `output` and
-    `outputs/solutions` directories, if they exist. If neither exist, we
-    attempt to get the solution from stdout.
+    Processes the solutions (output) of the run. Handles all different output
+    formats including CSV-archive, multi-file, JSON, and text. Looks for
+    `output` directory (csv-archive), `outputs/solutions` directory (multi-file),
+    or custom solutions path from manifest. Falls back to stdout for JSON/text.
+    Updates run metadata with output size and format information.
+
+    Only copies files that are truly new outputs, excluding files that already
+    exist in the original source code, inputs, statistics, or assets directories
+    to prevent copying application data as solutions.
 
     Parameters
     ----------
     run_id : str
-        The ID of the run.
+        The unique identifier of the run.
     run_dir : str
-        The path to the run directory.
+        The path to the run directory where outputs are stored.
     temp_run_outputs_dir : str
         The path to the temporary outputs directory.
     temp_src : str
         The path to the temporary source directory.
     outputs_dir : str
         The path to the outputs directory in the run directory.
-    stdout_output : dict[str, Any]
-        The stdout output of the run, parsed as a dictionary.
+    stdout_output : Union[str, dict[str, Any]]
+        The stdout output of the run, either as raw string or parsed dictionary.
     output_format : OutputFormat
-        The output format of the run.
+        The determined output format (JSON, CSV_ARCHIVE, MULTI_FILE, or TEXT).
     manifest : Manifest
-        The application manifest.
+        The application manifest containing configuration and custom paths.
+    src : str
+        The path to the application source code.
     """
 
     info_file = os.path.join(run_dir, f"{run_id}.json")
@@ -641,9 +684,12 @@ def process_run_solutions(
     solutions_dst = os.path.join(outputs_dir, SOLUTIONS_KEY)
     os.makedirs(solutions_dst, exist_ok=True)
 
+    # Build list of directories to exclude from copying
+    exclusion_dirs = _build_exclusion_directories(src, manifest, outputs_dir, run_dir)
+
     if output_format == OutputFormat.CSV_ARCHIVE:
         output_src = os.path.join(temp_src, OUTPUT_KEY)
-        shutil.copytree(output_src, solutions_dst, dirs_exist_ok=True)
+        _copy_new_or_modified_files(output_src, solutions_dst, src, exclusion_dirs)
     elif output_format == OutputFormat.MULTI_FILE:
         solutions_src = os.path.join(temp_run_outputs_dir, SOLUTIONS_KEY)
         if (
@@ -654,11 +700,14 @@ def process_run_solutions(
         ):
             solutions_src = os.path.join(temp_src, manifest.configuration.content.multi_file.output.solutions)
 
-        shutil.copytree(solutions_src, solutions_dst, dirs_exist_ok=True)
+        _copy_new_or_modified_files(solutions_src, solutions_dst, src, exclusion_dirs)
     else:
-        if stdout_output:
+        if bool(stdout_output):
             with open(os.path.join(solutions_dst, DEFAULT_OUTPUT_JSON_FILE), "w") as f:
-                json.dump(stdout_output, f, indent=2)
+                if isinstance(stdout_output, dict):
+                    json.dump(stdout_output, f, indent=2)
+                elif isinstance(stdout_output, str):
+                    f.write(stdout_output)
 
     # Update the run information file with the output size and type.
     calculate_files_size(run_dir, run_id, solutions_dst, metadata_key="output_size")
@@ -670,14 +719,15 @@ def process_run_solutions(
 def process_run_visuals(run_dir: str, outputs_dir: str) -> None:
     """
     Processes the visuals from the assets in the run output. This function looks
-    for Plotly assets and generates HTML files for each visual.
+    for visual assets (Plotly and GeoJSON) in the assets.json file and generates
+    HTML files for each visual. ChartJS visuals are ignored for local runs.
 
     Parameters
     ----------
     run_dir : str
-        The path to the run directory.
+        The path to the run directory where visuals will be stored.
     outputs_dir : str
-        The path to the outputs directory in the run directory.
+        The path to the outputs directory in the run directory containing assets.
     """
 
     # Get the assets.
@@ -709,6 +759,266 @@ def process_run_visuals(run_dir: str, outputs_dir: str) -> None:
 
         # ChartJS is not easily supported directly from Python in local runs,
         # so we ignore it for now.
+
+
+def resolve_stdout(result: subprocess.CompletedProcess[str]) -> Union[str, dict[str, Any]]:
+    """
+    Resolves the stdout output of the subprocess run. If the stdout is valid
+    JSON, it returns the parsed dictionary. Otherwise, it returns the raw
+    string output.
+
+    Parameters
+    ----------
+    result : subprocess.CompletedProcess[str]
+        The result of the subprocess run.
+
+    Returns
+    -------
+    Union[str, dict[str, Any]]
+        The parsed stdout output as a dictionary if valid JSON, otherwise the
+        raw string output.
+    """
+    raw_output = result.stdout
+    if raw_output.strip() == "":
+        return ""
+
+    try:
+        return json.loads(raw_output)
+    except json.JSONDecodeError:
+        return raw_output
+
+
+def ignore_patterns(dir_path: str, names: list[str]) -> list[str]:
+    """
+    Custom ignore function for copytree that filters files and directories
+    during source code copying. Excludes virtual environments, cache files,
+    the nextmv directory, and non-essential files while preserving Python
+    source files and application manifests.
+
+    Parameters
+    ----------
+    dir_path : str
+        The path to the directory being processed.
+    names : list[str]
+        A list of file and directory names in the current directory.
+
+    Returns
+    -------
+    list[str]
+        A list of names to ignore during the copy operation.
+    """
+    ignored = []
+    for name in names:
+        full_path = os.path.join(dir_path, name)
+
+        # Ignore nextmv directory
+        if name == NEXTMV_DIR:
+            ignored.append(name)
+            continue
+
+        # Ignore virtual environment directories
+        if name in ("venv", ".venv", "env", ".env", "virtualenv", ".virtualenv"):
+            ignored.append(name)
+            continue
+
+        # Ignore __pycache__ directories
+        if name == "__pycache__":
+            ignored.append(name)
+            continue
+
+        # If it's a file, only keep Python files and app.yaml
+        if os.path.isfile(full_path):
+            if not (name.endswith(".py") or name == "app.yaml"):
+                ignored.append(name)
+                continue
+
+        # Ignore .pyc files explicitly
+        if name.endswith(".pyc"):
+            ignored.append(name)
+            continue
+
+    return ignored
+
+
+def _build_exclusion_directories(src: str, manifest: Manifest, outputs_dir: str, run_dir: str) -> list[str]:
+    """
+    Build a list of directories to exclude when copying solution files.
+
+    Parameters
+    ----------
+    src : str
+        The path to the original application source code.
+    manifest : Manifest
+        The application manifest containing configuration.
+    outputs_dir : str
+        The path to the outputs directory in the run directory.
+    run_dir : str
+        The path to the run directory.
+
+    Returns
+    -------
+    list[str]
+        List of directory paths to exclude from copying.
+    """
+    exclusion_dirs = []
+
+    # Add inputs directory from original source
+    inputs_dir_original = os.path.join(src, INPUTS_KEY)
+    if os.path.exists(inputs_dir_original):
+        exclusion_dirs.append(inputs_dir_original)
+
+    # Add custom inputs directory if specified in manifest
+    if (
+        manifest.configuration is not None
+        and manifest.configuration.content is not None
+        and manifest.configuration.content.format == InputFormat.MULTI_FILE
+        and manifest.configuration.content.multi_file is not None
+    ):
+        custom_inputs_dir = os.path.join(src, manifest.configuration.content.multi_file.input.path)
+        if os.path.exists(custom_inputs_dir):
+            exclusion_dirs.append(custom_inputs_dir)
+
+    # Add inputs directory from run directory
+    inputs_dir_run = os.path.join(run_dir, INPUTS_KEY)
+    if os.path.exists(inputs_dir_run):
+        exclusion_dirs.append(inputs_dir_run)
+
+    # Add statistics and assets directories from run outputs
+    stats_dir = os.path.join(outputs_dir, STATISTICS_KEY)
+    if os.path.exists(stats_dir):
+        exclusion_dirs.append(stats_dir)
+
+    assets_dir = os.path.join(outputs_dir, ASSETS_KEY)
+    if os.path.exists(assets_dir):
+        exclusion_dirs.append(assets_dir)
+
+    return exclusion_dirs
+
+
+def _copy_new_or_modified_files(
+    src_dir: str, dst_dir: str, original_src_dir: Optional[str] = None, exclusion_dirs: Optional[list[str]] = None
+) -> None:
+    """
+    Copy files from source to destination only if they meet specific criteria.
+
+    This function ensures that only files that are either:
+    1. New files (not present in destination)
+    2. Existing files with different content (based on checksum comparison)
+    3. Files that are NOT present in the original source directory (if provided)
+    4. Files that are NOT present in any of the exclusion directories (if provided)
+
+    Parameters
+    ----------
+    src_dir : str
+        The source directory path to copy from.
+    dst_dir : str
+        The destination directory path to copy to.
+    original_src_dir : Optional[str], optional
+        The original source directory to check against. Files present in this
+        directory will NOT be copied, by default None.
+    exclusion_dirs : Optional[list[str]], optional
+        Additional directories to check against. Files present in any of these
+        directories will NOT be copied, by default None.
+    """
+    # Build list of all exclusion directories
+    exclusion_directories = []
+    if original_src_dir is not None:
+        exclusion_directories.append(original_src_dir)
+    if exclusion_dirs is not None:
+        exclusion_directories.extend(exclusion_dirs)
+
+    for root, _dirs, files in os.walk(src_dir):
+        rel_root = os.path.relpath(root, src_dir)
+        dst_root = dst_dir if rel_root == "." else os.path.join(dst_dir, rel_root)
+        os.makedirs(dst_root, exist_ok=True)
+
+        for file in files:
+            # Skip if file exists in any exclusion directory
+            if exclusion_directories and _file_exists_in_exclusion_dirs(file, rel_root, exclusion_directories):
+                continue
+
+            src_file = os.path.join(root, file)
+            dst_file = os.path.join(dst_root, file)
+
+            if _should_copy_file(src_file, dst_file):
+                shutil.copy2(src_file, dst_file)
+
+
+def _should_copy_file(src_file: str, dst_file: str) -> bool:
+    """
+    Determine if a file should be copied based on existence and content.
+
+    Parameters
+    ----------
+    src_file : str
+        Path to the source file.
+    dst_file : str
+        Path to the destination file.
+
+    Returns
+    -------
+    bool
+        True if the file should be copied, False otherwise.
+    """
+    if not os.path.exists(dst_file):
+        return True
+
+    try:
+        src_checksum = _calculate_file_checksum(src_file)
+        dst_checksum = _calculate_file_checksum(dst_file)
+        return src_checksum != dst_checksum
+    except OSError:
+        return True
+
+
+def _calculate_file_checksum(file_path: str) -> str:
+    """
+    Calculate MD5 checksum of a file.
+
+    Parameters
+    ----------
+    file_path : str
+        The path to the file.
+
+    Returns
+    -------
+    str
+        The MD5 checksum of the file.
+    """
+    hash_md5 = hashlib.md5()
+    with open(file_path, "rb") as f:
+        for chunk in iter(lambda: f.read(4096), b""):
+            hash_md5.update(chunk)
+    return hash_md5.hexdigest()
+
+
+def _file_exists_in_exclusion_dirs(file_name: str, rel_root: str, exclusion_dirs: list[str]) -> bool:
+    """
+    Check if a file exists in any of the exclusion directories.
+
+    Parameters
+    ----------
+    file_name : str
+        The name of the file to check.
+    rel_root : str
+        The relative root path from the source directory.
+    exclusion_dirs : list[str]
+        List of directories to check against.
+
+    Returns
+    -------
+    bool
+        True if the file exists in any exclusion directory, False otherwise.
+    """
+    for exclusion_dir in exclusion_dirs:
+        if rel_root != ".":
+            exclusion_file = os.path.join(exclusion_dir, rel_root, file_name)
+        else:
+            exclusion_file = os.path.join(exclusion_dir, file_name)
+
+        if os.path.exists(exclusion_file):
+            return True
+    return False
 
 
 if __name__ == "__main__":

--- a/nextmv/nextmv/local/local.py
+++ b/nextmv/nextmv/local/local.py
@@ -36,7 +36,7 @@ LOGS_KEY = "logs"
 """
 Logs key constant used for identifying logs in the run output.
 """
-LOGS_FILE = "stderr.log"
+LOGS_FILE = "logs.log"
 """
 Constant used for identifying the file used for logging.
 """

--- a/nextmv/nextmv/manifest.py
+++ b/nextmv/nextmv/manifest.py
@@ -11,6 +11,8 @@ ManifestType
     Enum for application types based on programming language.
 ManifestRuntime
     Enum for runtime environments where apps run on Nextmv.
+ManifestPythonArch
+    Enum for target architecture for bundling Python apps.
 ManifestBuild
     Class for build-specific attributes in the manifest.
 ManifestPythonModel
@@ -37,6 +39,11 @@ ManifestConfiguration
     Class for configuration settings for the decision model.
 Manifest
     Main class representing an app manifest for Nextmv.
+
+Functions
+---------
+default_python_manifest
+    Creates a default Python manifest as a starting point for applications.
 
 Constants
 --------
@@ -331,7 +338,7 @@ class ManifestPython(BaseModel):
 
     Parameters
     ----------
-    pip_requirements : Optional[str], default=None
+    pip_requirements : Optional[Union[str, list[str]]], default=None
         Path to a requirements.txt file containing (additional) Python
         dependencies that will be bundled with the app. Alternatively, you can provide a
         list of strings, each representing a package to install, e.g.,
@@ -358,10 +365,11 @@ class ManifestPython(BaseModel):
         default=None,
     )
     """
-    Path to a requirements.txt file.
+    Path to a requirements.txt file or list of packages.
 
     Contains (additional) Python dependencies that will be bundled with the
-    app.
+    app. Can be either a string path to a requirements.txt file or a list
+    of package specifications.
     """
     arch: Optional[ManifestPythonArch] = None
     """
@@ -383,6 +391,31 @@ class ManifestPython(BaseModel):
     @field_validator("version", mode="before")
     @classmethod
     def validate_version(cls, v: Optional[Union[str, float]]) -> Optional[str]:
+        """
+        Validate and convert the Python version field to a string.
+
+        This validator allows the version to be specified as either a float or string
+        in the manifest for convenience, but ensures it's stored internally as a string.
+
+        Parameters
+        ----------
+        v : Optional[Union[str, float]]
+            The version value to validate. Can be None, a string, or a float.
+
+        Returns
+        -------
+        Optional[str]
+            The version as a string, or None if the input was None.
+
+        Examples
+        --------
+        >>> ManifestPython.validate_version(3.11)
+        '3.11'
+        >>> ManifestPython.validate_version("3.11")
+        '3.11'
+        >>> ManifestPython.validate_version(None) is None
+        True
+        """
         # We allow the version to be a float in the manifest for convenience, but we want
         # to store it as a string internally.
         if v is None:
@@ -917,7 +950,23 @@ class ManifestContent(BaseModel):
     """Configuration for multi-file content format."""
 
     def model_post_init(self, __context) -> None:
-        """Post-initialization to validate fields."""
+        """
+        Post-initialization validation to ensure format field contains valid values.
+
+        This method is automatically called by Pydantic after the model is initialized
+        to validate that the format field contains one of the acceptable values.
+
+        Parameters
+        ----------
+        __context : Any
+            Pydantic context (unused in this implementation).
+
+        Raises
+        ------
+        ValueError
+            If the format field contains an invalid value that is not one of the
+            acceptable formats (JSON, MULTI_FILE, or CSV_ARCHIVE).
+        """
         acceptable_formats = [InputFormat.JSON, InputFormat.MULTI_FILE, InputFormat.CSV_ARCHIVE]
         if self.format not in acceptable_formats:
             raise ValueError(f"Invalid format: {self.format}. Must be one of {acceptable_formats}.")
@@ -1084,6 +1133,26 @@ class Manifest(BaseModel):
     """
 
     def model_post_init(self, __context) -> None:
+        """
+        Post-initialization to set default entrypoint based on runtime if not specified.
+
+        This method is automatically called by Pydantic after the model is initialized.
+        If no entrypoint is provided, it sets a default entrypoint based on the runtime:
+        - Python runtimes (PYTHON, HEXALY, PYOMO, CUOPT): "./main.py"
+        - DEFAULT runtime: "./main"
+        - JAVA runtime: "./main.jar"
+
+        Parameters
+        ----------
+        __context : Any
+            Pydantic context (unused in this implementation).
+
+        Raises
+        ------
+        ValueError
+            If no entrypoint is provided and the runtime cannot be resolved to
+            establish a default entrypoint.
+        """
         if self.entrypoint is None:
             if self.runtime in (
                 ManifestRuntime.PYTHON,

--- a/nextmv/nextmv/manifest.py
+++ b/nextmv/nextmv/manifest.py
@@ -1024,17 +1024,28 @@ class Manifest(BaseModel):
     ['main.py', 'model_logic/']
     """
 
-    files: list[str]
-    """The files to include (or exclude) in the app. This is mandatory."""
-
+    type: ManifestType = ManifestType.PYTHON
+    """
+    Type of application, based on the programming language. This is mandatory.
+    """
     runtime: ManifestRuntime = ManifestRuntime.PYTHON
     """
     The runtime to use for the app. It provides the environment in which the
     app runs. This is mandatory.
     """
-    type: ManifestType = ManifestType.PYTHON
+    python: Optional[ManifestPython] = None
     """
-    Type of application, based on the programming language. This is mandatory.
+    Python-specific attributes. Only for Python apps. Contains further
+    Python-specific attributes.
+    """
+    files: list[str] = Field(
+        default_factory=list,
+    )
+    """The files to include (or exclude) in the app. This is mandatory."""
+    configuration: Optional[ManifestConfiguration] = None
+    """
+    Configuration for the decision model. A list of options for the decision
+    model. An option is a parameter that configures the decision model.
     """
     build: Optional[ManifestBuild] = None
     """
@@ -1061,16 +1072,6 @@ class Manifest(BaseModel):
     Windows). The command must exit with a status of 0 to continue the push
     process. This command is executed just before the app gets bundled and
     pushed (after the build command).
-    """
-    python: Optional[ManifestPython] = None
-    """
-    Python-specific attributes. Only for Python apps. Contains further
-    Python-specific attributes.
-    """
-    configuration: Optional[ManifestConfiguration] = None
-    """
-    Configuration for the decision model. A list of options for the decision
-    model. An option is a parameter that configures the decision model.
     """
     entrypoint: Optional[str] = None
     """
@@ -1175,7 +1176,14 @@ class Manifest(BaseModel):
         """
 
         with open(os.path.join(dirpath, MANIFEST_FILE_NAME), "w") as file:
-            yaml.dump(self.to_dict(), file)
+            yaml.dump(
+                self.to_dict(),
+                file,
+                sort_keys=False,
+                default_flow_style=False,
+                indent=2,
+                width=120,
+            )
 
     def extract_options(self) -> Optional[Options]:
         """
@@ -1376,9 +1384,12 @@ def default_python_manifest() -> Manifest:
         A default Python manifest with common settings.
     """
 
-    return Manifest(
+    m = Manifest(
         files=["main.py"],
         runtime=ManifestRuntime.PYTHON,
         type=ManifestType.PYTHON,
         python=ManifestPython(pip_requirements="requirements.txt"),
     )
+    m.entrypoint = None  # TODO: change this when we are ready for the entrypoint.
+
+    return m

--- a/nextmv/nextmv/manifest.py
+++ b/nextmv/nextmv/manifest.py
@@ -357,19 +357,24 @@ class ManifestPython(BaseModel):
         validation_alias=AliasChoices("pip-requirements", "pip_requirements"),
         default=None,
     )
-    """Path to a requirements.txt file.
+    """
+    Path to a requirements.txt file.
 
     Contains (additional) Python dependencies that will be bundled with the
     app.
     """
     arch: Optional[ManifestPythonArch] = None
-    """The architecture this model is meant to run on. One of "arm64" or "amd64". Uses
-    "arm64" if not specified."""
+    """
+    The architecture this model is meant to run on. One of "arm64" or "amd64". Uses
+    "arm64" if not specified.
+    """
     version: Optional[Union[str, float]] = None
-    """The Python version this model is meant to run with. Uses "3.11" if not specified.
+    """
+    The Python version this model is meant to run with. Uses "3.11" if not specified.
     """
     model: Optional[ManifestPythonModel] = None
-    """Information about an encoded decision model.
+    """
+    Information about an encoded decision model.
 
     As handled via mlflow. This information is used to load the decision model
     from the app bundle.
@@ -1352,3 +1357,28 @@ class Manifest(BaseModel):
         )
 
         return manifest
+
+
+def default_python_manifest() -> Manifest:
+    """
+    Creates a default Python manifest as a starting point for applications
+    being executed on the Nextmv Platform.
+
+    You can import the `default_python_manifest` function directly from `nextmv`:
+
+    ```python
+    from nextmv import default_python_manifest
+    ```
+
+    Returns
+    -------
+    Manifest
+        A default Python manifest with common settings.
+    """
+
+    return Manifest(
+        files=["main.py"],
+        runtime=ManifestRuntime.PYTHON,
+        type=ManifestType.PYTHON,
+        python=ManifestPython(pip_requirements="requirements.txt"),
+    )

--- a/nextmv/tests/local/test_executor.py
+++ b/nextmv/tests/local/test_executor.py
@@ -274,11 +274,11 @@ class TestLocalExecutor(unittest.TestCase):
         logs_dir = os.path.join(self.run_dir, "logs")
         self.assertTrue(os.path.exists(logs_dir))
 
-        # Check that stderr.log was created with correct content
-        stderr_file = os.path.join(logs_dir, "stderr.log")
-        self.assertTrue(os.path.exists(stderr_file))
+        # Check that logs.log was created with correct content
+        logs_file = os.path.join(logs_dir, "logs.log")
+        self.assertTrue(os.path.exists(logs_file))
 
-        with open(stderr_file) as f:
+        with open(logs_file) as f:
             content = f.read()
 
         self.assertEqual(content, "Error line 1\nError line 2\n")
@@ -299,7 +299,12 @@ class TestLocalExecutor(unittest.TestCase):
         stdout_output = {}
 
         process_run_statistics(
-            temp_outputs_dir, outputs_dir, stdout_output, temp_src=self.temp_src, manifest=self.mock_manifest
+            temp_outputs_dir,
+            outputs_dir,
+            stdout_output,
+            temp_src=self.temp_src,
+            manifest=self.mock_manifest,
+            src=self.test_dir,
         )
 
         # Check that statistics directory was copied
@@ -316,7 +321,12 @@ class TestLocalExecutor(unittest.TestCase):
         stdout_output = {STATISTICS_KEY: {"duration": 2.5, "iterations": 100}}
 
         process_run_statistics(
-            temp_outputs_dir, outputs_dir, stdout_output, temp_src=self.temp_src, manifest=self.mock_manifest
+            temp_outputs_dir,
+            outputs_dir,
+            stdout_output,
+            temp_src=self.temp_src,
+            manifest=self.mock_manifest,
+            src=self.test_dir,
         )
 
         # Check that statistics.json was created
@@ -341,7 +351,12 @@ class TestLocalExecutor(unittest.TestCase):
         stdout_output = {}
 
         process_run_statistics(
-            temp_outputs_dir, outputs_dir, stdout_output, temp_src=self.temp_src, manifest=self.mock_manifest
+            temp_outputs_dir,
+            outputs_dir,
+            stdout_output,
+            temp_src=self.temp_src,
+            manifest=self.mock_manifest,
+            src=self.test_dir,
         )
 
         # Check that statistics directory was not created
@@ -364,7 +379,12 @@ class TestLocalExecutor(unittest.TestCase):
         stdout_output = {}
 
         process_run_assets(
-            temp_outputs_dir, outputs_dir, stdout_output, temp_src=self.temp_src, manifest=self.mock_manifest
+            temp_outputs_dir,
+            outputs_dir,
+            stdout_output,
+            temp_src=self.temp_src,
+            manifest=self.mock_manifest,
+            src=self.test_dir,
         )
 
         # Check that assets directory was copied
@@ -386,7 +406,12 @@ class TestLocalExecutor(unittest.TestCase):
         }
 
         process_run_assets(
-            temp_outputs_dir, outputs_dir, stdout_output, temp_src=self.temp_src, manifest=self.mock_manifest
+            temp_outputs_dir,
+            outputs_dir,
+            stdout_output,
+            temp_src=self.temp_src,
+            manifest=self.mock_manifest,
+            src=self.test_dir,
         )
 
         # Check that assets.json was created
@@ -429,6 +454,7 @@ class TestLocalExecutor(unittest.TestCase):
             stdout_output,
             output_format=OutputFormat.CSV_ARCHIVE,
             manifest=self.mock_manifest,
+            src=self.test_dir,
         )
 
         # Check that solutions directory was created and files copied
@@ -463,6 +489,7 @@ class TestLocalExecutor(unittest.TestCase):
             stdout_output,
             output_format=OutputFormat.MULTI_FILE,
             manifest=self.mock_manifest,
+            src=self.test_dir,
         )
 
         # Check that solutions directory was created and files copied
@@ -490,6 +517,7 @@ class TestLocalExecutor(unittest.TestCase):
             stdout_output,
             output_format=self.mock_output_format,
             manifest=self.mock_manifest,
+            src=self.test_dir,
         )
 
         # Check that solution.json was created
@@ -524,6 +552,7 @@ class TestLocalExecutor(unittest.TestCase):
             stdout_output,
             output_format=self.mock_output_format,
             manifest=self.mock_manifest,
+            src=self.test_dir,
         )
 
         # Check that solutions directory was created
@@ -609,6 +638,7 @@ class TestLocalExecutor(unittest.TestCase):
             temp_src=temp_src,
             result=mock_result,
             run_dir="/test/run_dir",
+            src="/test/src",
         )
 
     def test_process_run_output_with_valid_json(self):
@@ -636,6 +666,7 @@ class TestLocalExecutor(unittest.TestCase):
                 temp_src=self.temp_src,
                 result=mock_result,
                 run_dir=self.run_dir,
+                src=self.test_dir,
             )
 
             # Verify all processing functions were called
@@ -674,11 +705,12 @@ class TestLocalExecutor(unittest.TestCase):
                 temp_src=self.temp_src,
                 result=mock_result,
                 run_dir=self.run_dir,
+                src=self.test_dir,
             )
 
-            # Verify all processing functions were called with empty dict
+            # Verify all processing functions were called with empty string
             mock_logs.assert_called_once_with(
-                output_format=unittest.mock.ANY, run_dir=self.run_dir, result=mock_result, stdout_output={}
+                output_format=unittest.mock.ANY, run_dir=self.run_dir, result=mock_result, stdout_output=""
             )
             mock_stats.assert_called_once()
             mock_assets.assert_called_once()
@@ -686,7 +718,7 @@ class TestLocalExecutor(unittest.TestCase):
 
             # Get the stdout_output that was passed to the functions
             stdout_output = mock_stats.call_args.kwargs["stdout_output"]
-            self.assertEqual(stdout_output, {})
+            self.assertEqual(stdout_output, "")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description

Multiple changes to enhance local experience:

- Add support for the `manifest` in the `local` `Application`.
- Make `configuration` optional on `new_run` for `local.Application` if the app's manifest has the correct configuration for the content type.
- Makes fixes to the local executor:
  - For multi-file, stream stdout to logs
  - Does not enforce JSON for stdout
  - Copies over files smartly to solutions. There is a use case where the `src` of the app is the same as the script that is performing a run. In that case, if the app's manifest states that the output goes in the root, that would end up copying the whole application to the `solutions` dir in the local result. To avoid that, smart copying is introduced where files are excluded by checksum and names. In conclusion: we only copy solution files that are net new, or whose content changed, and that are not present in the other run folders (`inputs`, `logs`, `statistics`, `assets`).
- Adds a new function for creating a default python manifest.
- Modifies the order of the fields in the manifest to match how we normally present the manifest.