### PR TITLE
Fixes copying of the solutions produced by `local`

### DIFF
--- a/nextmv/nextmv/__about__.py
+++ b/nextmv/nextmv/__about__.py
@@ -1,1 +1,1 @@
-__version__ = "v0.34.0"
+__version__ = "v0.34.1.dev0"

--- a/nextmv/nextmv/local/executor.py
+++ b/nextmv/nextmv/local/executor.py
@@ -32,13 +32,12 @@ process_run_visuals
     Function to process and save run visuals.
 resolve_stdout
     Function to parse subprocess stdout output.
-ignore_patterns
-    Function to filter files and directories during source code copying.
 """
 
 import hashlib
 import json
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -129,7 +128,7 @@ def execute_run(
         # place to work from, and be cleaned up afterwards.
         with tempfile.TemporaryDirectory() as temp_dir:
             temp_src = os.path.join(temp_dir, "src")
-            shutil.copytree(src, temp_src, ignore=ignore_patterns)
+            shutil.copytree(src, temp_src, ignore=_ignore_patterns)
 
             manifest = Manifest.from_dict(manifest_dict)
 
@@ -353,7 +352,6 @@ def process_run_output(
         stdout_output=stdout_output,
         temp_src=temp_src,
         manifest=manifest,
-        src=src,
     )
     process_run_assets(
         temp_run_outputs_dir=temp_run_outputs_dir,
@@ -361,7 +359,6 @@ def process_run_output(
         stdout_output=stdout_output,
         temp_src=temp_src,
         manifest=manifest,
-        src=src,
     )
     process_run_solutions(
         run_id=run_id,
@@ -508,7 +505,6 @@ def process_run_statistics(
     stdout_output: Union[str, dict[str, Any]],
     temp_src: str,
     manifest: Manifest,
-    src: str,
 ) -> None:
     """
     Processes the statistics of the run. Checks for an outputs/statistics folder
