### PR TITLE
Adds `integration_id` to configuration of runs and instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@
 Welcome to `nextmv-py`, a repository for all of Nextmv’s Python SDKs. Here you
 can find the source for the following packages:
 
-* [`nextmv`](./nextmv/README.md): The general-purpose Python SDK for working
-  with decision models and the Nextmv Cloud API.
+* [`nextmv`](./nextmv/README.md): A free and open-source, general-purpose
+  Python SDK for working with decision models and the Nextmv Cloud API.
 * [`nextmv-gurobipy`](./nextmv-gurobipy/README.md): A Python SDK providing
   convenience functions for working with Gurobi (`gurobipy`) models in the
   Nextmv platform.

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,8 +36,8 @@
 Nextmv offers several Python SDKs to help you work with decision models and the
 Nextmv Cloud API:
 
-* [`nextmv`][nextmv]: The general-purpose Python SDK for working with decision
-      models and the Nextmv Cloud API.
+* [`nextmv`][nextmv]: A free and open-source, general-purpose Python SDK for
+      working with decision models and the Nextmv Cloud API.
 * [`nextmv-gurobipy`][nextmv-gurobipy]: A Python SDK providing convenience
       functions for working with Gurobi (`gurobipy`) models in the Nextmv
       platform.

--- a/docs/nextmv/index.md
+++ b/docs/nextmv/index.md
@@ -19,9 +19,9 @@
 
 <!-- markdownlint-enable MD033 MD013 -->
 
-The [Nextmv Python SDK][nextmv], `nextmv`, is a library to interact
-programmatically with the Nextmv Platform from Python. There are three main
-packages (or namespaces) in the SDK:
+The [Nextmv Python SDK][nextmv], `nextmv`, is a free and open-source library to
+interact programmatically with the Nextmv Platform from Python. There are three
+main packages (or namespaces) in the SDK:
 
 1. [`nextmv`][modeling-index] (root): modeling constructs to work with decision
    models in an opinionated way.

--- a/docs/nextmv/local/index.md
+++ b/docs/nextmv/local/index.md
@@ -3,10 +3,10 @@
 The `nextmv.local` package provides functionality to run Nextmv Applications
 locally on your machine.
 
-!!! success "Free to use"
+!!! success "Open source & free"
 
-    The `local` experience is completely free of charge and does not require a
-    Nextmv account.
+    The `local` experience is completely open-source and free of charge, it does
+    not require a Nextmv account.
 
 At Nextmv, we believe that decision models should be easy to build, test, and
 run. The Nextmv [Cloud Platform][cloud-overview] provides great functionality

--- a/docs/nextmv/local/index.md
+++ b/docs/nextmv/local/index.md
@@ -3,10 +3,10 @@
 The `nextmv.local` package provides functionality to run Nextmv Applications
 locally on your machine.
 
-!!! success "Open source & free"
+!!! success "Free & open-source"
 
-    The `local` experience is completely open-source and free of charge, it does
-    not require a Nextmv account.
+    The `local` experience is free and open-source, and does not require a
+    Nextmv account.
 
 At Nextmv, we believe that decision models should be easy to build, test, and
 run. The Nextmv [Cloud Platform][cloud-overview] provides great functionality

--- a/nextmv/nextmv/cloud/batch_experiment.py
+++ b/nextmv/nextmv/cloud/batch_experiment.py
@@ -257,7 +257,7 @@ class BatchExperimentRun(BaseModel):
     repetition: int | None = None
     """Repetition number of the experiment."""
 
-    def __post_init_post_parse__(self):
+    def model_post_init(self, __context) -> None:
         """
         Logic to run after the class is initialized.
 

--- a/nextmv/nextmv/cloud/instance.py
+++ b/nextmv/nextmv/cloud/instance.py
@@ -15,6 +15,7 @@ Instance
 from datetime import datetime
 
 from nextmv.base_model import BaseModel
+from nextmv.run import RunQueuing
 
 
 class InstanceConfiguration(BaseModel):
@@ -37,6 +38,10 @@ class InstanceConfiguration(BaseModel):
         Runtime options/parameters for the application.
     secrets_collection_id : str, optional
         ID of the secrets collection to use with this instance.
+    queuing : RunQueuing, optional
+        Queuing configuration for the instance.
+    integration_id : str, optional
+        ID of the integration to use for the instance.
 
     Examples
     --------
@@ -53,6 +58,29 @@ class InstanceConfiguration(BaseModel):
     """Options of the app that the instance uses."""
     secrets_collection_id: str | None = None
     """ID of the secrets collection that the instance uses."""
+    queuing: RunQueuing | None = None
+    """Queuing configuration for the instance."""
+    integration_id: str | None = None
+    """ID of the integration to use for the instance."""
+
+    def model_post_init(self, __context) -> None:
+        """
+        Validations done after parsing the model.
+
+        Raises
+        ------
+        ValueError
+            If execution_class is an empty string.
+        """
+
+        if self.integration_id is None or self.integration_id == "":
+            return
+
+        integration_val = "integration"
+        if self.execution_class is not None and self.execution_class != "" and self.execution_class != integration_val:
+            raise ValueError(f"When integration_id is set, execution_class must be `{integration_val}` or None.")
+
+        self.execution_class = integration_val
 
 
 class Instance(BaseModel):

--- a/nextmv/nextmv/run.py
+++ b/nextmv/nextmv/run.py
@@ -1081,7 +1081,7 @@ class RunQueuing(BaseModel):
     queued. If False, the run will be queued.
     """
 
