### PR TITLE
Moves mlflow dependency to its own optional dependency group

### DIFF
--- a/docs/nextmv/cloud/push.md
+++ b/docs/nextmv/cloud/push.md
@@ -127,7 +127,7 @@ pushed to Nextmv Cloud. To push a `nextmv.Model` to Nextmv Cloud, you need
 optional dependencies. You can install them by running:
 
 ```bash
-pip install "nextmv[all]"
+pip install "nextmv[notebook]"
 ```
 
 Once all the optional dependencies are installed, you can push the app to

--- a/nextmv/nextmv/model.py
+++ b/nextmv/nextmv/model.py
@@ -284,7 +284,7 @@ class Model:
             import mlflow as mlflow
         except ImportError as e:
             raise ImportError(
-                "mlflow is not installed. Please install optional dependencies with `pip install nextmv[all]`"
+                "mlflow is not installed. Please install optional dependencies with `pip install nextmv[notebook]`"
             ) from e
 
         finally:

--- a/nextmv/pyproject.toml
+++ b/nextmv/pyproject.toml
@@ -51,9 +51,11 @@ Repository = "https://github.com/nextmv-io/nextmv-py"
 
 [project.optional-dependencies]
 all = [
-    "mlflow>=2.17.2",
     "folium>=0.20.0",
     "plotly>=6.0.1",
+]
+notebook = [
+    "mlflow>=2.17.2",
 ]
 dev = [
     "build>=1.0.3",

--- a/nextmv/pyproject.toml
+++ b/nextmv/pyproject.toml
@@ -55,7 +55,7 @@ all = [
     "plotly>=6.0.1",
 ]
 notebook = [
-    "mlflow>=2.17.2",
+    "mlflow>=2.19.0",
 ]
 dev = [
     "build>=1.0.3",


### PR DESCRIPTION
# Description

Moves the `mlflow` dependency which causes issues on windows to its own optional dependency group.

## Changes

- Moves `mlflow` dependency from `nextmv[all]` to `nextmv[notebook]` group.