@@ -527,9 +523,6 @@ def process_run_statistics(
         The path to the temporary source directory.
     manifest : Manifest
         The application manifest containing configuration and custom paths.
-    src : str
-        The path to the original application source code, used to avoid copying
-        files that are already part of the source.
     """
 
     stats_dst = os.path.join(outputs_dir, STATISTICS_KEY)
@@ -553,10 +546,7 @@ def process_run_statistics(
 
     stats_src = os.path.join(temp_run_outputs_dir, STATISTICS_KEY)
     if os.path.exists(stats_src) and os.path.isdir(stats_src):
-        _copy_new_or_modified_files(stats_src, stats_dst, src)
-        return
-
-    if not isinstance(stdout_output, dict):
+        shutil.copytree(stats_src, stats_dst, dirs_exist_ok=True)
         return
 
     if STATISTICS_KEY not in stdout_output:
@@ -573,7 +563,6 @@ def process_run_assets(
     stdout_output: Union[str, dict[str, Any]],
     temp_src: str,
     manifest: Manifest,
-    src: str,
 ) -> None:
     """
     Processes the assets of the run. Checks for an outputs/assets folder or
@@ -592,9 +581,6 @@ def process_run_assets(
         The path to the temporary source directory.
     manifest : Manifest
         The application manifest containing configuration and custom paths.
-    src : str
-        The path to the original application source code, used to avoid copying
-        files that are already part of the source.
     """
 
     assets_dst = os.path.join(outputs_dir, ASSETS_KEY)
@@ -618,10 +604,7 @@ def process_run_assets(
 
     assets_src = os.path.join(temp_run_outputs_dir, ASSETS_KEY)
     if os.path.exists(assets_src) and os.path.isdir(assets_src):
-        _copy_new_or_modified_files(assets_src, assets_dst, src)
-        return
-
-    if not isinstance(stdout_output, dict):
+        shutil.copytree(assets_src, assets_dst, dirs_exist_ok=True)
         return
 
     if ASSETS_KEY not in stdout_output:
@@ -684,12 +667,9 @@ def process_run_solutions(
     solutions_dst = os.path.join(outputs_dir, SOLUTIONS_KEY)
     os.makedirs(solutions_dst, exist_ok=True)
 
-    # Build list of directories to exclude from copying
-    exclusion_dirs = _build_exclusion_directories(src, manifest, outputs_dir, run_dir)
-
     if output_format == OutputFormat.CSV_ARCHIVE:
         output_src = os.path.join(temp_src, OUTPUT_KEY)
-        _copy_new_or_modified_files(output_src, solutions_dst, src, exclusion_dirs)
+        shutil.copytree(output_src, solutions_dst, dirs_exist_ok=True)
     elif output_format == OutputFormat.MULTI_FILE:
         solutions_src = os.path.join(temp_run_outputs_dir, SOLUTIONS_KEY)
         if (
@@ -700,7 +680,16 @@ def process_run_solutions(
         ):
             solutions_src = os.path.join(temp_src, manifest.configuration.content.multi_file.output.solutions)
 
-        _copy_new_or_modified_files(solutions_src, solutions_dst, src, exclusion_dirs)
+        _copy_new_or_modified_files(
+            runtime_dir=solutions_src,
+            dst_dir=solutions_dst,
+            original_src_dir=src,
+            exclusion_dirs=[
+                os.path.join(outputs_dir, STATISTICS_KEY),
+                os.path.join(outputs_dir, ASSETS_KEY),
+                os.path.join(run_dir, INPUTS_KEY),
+            ],
+        )
     else:
         if bool(stdout_output):
             with open(os.path.join(solutions_dst, DEFAULT_OUTPUT_JSON_FILE), "w") as f:
@@ -788,7 +777,7 @@ def resolve_stdout(result: subprocess.CompletedProcess[str]) -> Union[str, dict[
         return raw_output
 
 
-def ignore_patterns(dir_path: str, names: list[str]) -> list[str]:
+def _ignore_patterns(dir_path: str, names: list[str]) -> list[str]:
     """
     Custom ignore function for copytree that filters files and directories
     during source code copying. Excludes virtual environments, cache files,
@@ -817,7 +806,7 @@ def ignore_patterns(dir_path: str, names: list[str]) -> list[str]:
             continue
 
         # Ignore virtual environment directories
-        if name in ("venv", ".venv", "env", ".env", "virtualenv", ".virtualenv"):
+        if re.match(r"^\.?(venv|env|virtualenv).*$", name):
             ignored.append(name)
             continue
 
@@ -840,123 +829,119 @@ def ignore_patterns(dir_path: str, names: list[str]) -> list[str]:
     return ignored
 
 
-def _build_exclusion_directories(src: str, manifest: Manifest, outputs_dir: str, run_dir: str) -> list[str]:
-    """
-    Build a list of directories to exclude when copying solution files.
-
-    Parameters
-    ----------
-    src : str
-        The path to the original application source code.
-    manifest : Manifest
-        The application manifest containing configuration.
-    outputs_dir : str
-        The path to the outputs directory in the run directory.
-    run_dir : str
-        The path to the run directory.
-
-    Returns
-    -------
-    list[str]
-        List of directory paths to exclude from copying.
-    """
-    exclusion_dirs = []
-
-    # Add inputs directory from original source
-    inputs_dir_original = os.path.join(src, INPUTS_KEY)
-    if os.path.exists(inputs_dir_original):
-        exclusion_dirs.append(inputs_dir_original)
-
-    # Add custom inputs directory if specified in manifest
-    if (
-        manifest.configuration is not None
-        and manifest.configuration.content is not None
-        and manifest.configuration.content.format == InputFormat.MULTI_FILE
-        and manifest.configuration.content.multi_file is not None
-    ):
-        custom_inputs_dir = os.path.join(src, manifest.configuration.content.multi_file.input.path)
-        if os.path.exists(custom_inputs_dir):
-            exclusion_dirs.append(custom_inputs_dir)
-
-    # Add inputs directory from run directory
-    inputs_dir_run = os.path.join(run_dir, INPUTS_KEY)
-    if os.path.exists(inputs_dir_run):
-        exclusion_dirs.append(inputs_dir_run)
-
-    # Add statistics and assets directories from run outputs
-    stats_dir = os.path.join(outputs_dir, STATISTICS_KEY)
-    if os.path.exists(stats_dir):
-        exclusion_dirs.append(stats_dir)
-
-    assets_dir = os.path.join(outputs_dir, ASSETS_KEY)
-    if os.path.exists(assets_dir):
-        exclusion_dirs.append(assets_dir)
-
-    return exclusion_dirs
-
-
-def _copy_new_or_modified_files(
-    src_dir: str, dst_dir: str, original_src_dir: Optional[str] = None, exclusion_dirs: Optional[list[str]] = None
+def _copy_new_or_modified_files(  # noqa: C901
+    runtime_dir: str,
+    dst_dir: str,
+    original_src_dir: Optional[str] = None,
+    exclusion_dirs: Optional[list[str]] = None,
 ) -> None:
     """
-    Copy files from source to destination only if they meet specific criteria.
+    Copy only new or modified files from runtime directory to destination directory.
 
-    This function ensures that only files that are either:
-    1. New files (not present in destination)
-    2. Existing files with different content (based on checksum comparison)
-    3. Files that are NOT present in the original source directory (if provided)
-    4. Files that are NOT present in any of the exclusion directories (if provided)
-
-    Empty directories are not created or are removed after copying to avoid
-    cluttering the output with empty folders.
+    This function identifies files that are either new (not present in the original
+    source) or have been modified (different content, checksum, or modification time)
+    compared to the original source. It excludes files that exist in specified
+    exclusion directories to avoid copying input data, statistics, or assets as
+    solution outputs.
 
     Parameters
     ----------
-    src_dir : str
-        The source directory path to copy from.
+    runtime_dir : str
+        The path to the runtime directory containing files to potentially copy.
     dst_dir : str
-        The destination directory path to copy to.
+        The destination directory where new or modified files will be copied.
     original_src_dir : Optional[str], optional
-        The original source directory to check against. Files present in this
-        directory will NOT be copied, by default None.
+        The path to the original source directory for comparison, by default None.
+        If None, all files from runtime_dir are considered new.
     exclusion_dirs : Optional[list[str]], optional
-        Additional directories to check against. Files present in any of these
-        directories will NOT be copied, by default None.
+        List of directory paths containing files to exclude from copying,
+        by default None. Files matching those in exclusion directories will
+        not be copied even if they are new or modified.
     """
-    # Build list of all exclusion directories
-    exclusion_directories = []
+
+    # Gather a list of the files that are created/modified in the runtime dir,
+    # this is, the directory where the actual executable code is run from.
+    runtime_files_rel = []
+    runtime_files_abs = []
+    for root, _, files in os.walk(runtime_dir):
+        for rel_file in files:
+            file_path = os.path.join(root, rel_file)
+            runtime_files_rel.append(os.path.relpath(file_path, runtime_dir))
+            runtime_files_abs.append(file_path)
+
+    # Gather a list of the files that exist in the original source dir. Given
+    # that the source dir is copied to the runtime dir before execution, we can
+    # use this to determine which files are new or modified.
+    original_src_files_rel = set()
     if original_src_dir is not None:
-        exclusion_directories.append(original_src_dir)
+        for root, _, files in os.walk(original_src_dir):
+            for rel_file in files:
+                file_path = os.path.join(root, rel_file)
+                original_src_files_rel.add(os.path.relpath(file_path, original_src_dir))
+
+    # Gather a list of the files that exist in the exclusion dirs. This is used
+    # to avoid copying files that are part of this special exclusion set.
+    exclusion_files_rel = set()
     if exclusion_dirs is not None:
-        exclusion_directories.extend(exclusion_dirs)
+        for exclusion_dir in exclusion_dirs:
+            for root, _, files in os.walk(exclusion_dir):
+                for rel_file in files:
+                    file_path = os.path.join(root, rel_file)
+                    exclusion_files_rel.add(os.path.relpath(file_path, exclusion_dir))
 
-    files_copied = False
-    for root, _dirs, files in os.walk(src_dir):
-        rel_root = os.path.relpath(root, src_dir)
-        dst_root = dst_dir if rel_root == "." else os.path.join(dst_dir, rel_root)
+    # Now we filter the runtime files to only keep those that are new or
+    # modified compared to the original source files.
+    files_before_exclusion = []
+    for ix, rel_file in enumerate(runtime_files_rel):
+        abs_file = runtime_files_abs[ix]
 
-        files_to_copy = []
-        for file in files:
-            # Skip if file exists in any exclusion directory
-            if exclusion_directories and _file_exists_in_exclusion_dirs(file, rel_root, exclusion_directories):
+        # If the file is net new, we keep it.
+        if rel_file not in original_src_files_rel:
+            files_before_exclusion.append(abs_file)
+            continue
+
+        # If content of the file is different, we keep it.
+        runtime_checksum = _calculate_file_checksum(abs_file)
+        original_abs_file = os.path.join(original_src_dir, rel_file)
+        original_checksum = _calculate_file_checksum(original_abs_file)
+        if runtime_checksum != original_checksum:
+            files_before_exclusion.append(abs_file)
+            continue
+
+        # If content of the file is the same, but the date is newer, we keep it.
+        src_mtime = os.path.getmtime(abs_file)
+        original_mtime = os.path.getmtime(original_abs_file)
+        if src_mtime > original_mtime:
+            files_before_exclusion.append(abs_file)
+            continue
+
+    # Now we filter out any files that are part of the exclusion set.
+    final_files = []
+    if exclusion_dirs is not None:
+        for file in files_before_exclusion:
+            rel_file = os.path.relpath(file, runtime_dir)
+            if rel_file in exclusion_files_rel:
                 continue
 
-            src_file = os.path.join(root, file)
-            dst_file = os.path.join(dst_root, file)
+            final_files.append(file)
+    else:
+        final_files = files_before_exclusion
 
-            if _should_copy_file(src_file, dst_file):
-                files_to_copy.append((src_file, dst_file))
+    # Now that we have a clean list of files that we are going to copy, we
+    # proceed to copy them over to the destination directory.
+    for file in final_files:
+        rel_file = os.path.relpath(file, runtime_dir)
+        dst_file = os.path.join(dst_dir, rel_file)
 
-        # Only create directory if there are files to copy
-        if files_to_copy:
-            os.makedirs(dst_root, exist_ok=True)
-            for src_file, dst_file in files_to_copy:
-                shutil.copy2(src_file, dst_file)
-                files_copied = True
+        # Create the directory structure if it doesn't exist
+        dst_file_dir = os.path.dirname(dst_file)
+        os.makedirs(dst_file_dir, exist_ok=True)
 
-    # Clean up empty directories after copying
-    if files_copied:
-        _remove_empty_directories(dst_dir)
+        # Copy the file
+        shutil.copy2(file, dst_file)
+
+    # Finally, we remove any empty directories that might have been created.
+    _remove_empty_directories(dst_dir)
 
 
 def _remove_empty_directories(directory: str) -> None:
@@ -986,40 +971,6 @@ def _remove_empty_directories(directory: str) -> None:
                 pass
 
 
-def _should_copy_file(src_file: str, dst_file: str) -> bool:
-    """
-    Determine if a file should be copied based on existence, content, and modification time.
-
-    Parameters
-    ----------
-    src_file : str
-        Path to the source file.
-    dst_file : str
-        Path to the destination file.
-
-    Returns
-    -------
-    bool
-        True if the file should be copied, False otherwise.
-    """
-    if not os.path.exists(dst_file):
-        return True
-
-    try:
-        # First check if content is different
-        src_checksum = _calculate_file_checksum(src_file)
-        dst_checksum = _calculate_file_checksum(dst_file)
-        if src_checksum != dst_checksum:
-            return True
-
-        # If content is the same, check if source file is newer
-        src_mtime = os.path.getmtime(src_file)
-        dst_mtime = os.path.getmtime(dst_file)
-        return src_mtime > dst_mtime
-    except OSError:
-        return True
-
-
 def _calculate_file_checksum(file_path: str) -> str:
     """
     Calculate MD5 checksum of a file.
@@ -1039,35 +990,6 @@ def _calculate_file_checksum(file_path: str) -> str:
         for chunk in iter(lambda: f.read(4096), b""):
             hash_md5.update(chunk)
     return hash_md5.hexdigest()
-
-
-def _file_exists_in_exclusion_dirs(file_name: str, rel_root: str, exclusion_dirs: list[str]) -> bool:
-    """
-    Check if a file exists in any of the exclusion directories.
-
-    Parameters
-    ----------
-    file_name : str
-        The name of the file to check.
-    rel_root : str
-        The relative root path from the source directory.
-    exclusion_dirs : list[str]
-        List of directories to check against.
-
-    Returns
-    -------
-    bool
-        True if the file exists in any exclusion directory, False otherwise.
-    """
-    for exclusion_dir in exclusion_dirs:
-        if rel_root != ".":
-            exclusion_file = os.path.join(exclusion_dir, rel_root, file_name)
-        else:
-            exclusion_file = os.path.join(exclusion_dir, file_name)
-
-        if os.path.exists(exclusion_file):
-            return True
-    return False
 
 
 if __name__ == "__main__":

--- a/nextmv/nextmv/local/executor.py
+++ b/nextmv/nextmv/local/executor.py
@@ -988,7 +988,7 @@ def _remove_empty_directories(directory: str) -> None:
 
 def _should_copy_file(src_file: str, dst_file: str) -> bool:
     """
-    Determine if a file should be copied based on existence and content.
+    Determine if a file should be copied based on existence, content, and modification time.
 
     Parameters
     ----------
@@ -1006,9 +1006,16 @@ def _should_copy_file(src_file: str, dst_file: str) -> bool:
         return True
 
     try:
+        # First check if content is different
         src_checksum = _calculate_file_checksum(src_file)
         dst_checksum = _calculate_file_checksum(dst_file)
-        return src_checksum != dst_checksum
+        if src_checksum != dst_checksum:
+            return True
+
+        # If content is the same, check if source file is newer
+        src_mtime = os.path.getmtime(src_file)
+        dst_mtime = os.path.getmtime(dst_file)
+        return src_mtime > dst_mtime
     except OSError:
         return True
 

--- a/nextmv/nextmv/local/executor.py
+++ b/nextmv/nextmv/local/executor.py
@@ -549,6 +549,9 @@ def process_run_statistics(
         shutil.copytree(stats_src, stats_dst, dirs_exist_ok=True)
         return
 
+    if not isinstance(stdout_output, dict):
+        return
+
     if STATISTICS_KEY not in stdout_output:
         return
 
@@ -605,6 +608,9 @@ def process_run_assets(
     assets_src = os.path.join(temp_run_outputs_dir, ASSETS_KEY)
     if os.path.exists(assets_src) and os.path.isdir(assets_src):
         shutil.copytree(assets_src, assets_dst, dirs_exist_ok=True)
+        return
+
+    if not isinstance(stdout_output, dict):
         return
 
     if ASSETS_KEY not in stdout_output:

--- a/nextmv/nextmv/local/executor.py
+++ b/nextmv/nextmv/local/executor.py
@@ -864,7 +864,15 @@ def _copy_new_or_modified_files(  # noqa: C901
     runtime_files_rel = []
     runtime_files_abs = []
     for root, _, files in os.walk(runtime_dir):
+        # Skip __pycache__ directories
+        if "__pycache__" in root:
+            continue
+
         for rel_file in files:
+            # Skip .pyc files
+            if rel_file.endswith(".pyc"):
+                continue
+
             file_path = os.path.join(root, rel_file)
             runtime_files_rel.append(os.path.relpath(file_path, runtime_dir))
             runtime_files_abs.append(file_path)

--- a/nextmv/tests/local/test_executor.py
+++ b/nextmv/tests/local/test_executor.py
@@ -5,12 +5,16 @@ Unit tests for the nextmv.local.executor module.
 import json
 import os
 import shutil
+import stat
 import sys
 import tempfile
+import time
 import unittest
 from unittest.mock import Mock, patch
 
 from nextmv.local.executor import (
+    _calculate_file_checksum,
+    _copy_new_or_modified_files,
     execute_run,
     main,
     options_args,
@@ -714,6 +718,416 @@ class TestLocalExecutor(unittest.TestCase):
             # Get the stdout_output that was passed to the functions
             stdout_output = mock_stats.call_args.kwargs["stdout_output"]
             self.assertEqual(stdout_output, "")
+
+
+class TestCopyNewOrModifiedFiles(unittest.TestCase):
+    """Test cases for the _copy_new_or_modified_files function."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.test_dir = tempfile.mkdtemp()
+        self.runtime_dir = os.path.join(self.test_dir, "runtime")
+        self.dst_dir = os.path.join(self.test_dir, "destination")
+        self.original_src_dir = os.path.join(self.test_dir, "original_src")
+        self.exclusion_dir1 = os.path.join(self.test_dir, "exclusion1")
+        self.exclusion_dir2 = os.path.join(self.test_dir, "exclusion2")
+
+        # Create all directories
+        for dir_path in [
+            self.runtime_dir,
+            self.dst_dir,
+            self.original_src_dir,
+            self.exclusion_dir1,
+            self.exclusion_dir2,
+        ]:
+            os.makedirs(dir_path, exist_ok=True)
+
+    def tearDown(self):
+        """Clean up test fixtures."""
+        shutil.rmtree(self.test_dir)
+
+    def _create_file(self, directory: str, filename: str, content: str = "content") -> str:
+        """Helper to create a file with given content."""
+        filepath = os.path.join(directory, filename)
+        os.makedirs(os.path.dirname(filepath), exist_ok=True)
+        with open(filepath, "w") as f:
+            f.write(content)
+        return filepath
+
+    def _create_binary_file(self, directory: str, filename: str, content: bytes = b"binary_content") -> str:
+        """Helper to create a binary file with given content."""
+        filepath = os.path.join(directory, filename)
+        os.makedirs(os.path.dirname(filepath), exist_ok=True)
+        with open(filepath, "wb") as f:
+            f.write(content)
+        return filepath
+
+    def _assert_file_exists_with_content(self, filepath: str, expected_content: str):
+        """Helper to assert file exists and has expected content."""
+        self.assertTrue(os.path.exists(filepath), f"File {filepath} should exist")
+        with open(filepath) as f:
+            self.assertEqual(f.read(), expected_content)
+
+    def _assert_file_not_exists(self, filepath: str):
+        """Helper to assert file does not exist."""
+        self.assertFalse(os.path.exists(filepath), f"File {filepath} should not exist")
+
+    def test_copy_all_files_when_no_original_src(self):
+        """Test copying all files when original_src_dir is None."""
+
+        # Create files in runtime directory
+        self._create_file(self.runtime_dir, "file1.txt", "content1")
+        self._create_file(self.runtime_dir, "subdir/file2.txt", "content2")
+        self._create_file(self.runtime_dir, "file3.py", "print('hello')")
+
+        _copy_new_or_modified_files(self.runtime_dir, self.dst_dir)
+
+        # All files should be copied
+        self._assert_file_exists_with_content(os.path.join(self.dst_dir, "file1.txt"), "content1")
+        self._assert_file_exists_with_content(os.path.join(self.dst_dir, "subdir/file2.txt"), "content2")
+        self._assert_file_exists_with_content(os.path.join(self.dst_dir, "file3.py"), "print('hello')")
+
+    def test_copy_new_files_only(self):
+        """Test copying only new files not present in original source."""
+
+        # Create files in original source
+        original_file1 = self._create_file(self.original_src_dir, "existing_file.txt", "original_content")
+        self._create_file(self.original_src_dir, "subdir/existing_file2.txt", "original_content2")
+
+        # Wait to ensure different timestamps
+        time.sleep(0.1)
+
+        # Create files in runtime directory - some new, some existing
+        runtime_file1 = self._create_file(self.runtime_dir, "existing_file.txt", "original_content")
+        # Same as original
+        runtime_file2 = self._create_file(self.runtime_dir, "subdir/existing_file2.txt", "original_content2")
+        self._create_file(self.runtime_dir, "new_file.txt", "new_content")  # New file
+        self._create_file(self.runtime_dir, "new_subdir/new_file2.txt", "new_content2")  # New file in new dir
+
+        # Make runtime files appear older than original (simulating unchanged files)
+        older_time = os.path.getmtime(original_file1) - 1
+        os.utime(runtime_file1, (older_time, older_time))
+        os.utime(runtime_file2, (older_time, older_time))
+
+        _copy_new_or_modified_files(self.runtime_dir, self.dst_dir, self.original_src_dir)
+
+        # Only new files should be copied
+        self._assert_file_exists_with_content(os.path.join(self.dst_dir, "new_file.txt"), "new_content")
+        self._assert_file_exists_with_content(os.path.join(self.dst_dir, "new_subdir/new_file2.txt"), "new_content2")
+
+        # Existing files should not be copied (same content and older timestamp)
+        self._assert_file_not_exists(os.path.join(self.dst_dir, "existing_file.txt"))
+        self._assert_file_not_exists(os.path.join(self.dst_dir, "subdir/existing_file2.txt"))
+
+    def test_copy_modified_files_content_changed(self):
+        """Test copying files with modified content."""
+
+        # Create files in original source
+        self._create_file(self.original_src_dir, "file1.txt", "original_content")
+        self._create_file(self.original_src_dir, "subdir/file2.txt", "original_content2")
+
+        # Create files in runtime directory with modified content
+        self._create_file(self.runtime_dir, "file1.txt", "modified_content")
+        self._create_file(self.runtime_dir, "subdir/file2.txt", "modified_content2")
+
+        _copy_new_or_modified_files(self.runtime_dir, self.dst_dir, self.original_src_dir)
+
+        # Modified files should be copied
+        self._assert_file_exists_with_content(os.path.join(self.dst_dir, "file1.txt"), "modified_content")
+        self._assert_file_exists_with_content(os.path.join(self.dst_dir, "subdir/file2.txt"), "modified_content2")
+
+    def test_copy_modified_files_newer_timestamp(self):
+        """Test copying files with newer modification time but same content."""
+
+        # Create files in original source
+        original_file1 = self._create_file(self.original_src_dir, "file1.txt", "same_content")
+        original_file2 = self._create_file(self.original_src_dir, "subdir/file2.txt", "same_content2")
+
+        # Wait a bit to ensure different timestamps
+        time.sleep(0.1)
+
+        # Create files in runtime directory with same content but newer timestamp
+        runtime_file1 = self._create_file(self.runtime_dir, "file1.txt", "same_content")
+        runtime_file2 = self._create_file(self.runtime_dir, "subdir/file2.txt", "same_content2")
+
+        # Verify runtime files are newer
+        self.assertGreater(os.path.getmtime(runtime_file1), os.path.getmtime(original_file1))
+        self.assertGreater(os.path.getmtime(runtime_file2), os.path.getmtime(original_file2))
+
+        _copy_new_or_modified_files(self.runtime_dir, self.dst_dir, self.original_src_dir)
+
+        # Files with newer timestamps should be copied
+        self._assert_file_exists_with_content(os.path.join(self.dst_dir, "file1.txt"), "same_content")
+        self._assert_file_exists_with_content(os.path.join(self.dst_dir, "subdir/file2.txt"), "same_content2")
+
+    def test_skip_unchanged_files(self):
+        """Test that unchanged files are not copied."""
+
+        # Create files in original source
+        original_file1 = self._create_file(self.original_src_dir, "file1.txt", "same_content")
+
+        # Wait a bit to create runtime file
+        time.sleep(0.1)
+
+        # Create file in runtime directory with same content
+        runtime_file1 = self._create_file(self.runtime_dir, "file1.txt", "same_content")
+
+        # Make the original file newer (simulate unchanged file)
+        newer_time = os.path.getmtime(runtime_file1) + 1
+        os.utime(original_file1, (newer_time, newer_time))
+
+        _copy_new_or_modified_files(self.runtime_dir, self.dst_dir, self.original_src_dir)
+
+        # Unchanged file should not be copied
+        self._assert_file_not_exists(os.path.join(self.dst_dir, "file1.txt"))
+
+    def test_exclusion_dirs_functionality(self):
+        """Test that files in exclusion directories are not copied."""
+
+        # Create files in runtime directory
+        self._create_file(self.runtime_dir, "keep_this.txt", "keep_content")
+        self._create_file(self.runtime_dir, "exclude_this.txt", "exclude_content")
+        self._create_file(self.runtime_dir, "subdir/keep_this2.txt", "keep_content2")
+        self._create_file(self.runtime_dir, "subdir/exclude_this2.txt", "exclude_content2")
+
+        # Create matching files in exclusion directories
+        self._create_file(self.exclusion_dir1, "exclude_this.txt", "any_content")
+        self._create_file(self.exclusion_dir2, "subdir/exclude_this2.txt", "any_content2")
+
+        exclusion_dirs = [self.exclusion_dir1, self.exclusion_dir2]
+        _copy_new_or_modified_files(self.runtime_dir, self.dst_dir, exclusion_dirs=exclusion_dirs)
+
+        # Files not in exclusion should be copied
+        self._assert_file_exists_with_content(os.path.join(self.dst_dir, "keep_this.txt"), "keep_content")
+        self._assert_file_exists_with_content(os.path.join(self.dst_dir, "subdir/keep_this2.txt"), "keep_content2")
+
+        # Files in exclusion should not be copied
+        self._assert_file_not_exists(os.path.join(self.dst_dir, "exclude_this.txt"))
+        self._assert_file_not_exists(os.path.join(self.dst_dir, "subdir/exclude_this2.txt"))
+
+    def test_skip_pycache_and_pyc_files(self):
+        """Test that __pycache__ directories and .pyc files are skipped."""
+
+        # Create regular files
+        self._create_file(self.runtime_dir, "normal_file.py", "print('hello')")
+
+        # Create __pycache__ directory with .pyc files
+        pycache_dir = os.path.join(self.runtime_dir, "__pycache__")
+        os.makedirs(pycache_dir)
+        self._create_file(pycache_dir, "normal_file.cpython-39.pyc", "bytecode")
+
+        # Create nested __pycache__
+        subdir_pycache = os.path.join(self.runtime_dir, "subdir", "__pycache__")
+        os.makedirs(subdir_pycache)
+        self._create_file(subdir_pycache, "another_file.cpython-39.pyc", "bytecode2")
+
+        # Create .pyc file in regular directory
+        self._create_file(self.runtime_dir, "direct_pyc.pyc", "bytecode3")
+
+        _copy_new_or_modified_files(self.runtime_dir, self.dst_dir)
+
+        # Regular Python file should be copied
+        self._assert_file_exists_with_content(os.path.join(self.dst_dir, "normal_file.py"), "print('hello')")
+
+        # __pycache__ directories and .pyc files should not be copied
+        self._assert_file_not_exists(os.path.join(self.dst_dir, "__pycache__", "normal_file.cpython-39.pyc"))
+        self._assert_file_not_exists(os.path.join(self.dst_dir, "subdir", "__pycache__", "another_file.cpython-39.pyc"))
+        self._assert_file_not_exists(os.path.join(self.dst_dir, "direct_pyc.pyc"))
+
+    def test_binary_files_handling(self):
+        """Test that binary files are handled correctly."""
+
+        # Create binary files in original source and runtime
+        self._create_binary_file(self.original_src_dir, "image.png", b"\x89PNG\r\n\x1a\n")
+        runtime_binary_same = self._create_binary_file(self.runtime_dir, "image.png", b"\x89PNG\r\n\x1a\n")
+        self._create_binary_file(self.runtime_dir, "new_image.jpg", b"\xff\xd8\xff\xe0")
+        self._create_binary_file(self.runtime_dir, "modified.png", b"\x89PNG\r\n\x1a\n\x00")
+
+        # Create corresponding original file for the modified one
+        self._create_binary_file(self.original_src_dir, "modified.png", b"\x89PNG\r\n\x1a\n")
+
+        _copy_new_or_modified_files(self.runtime_dir, self.dst_dir, self.original_src_dir)
+
+        # New binary file should be copied
+        self.assertTrue(os.path.exists(os.path.join(self.dst_dir, "new_image.jpg")))
+
+        # Modified binary file should be copied
+        self.assertTrue(os.path.exists(os.path.join(self.dst_dir, "modified.png")))
+
+        # Unchanged binary file should not be copied (assuming same content and timestamp)
+        # This depends on timing, so let's verify the file exists in runtime but behavior may vary
+        self.assertTrue(os.path.exists(runtime_binary_same))
+
+    def test_complex_directory_structure(self):
+        """Test with complex nested directory structures."""
+
+        # Create complex structure in original source
+        self._create_file(self.original_src_dir, "root_file.txt", "root")
+        self._create_file(self.original_src_dir, "level1/file1.txt", "level1_content")
+        self._create_file(self.original_src_dir, "level1/level2/file2.txt", "level2_content")
+        self._create_file(self.original_src_dir, "level1/level2/level3/file3.txt", "level3_content")
+
+        # Create similar structure in runtime with mix of new, modified, and unchanged files
+        self._create_file(self.runtime_dir, "root_file.txt", "root_modified")  # Modified
+        self._create_file(self.runtime_dir, "level1/file1.txt", "level1_content")  # Unchanged content
+        self._create_file(self.runtime_dir, "level1/level2/file2.txt", "level2_modified")  # Modified
+        self._create_file(self.runtime_dir, "level1/level2/level3/file3.txt", "level3_content")  # Unchanged content
+        self._create_file(self.runtime_dir, "level1/new_file.txt", "new_content")  # New file
+        self._create_file(
+            self.runtime_dir, "level1/level2/level3/level4/new_deep_file.txt", "deep_new"
+        )  # New deep file
+
+        _copy_new_or_modified_files(self.runtime_dir, self.dst_dir, self.original_src_dir)
+
+        # Modified files should be copied
+        self._assert_file_exists_with_content(os.path.join(self.dst_dir, "root_file.txt"), "root_modified")
+        self._assert_file_exists_with_content(os.path.join(self.dst_dir, "level1/level2/file2.txt"), "level2_modified")
+
+        # New files should be copied
+        self._assert_file_exists_with_content(os.path.join(self.dst_dir, "level1/new_file.txt"), "new_content")
+        self._assert_file_exists_with_content(
+            os.path.join(self.dst_dir, "level1/level2/level3/level4/new_deep_file.txt"), "deep_new"
+        )
+
+        # Unchanged files should not be copied (depending on timestamp)
+        # Note: This test might be flaky due to timing, but we can check the logic
+
+    def test_empty_directories_are_removed(self):
+        """Test that empty directories are removed after copying."""
+
+        # Create a structure where some directories will become empty
+        self._create_file(self.runtime_dir, "keep/file1.txt", "content1")
+        self._create_file(self.runtime_dir, "remove_empty/exclude_this.txt", "content2")
+
+        # Create exclusion that will prevent the second file from being copied
+        # The exclusion path must match the relative path from runtime_dir
+        self._create_file(self.exclusion_dir1, "remove_empty/exclude_this.txt", "any_content")
+
+        _copy_new_or_modified_files(self.runtime_dir, self.dst_dir, exclusion_dirs=[self.exclusion_dir1])
+
+        # Directory with kept file should exist
+        self.assertTrue(os.path.exists(os.path.join(self.dst_dir, "keep")))
+        self._assert_file_exists_with_content(os.path.join(self.dst_dir, "keep/file1.txt"), "content1")
+
+        # Directory that would be empty should not exist (or should be removed)
+        # Note: The function should remove empty directories
+        self._assert_file_not_exists(os.path.join(self.dst_dir, "remove_empty/exclude_this.txt"))
+
+    def test_edge_case_empty_runtime_dir(self):
+        """Test behavior with empty runtime directory."""
+
+        # Runtime directory is empty
+        _copy_new_or_modified_files(self.runtime_dir, self.dst_dir, self.original_src_dir)
+
+        # Destination should remain empty (except for the directory itself)
+        dst_contents = os.listdir(self.dst_dir)
+        self.assertEqual(len(dst_contents), 0)
+
+    def test_edge_case_nonexistent_exclusion_dir(self):
+        """Test behavior with nonexistent exclusion directories."""
+
+        self._create_file(self.runtime_dir, "file1.txt", "content1")
+
+        nonexistent_dir = os.path.join(self.test_dir, "nonexistent")
+        exclusion_dirs = [nonexistent_dir]
+
+        # Should not raise an error
+        _copy_new_or_modified_files(self.runtime_dir, self.dst_dir, exclusion_dirs=exclusion_dirs)
+
+        # File should still be copied
+        self._assert_file_exists_with_content(os.path.join(self.dst_dir, "file1.txt"), "content1")
+
+    def test_checksum_calculation_correctness(self):
+        """Test that file checksum calculation works correctly for determining modifications."""
+
+        # Create files with same content
+        content = "This is test content for checksum verification."
+        original_file = self._create_file(self.original_src_dir, "test_file.txt", content)
+        runtime_file = self._create_file(self.runtime_dir, "test_file.txt", content)
+
+        # Verify checksums are the same
+        original_checksum = _calculate_file_checksum(original_file)
+        runtime_checksum = _calculate_file_checksum(runtime_file)
+        self.assertEqual(original_checksum, runtime_checksum)
+
+        # Modify content slightly
+        modified_content = content + " Modified!"
+        with open(runtime_file, "w") as f:
+            f.write(modified_content)
+
+        # Verify checksums are now different
+        modified_checksum = _calculate_file_checksum(runtime_file)
+        self.assertNotEqual(original_checksum, modified_checksum)
+
+        _copy_new_or_modified_files(self.runtime_dir, self.dst_dir, self.original_src_dir)
+
+        # Modified file should be copied due to different checksum
+        self._assert_file_exists_with_content(os.path.join(self.dst_dir, "test_file.txt"), modified_content)
+
+    def test_preserve_file_permissions_and_metadata(self):
+        """Test that file permissions and metadata are preserved during copying."""
+
+        # Create a file with specific permissions
+        test_file = self._create_file(self.runtime_dir, "test_file.txt", "content")
+
+        # Set specific permissions (readable and writable by owner only)
+        os.chmod(test_file, stat.S_IRUSR | stat.S_IWUSR)
+        original_mode = os.stat(test_file).st_mode
+
+        _copy_new_or_modified_files(self.runtime_dir, self.dst_dir)
+
+        # Check that copied file has same permissions
+        copied_file = os.path.join(self.dst_dir, "test_file.txt")
+        copied_mode = os.stat(copied_file).st_mode
+
+        # Compare the permission bits (mask out file type bits)
+        self.assertEqual(original_mode & 0o777, copied_mode & 0o777)
+
+    def test_mixed_scenarios_integration(self):
+        """Integration test combining multiple scenarios."""
+
+        # Set up original source files
+        self._create_file(self.original_src_dir, "unchanged.txt", "unchanged_content")
+        self._create_file(self.original_src_dir, "to_modify.txt", "original_content")
+        self._create_file(self.original_src_dir, "subdir/nested_unchanged.txt", "nested_original")
+
+        # Wait to ensure different timestamps
+        time.sleep(0.1)
+
+        # Set up runtime files
+        self._create_file(self.runtime_dir, "unchanged.txt", "unchanged_content")  # Same content, newer timestamp
+        self._create_file(self.runtime_dir, "to_modify.txt", "modified_content")  # Different content
+        # Same content, newer timestamp
+        self._create_file(self.runtime_dir, "subdir/nested_unchanged.txt", "nested_original")
+        self._create_file(self.runtime_dir, "new_file.txt", "new_content")  # New file
+        self._create_file(self.runtime_dir, "exclude_me.txt", "exclude_content")  # Will be excluded
+        self._create_file(self.runtime_dir, "__pycache__/cached.pyc", "cache")  # Will be skipped
+        self._create_file(self.runtime_dir, "regular.pyc", "pyc_content")  # Will be skipped
+
+        # Set up exclusion
+        self._create_file(self.exclusion_dir1, "exclude_me.txt", "any_content")
+
+        _copy_new_or_modified_files(
+            self.runtime_dir, self.dst_dir, self.original_src_dir, exclusion_dirs=[self.exclusion_dir1]
+        )
+
+        # Files with newer timestamps should be copied
+        self._assert_file_exists_with_content(os.path.join(self.dst_dir, "unchanged.txt"), "unchanged_content")
+        nested_file_path = os.path.join(self.dst_dir, "subdir/nested_unchanged.txt")
+        self._assert_file_exists_with_content(nested_file_path, "nested_original")
+
+        # Modified files should be copied
+        self._assert_file_exists_with_content(os.path.join(self.dst_dir, "to_modify.txt"), "modified_content")
+
+        # New files should be copied
+        self._assert_file_exists_with_content(os.path.join(self.dst_dir, "new_file.txt"), "new_content")
+
+        # Excluded files should not be copied
+        self._assert_file_not_exists(os.path.join(self.dst_dir, "exclude_me.txt"))
+
+        # Cache files should not be copied
+        self._assert_file_not_exists(os.path.join(self.dst_dir, "__pycache__/cached.pyc"))
+        self._assert_file_not_exists(os.path.join(self.dst_dir, "regular.pyc"))
 
 
 if __name__ == "__main__":

--- a/nextmv/tests/local/test_executor.py
+++ b/nextmv/tests/local/test_executor.py
@@ -304,7 +304,6 @@ class TestLocalExecutor(unittest.TestCase):
             stdout_output,
             temp_src=self.temp_src,
             manifest=self.mock_manifest,
-            src=self.test_dir,
         )
 
         # Check that statistics directory was copied
@@ -326,7 +325,6 @@ class TestLocalExecutor(unittest.TestCase):
             stdout_output,
             temp_src=self.temp_src,
             manifest=self.mock_manifest,
-            src=self.test_dir,
         )
 
         # Check that statistics.json was created
@@ -356,7 +354,6 @@ class TestLocalExecutor(unittest.TestCase):
             stdout_output,
             temp_src=self.temp_src,
             manifest=self.mock_manifest,
-            src=self.test_dir,
         )
 
         # Check that statistics directory was not created
@@ -384,7 +381,6 @@ class TestLocalExecutor(unittest.TestCase):
             stdout_output,
             temp_src=self.temp_src,
             manifest=self.mock_manifest,
-            src=self.test_dir,
         )
 
         # Check that assets directory was copied
@@ -411,7 +407,6 @@ class TestLocalExecutor(unittest.TestCase):
             stdout_output,
             temp_src=self.temp_src,
             manifest=self.mock_manifest,
-            src=self.test_dir,
         )
 
         # Check that assets.json was created


### PR DESCRIPTION
# Description

There was an issue when working with custom `input` and `output` of the app manifest. When either of those pointed to `.`, meaning the inputs/outputs are loaded/written from/to the root, then strange things happened during file copying. The logic for copying files selectively was modified hastily, thus this PR aims to modify that behavior by making it accurate. Now, it doesn't matter if custom paths are specified or default paths are used, `multi-file` works by writing the generated/modified solutions to the `solutions` dir.