-    def __post_init_post_parse__(self):
+    def model_post_init(self, __context) -> None:
         """
         Validations done after parsing the model.
 
@@ -1121,6 +1121,8 @@ class RunConfiguration(BaseModel):
         ID of the secrets collection to use for the run. Defaults to None.
     queuing : RunQueuing, optional
         Queuing configuration for the run. Defaults to None.
+    integration_id : str, optional
+        ID of the integration to use for the run. Defaults to None.
 
     Examples
     --------
@@ -1150,6 +1152,27 @@ class RunConfiguration(BaseModel):
     """ID of the secrets collection to use for the run."""
     queuing: RunQueuing | None = None
     """Queuing configuration for the run."""
+    integration_id: str | None = None
+    """ID of the integration to use for the run."""
+
+    def model_post_init(self, __context) -> None:
+        """
+        Validations done after parsing the model.
+
+        Raises
+        ------
+        ValueError
+            If execution_class is an empty string.
+        """
+
+        if self.integration_id is None or self.integration_id == "":
+            return
+
+        integration_val = "integration"
+        if self.execution_class is not None and self.execution_class != "" and self.execution_class != integration_val:
+            raise ValueError(f"When integration_id is set, execution_class must be `{integration_val}` or None.")
+
+        self.execution_class = integration_val
 
     def resolve(
         self,
@@ -1292,7 +1315,7 @@ class ExternalRunResult(BaseModel):
     or `MULTI_FILE` output formats.
     """
 
-    def __post_init_post_parse__(self):
+    def model_post_init(self, __context) -> None:
         """
         Validations done after parsing the model.
 

--- a/nextmv/tests/cloud/test_instance.py
+++ b/nextmv/tests/cloud/test_instance.py
@@ -1,0 +1,87 @@
+import unittest
+
+from nextmv.cloud.instance import InstanceConfiguration
+
+
+class TestInstanceConfigurationValidation(unittest.TestCase):
+    """Test validation logic in InstanceConfiguration.model_post_init."""
+
+    def test_no_integration_id_no_validation(self):
+        """Test that validation is skipped when integration_id is None or empty."""
+        # With None integration_id
+        config = InstanceConfiguration(integration_id=None, execution_class="small")
+        self.assertEqual(config.execution_class, "small")
+
+        # With empty string integration_id
+        config = InstanceConfiguration(integration_id="", execution_class="large")
+        self.assertEqual(config.execution_class, "large")
+
+        # With no integration_id specified
+        config = InstanceConfiguration(execution_class="medium")
+        self.assertEqual(config.execution_class, "medium")
+
+    def test_integration_id_with_integration_execution_class(self):
+        """Test that integration_id with execution_class='integration' is valid."""
+        config = InstanceConfiguration(integration_id="int-12345", execution_class="integration")
+        self.assertEqual(config.integration_id, "int-12345")
+        self.assertEqual(config.execution_class, "integration")
+
+    def test_integration_id_with_none_execution_class(self):
+        """Test that integration_id with execution_class=None sets it to 'integration'."""
+        config = InstanceConfiguration(integration_id="int-12345", execution_class=None)
+        self.assertEqual(config.integration_id, "int-12345")
+        self.assertEqual(config.execution_class, "integration")
+
+    def test_integration_id_without_execution_class(self):
+        """Test that integration_id without execution_class sets it to 'integration'."""
+        config = InstanceConfiguration(integration_id="int-12345")
+        self.assertEqual(config.integration_id, "int-12345")
+        self.assertEqual(config.execution_class, "integration")
+
+    def test_integration_id_with_empty_execution_class(self):
+        """Test that integration_id with execution_class='' sets it to 'integration'."""
+        config = InstanceConfiguration(integration_id="int-12345", execution_class="")
+        self.assertEqual(config.integration_id, "int-12345")
+        self.assertEqual(config.execution_class, "integration")
+
+    def test_integration_id_with_invalid_execution_class_raises_error(self):
+        """Test that integration_id with non-integration execution_class raises ValueError."""
+        invalid_classes = ["small", "medium", "large", "custom", "standard"]
+
+        for execution_class in invalid_classes:
+            with self.subTest(execution_class=execution_class):
+                with self.assertRaises(ValueError) as context:
+                    InstanceConfiguration(integration_id="int-12345", execution_class=execution_class)
+
+                error_msg = str(context.exception)
+                self.assertIn("When integration_id is set", error_msg)
+                self.assertIn("execution_class must be `integration` or None", error_msg)
+
+    def test_integration_id_error_message_format(self):
+        """Test that the error message contains the expected format."""
+        with self.assertRaises(ValueError) as context:
+            InstanceConfiguration(integration_id="int-12345", execution_class="custom")
+
+        error_msg = str(context.exception)
+        # When using model_post_init, Pydantic wraps the error message
+        self.assertIn("When integration_id is set, execution_class must be `integration` or None.", error_msg)
+
+    def test_integration_id_with_other_configuration_options(self):
+        """Test that integration_id works correctly with other configuration options."""
+        config = InstanceConfiguration(
+            integration_id="int-12345", options={"max_runtime": 30}, secrets_collection_id="sc_1234567890"
+        )
+        self.assertEqual(config.integration_id, "int-12345")
+        self.assertEqual(config.execution_class, "integration")
+        self.assertEqual(config.options, {"max_runtime": 30})
+        self.assertEqual(config.secrets_collection_id, "sc_1234567890")
+
+    def test_no_integration_id_with_other_options(self):
+        """Test configuration without integration_id but with other options."""
+        config = InstanceConfiguration(
+            execution_class="small", options={"max_runtime": 60}, secrets_collection_id="sc_9876543210"
+        )
+        self.assertEqual(config.execution_class, "small")
+        self.assertEqual(config.options, {"max_runtime": 60})
+        self.assertEqual(config.secrets_collection_id, "sc_9876543210")
+        self.assertIsNone(config.integration_id)

--- a/nextmv/tests/test_run.py
+++ b/nextmv/tests/test_run.py
@@ -8,6 +8,7 @@ from nextmv.run import (
     FormatOutput,
     Metadata,
     Run,
+    RunConfiguration,
     RunInformation,
     RunTypeConfiguration,
     run_duration,
@@ -206,3 +207,67 @@ class TestRunInformationToRun(unittest.TestCase):
 
                 run = run_info.to_run()
                 self.assertEqual(run.status_v2, status_v2)
+
+
+class TestRunConfigurationValidation(unittest.TestCase):
+    """Test validation logic in RunConfiguration.model_post_init."""
+
+    def test_no_integration_id_no_validation(self):
+        """Test that validation is skipped when integration_id is None or empty."""
+        # With None integration_id
+        config = RunConfiguration(integration_id=None, execution_class="small")
+        self.assertEqual(config.execution_class, "small")
+
+        # With empty string integration_id
+        config = RunConfiguration(integration_id="", execution_class="large")
+        self.assertEqual(config.execution_class, "large")
+
+        # With no integration_id specified
+        config = RunConfiguration(execution_class="medium")
+        self.assertEqual(config.execution_class, "medium")
+
+    def test_integration_id_with_integration_execution_class(self):
+        """Test that integration_id with execution_class='integration' is valid."""
+        config = RunConfiguration(integration_id="int-12345", execution_class="integration")
+        self.assertEqual(config.integration_id, "int-12345")
+        self.assertEqual(config.execution_class, "integration")
+
+    def test_integration_id_with_none_execution_class(self):
+        """Test that integration_id with execution_class=None sets it to 'integration'."""
+        config = RunConfiguration(integration_id="int-12345", execution_class=None)
+        self.assertEqual(config.integration_id, "int-12345")
+        self.assertEqual(config.execution_class, "integration")
+
+    def test_integration_id_without_execution_class(self):
+        """Test that integration_id without execution_class sets it to 'integration'."""
+        config = RunConfiguration(integration_id="int-12345")
+        self.assertEqual(config.integration_id, "int-12345")
+        self.assertEqual(config.execution_class, "integration")
+
+    def test_integration_id_with_empty_execution_class(self):
+        """Test that integration_id with execution_class='' sets it to 'integration'."""
+        config = RunConfiguration(integration_id="int-12345", execution_class="")
+        self.assertEqual(config.integration_id, "int-12345")
+        self.assertEqual(config.execution_class, "integration")
+
+    def test_integration_id_with_invalid_execution_class_raises_error(self):
+        """Test that integration_id with non-integration execution_class raises ValueError."""
+        invalid_classes = ["small", "medium", "large", "custom", "standard"]
+
+        for execution_class in invalid_classes:
+            with self.subTest(execution_class=execution_class):
+                with self.assertRaises(ValueError) as context:
+                    RunConfiguration(integration_id="int-12345", execution_class=execution_class)
+
+                error_msg = str(context.exception)
+                self.assertIn("When integration_id is set", error_msg)
+                self.assertIn("execution_class must be `integration` or None", error_msg)
+
+    def test_integration_id_error_message_format(self):
+        """Test that the error message contains the expected format."""
+        with self.assertRaises(ValueError) as context:
+            RunConfiguration(integration_id="int-12345", execution_class="custom")
+
+        error_msg = str(context.exception)
+        # When using model_post_init, Pydantic wraps the error message
+        self.assertIn("When integration_id is set, execution_class must be `integration` or None.", error_msg)


### PR DESCRIPTION
# Description

Enables one to run with an `integration_id`. Adds some minor clarification to docs around licensing.