### PR TITLE
Allows downloading assets

### DIFF
--- a/nextmv/nextmv/__about__.py
+++ b/nextmv/nextmv/__about__.py
@@ -1,1 +1,1 @@
-__version__ = "v0.38.0.dev0"
+__version__ = "v0.38.0"

--- a/nextmv/nextmv/__about__.py
+++ b/nextmv/nextmv/__about__.py
@@ -1,1 +1,1 @@
-__version__ = "v0.37.2"
+__version__ = "v0.38.0.dev0"

--- a/nextmv/nextmv/cloud/__init__.py
+++ b/nextmv/nextmv/cloud/__init__.py
@@ -57,6 +57,7 @@ from .account import Queue as Queue
 from .account import QueuedRun as QueuedRun
 from .application import Application as Application
 from .application import poll as poll
+from .assets import RunAsset as RunAsset
 from .batch_experiment import BatchExperiment as BatchExperiment
 from .batch_experiment import BatchExperimentInformation as BatchExperimentInformation
 from .batch_experiment import BatchExperimentMetadata as BatchExperimentMetadata

--- a/nextmv/nextmv/cloud/application.py
+++ b/nextmv/nextmv/cloud/application.py
@@ -22,8 +22,10 @@ poll
     Function to poll for results with configurable options.
 """
 
+import io
 import json
 import os
+import pathlib
 import shutil
 import tarfile
 import tempfile
@@ -37,6 +39,7 @@ from nextmv._serialization import deflated_serialize_json
 from nextmv.base_model import BaseModel
 from nextmv.cloud import package
 from nextmv.cloud.acceptance_test import AcceptanceTest, Metric
+from nextmv.cloud.assets import RunAsset
 from nextmv.cloud.batch_experiment import (
     BatchExperiment,
     BatchExperimentInformation,
@@ -2539,13 +2542,13 @@ class Application:
         except OSError as e:
             raise Exception(f"error deleting output directory: {e}") from e
 
-    def list_run_assets(self, run_id: str) -> list[Asset]:
+    def list_assets(self, run_id: str) -> list[Asset]:
         """
         List the assets of a run.
 
-        Retrieves a list of assets associated with a specific run. Assets can
-        include files or other resources generated during the execution of the
-        run.
+        Retrieves a list of assets associated with a specific run. This method ONLY
+        returns the asset metadata, the content needs to be fetched via the
+        `download_asset` method.
 
         Parameters
         ----------
@@ -2564,35 +2567,39 @@ class Application:
 
         Examples
         --------
-        >>> assets = app.list_run_assets("run-123")
+        >>> assets = app.list_assets("run-123")
         >>> for asset in assets:
-        ...     print(asset.name, asset.url)
-        output.json https://...
-        log.txt https://...
+        ...     print(asset.id, asset.name)
+        b459daa6-1c13-48c6-b4c3-a262ea94cd04 clustering_polygons
+        a1234567-89ab-cdef-0123-456789abcdef histogram
         """
         response = self.client.request(
             method="GET",
             endpoint=f"{self.endpoint}/runs/{run_id}/assets",
         )
-        assets_data = response.json().get("assets", [])
-        return [Asset.from_dict(asset) for asset in assets_data]
+        assets_data = response.json().get("items", [])
+        for asset_data in assets_data:
+            asset_data["run_id"] = run_id
+        return [RunAsset.from_dict(asset) for asset in assets_data]
 
-    def run_asset(self, run_id: str, asset_id: str) -> Asset:
+    def download_asset(self, asset: RunAsset, destination: str | pathlib.Path | io.BytesIO | None = None) -> Any | None:
         """
-        Get a specific asset of a run.
-        Retrieves a specific asset associated with a run by its ID.
+        Downloads an asset to a specified destination.
 
         Parameters
         ----------
-        run_id : str
-            ID of the run to get the asset for.
-        asset_id : str
-            ID of the asset to retrieve.
+        asset : RunAsset
+            The asset to be downloaded.
+        destination : Union[str, pathlib.Path, io.BytesIO, None]
+            The destination where the asset will be saved. This can be a file path
+            (as a string or pathlib.Path) or an io.BytesIO object. If None, the asset
+            content will not be saved to a file, but returned immediately. If the asset
+            type is JSON, the content will be returned as a dict.
 
         Returns
         -------
-        Asset
-            The requested asset.
+        None
+            This method doesn't return anything.
 
         Raises
         ------
@@ -2601,15 +2608,44 @@ class Application:
 
         Examples
         --------
-        >>> asset = app.run_asset("run-123", "asset-456")
-        >>> print(asset.name, asset.url)
-        output.json https://...
+        >>> assets = app.list_assets("run-123")
+        >>> asset = assets[0]  # Assume we want to download the first asset
+        >>> # Download to a file path
+        >>> app.download_asset(asset, "polygons.geojson")
+        >>> # Download to an in-memory bytes buffer
+        >>> import io
+        >>> buffer = io.BytesIO()
+        >>> app.download_asset(asset, buffer)
+        >>> # Download and get content directly (for JSON assets)
+        >>> content = app.download_asset(asset)
+        >>> print(content)
+        {'type': 'FeatureCollection', 'features': [...]}
         """
-        response = self.client.request(
+        # First, get the download_url for the asset.
+        download_url_response = self.client.request(
             method="GET",
-            endpoint=f"{self.endpoint}/runs/{run_id}/assets/{asset_id}",
+            endpoint=f"{self.endpoint}/runs/{asset.run_id}/assets/{asset.id}",
+        ).json()
+        download_url = download_url_response["download_url"]
+        asset_type = download_url_response.get("type", "json")
+
+        # Now, download the asset content using the download_url.
+        download_response = self.client.request(
+            method="GET",
+            endpoint=download_url,
+            headers={"Content-Type": "application/json" if asset_type == "json" else "application/octet-stream"},
         )
-        return Asset.from_dict(response.json())
+
+        # Save the content to the specified destination.
+        if destination is None:
+            if asset_type == "json":
+                return download_response.json()
+            return download_response.content
+        if isinstance(destination, io.BytesIO):
+            destination.write(download_response.content)
+        else:
+            with open(destination, "wb") as file:
+                file.write(download_response.content)
 
     def run_input(self, run_id: str) -> dict[str, Any]:
         """

--- a/nextmv/nextmv/cloud/application.py
+++ b/nextmv/nextmv/cloud/application.py
@@ -2539,6 +2539,78 @@ class Application:
         except OSError as e:
             raise Exception(f"error deleting output directory: {e}") from e
 
+    def list_run_assets(self, run_id: str) -> list[Asset]:
+        """
+        List the assets of a run.
+
+        Retrieves a list of assets associated with a specific run. Assets can
+        include files or other resources generated during the execution of the
+        run.
+
+        Parameters
+        ----------
+        run_id : str
+            ID of the run to list assets for.
+
+        Returns
+        -------
+        list[RunAsset]
+            List of assets associated with the run.
+
+        Raises
+        ------
+        requests.HTTPError
+            If the response status code is not 2xx.
+
+        Examples
+        --------
+        >>> assets = app.list_run_assets("run-123")
+        >>> for asset in assets:
+        ...     print(asset.name, asset.url)
+        output.json https://...
+        log.txt https://...
+        """
+        response = self.client.request(
+            method="GET",
+            endpoint=f"{self.endpoint}/runs/{run_id}/assets",
+        )
+        assets_data = response.json().get("assets", [])
+        return [Asset.from_dict(asset) for asset in assets_data]
+
+    def run_asset(self, run_id: str, asset_id: str) -> Asset:
+        """
+        Get a specific asset of a run.
+        Retrieves a specific asset associated with a run by its ID.
+
+        Parameters
+        ----------
+        run_id : str
+            ID of the run to get the asset for.
+        asset_id : str
+            ID of the asset to retrieve.
+
+        Returns
+        -------
+        Asset
+            The requested asset.
+
+        Raises
+        ------
+        requests.HTTPError
+            If the response status code is not 2xx.
+
+        Examples
+        --------
+        >>> asset = app.run_asset("run-123", "asset-456")
+        >>> print(asset.name, asset.url)
+        output.json https://...
+        """
+        response = self.client.request(
+            method="GET",
+            endpoint=f"{self.endpoint}/runs/{run_id}/assets/{asset_id}",
+        )
+        return Asset.from_dict(response.json())
+
     def run_input(self, run_id: str) -> dict[str, Any]:
         """
         Get the input of a run.

--- a/nextmv/nextmv/cloud/application.py
+++ b/nextmv/nextmv/cloud/application.py
@@ -2542,7 +2542,7 @@ class Application:
         except OSError as e:
             raise Exception(f"error deleting output directory: {e}") from e
 
-    def list_assets(self, run_id: str) -> list[Asset]:
+    def list_assets(self, run_id: str) -> list[RunAsset]:
         """
         List the assets of a run.
 

--- a/nextmv/nextmv/cloud/application.py
+++ b/nextmv/nextmv/cloud/application.py
@@ -2598,8 +2598,11 @@ class Application:
 
         Returns
         -------
-        None
-            This method doesn't return anything.
+        Any or None
+            If ``destination`` is None, returns the asset content: for JSON assets, a
+            ``dict`` parsed from the JSON response; for other asset types, the raw
+            ``bytes`` content. If ``destination`` is provided, the content is written
+            to the given destination and the method returns ``None``.
 
         Raises
         ------

--- a/nextmv/nextmv/cloud/application.py
+++ b/nextmv/nextmv/cloud/application.py
@@ -2548,7 +2548,7 @@ class Application:
 
         Retrieves a list of assets associated with a specific run. This method ONLY
         returns the asset metadata, the content needs to be fetched via the
-        `download_asset` method.
+        `download_asset_content` method.
 
         Parameters
         ----------
@@ -2582,9 +2582,13 @@ class Application:
             asset_data["run_id"] = run_id
         return [RunAsset.from_dict(asset) for asset in assets_data]
 
-    def download_asset(self, asset: RunAsset, destination: str | pathlib.Path | io.BytesIO | None = None) -> Any | None:
+    def download_asset_content(
+        self,
+        asset: RunAsset,
+        destination: str | pathlib.Path | io.BytesIO | None = None,
+    ) -> Any | None:
         """
-        Downloads an asset to a specified destination.
+        Downloads an asset's content to a specified destination.
 
         Parameters
         ----------
@@ -2599,10 +2603,10 @@ class Application:
         Returns
         -------
         Any or None
-            If ``destination`` is None, returns the asset content: for JSON assets, a
-            ``dict`` parsed from the JSON response; for other asset types, the raw
-            ``bytes`` content. If ``destination`` is provided, the content is written
-            to the given destination and the method returns ``None``.
+            If `destination` is None, returns the asset content: for JSON assets, a
+            `dict` parsed from the JSON response; for other asset types, the raw
+            `bytes` content. If `destination` is provided, the content is written
+            to the given destination and the method returns `None`.
 
         Raises
         ------
@@ -2614,13 +2618,13 @@ class Application:
         >>> assets = app.list_assets("run-123")
         >>> asset = assets[0]  # Assume we want to download the first asset
         >>> # Download to a file path
-        >>> app.download_asset(asset, "polygons.geojson")
+        >>> app.download_asset_content(asset, "polygons.geojson")
         >>> # Download to an in-memory bytes buffer
         >>> import io
         >>> buffer = io.BytesIO()
-        >>> app.download_asset(asset, buffer)
+        >>> app.download_asset_content(asset, buffer)
         >>> # Download and get content directly (for JSON assets)
-        >>> content = app.download_asset(asset)
+        >>> content = app.download_asset_content(asset)
         >>> print(content)
         {'type': 'FeatureCollection', 'features': [...]}
         """

--- a/nextmv/nextmv/cloud/application.py
+++ b/nextmv/nextmv/cloud/application.py
@@ -2644,11 +2644,13 @@ class Application:
             if asset_type == "json":
                 return download_response.json()
             return download_response.content
-        if isinstance(destination, io.BytesIO):
+        elif isinstance(destination, io.BytesIO):
             destination.write(download_response.content)
+            return None
         else:
             with open(destination, "wb") as file:
                 file.write(download_response.content)
+            return None
 
     def run_input(self, run_id: str) -> dict[str, Any]:
         """

--- a/nextmv/nextmv/cloud/assets.py
+++ b/nextmv/nextmv/cloud/assets.py
@@ -1,0 +1,66 @@
+from nextmv.base_model import BaseModel
+from nextmv.output import Visual
+
+
+class RunAsset(BaseModel):
+    """
+    Represents downloadable information that is part of the `Output`.
+
+    You can import the `Asset` class directly from `nextmv`:
+
+    ```python
+    from nextmv import Asset
+    ```
+
+    An asset contains content that can be serialized to JSON and optionally
+    includes visual information for rendering in the Nextmv Console.
+
+    Parameters
+    ----------
+    name : str
+        Name of the asset.
+    content : Any
+        Content of the asset. The type must be serializable to JSON.
+    content_type : str, optional
+        Content type of the asset. Only "json" is currently supported. Default is "json".
+    description : str, optional
+        Description of the asset. Default is None.
+    visual : Visual, optional
+        Visual schema of the asset. Default is None.
+
+    Raises
+    ------
+    ValueError
+        If the content_type is not "json".
+
+    Examples
+    --------
+    >>> from nextmv.output import Asset, Visual, VisualSchema
+    >>> visual = Visual(visual_schema=VisualSchema.CHARTJS, label="Solution Progress")
+    >>> asset = Asset(
+    ...     name="optimization_progress",
+    ...     content={"iterations": [1, 2, 3], "values": [10, 8, 7]},
+    ...     description="Optimization progress over iterations",
+    ...     visual=visual
+    ... )
+    >>> asset.name
+    'optimization_progress'
+    """
+
+    id: str
+    """Unique identifier of the asset."""
+    run_id: str
+    """Identifier of the run associated with the asset."""
+    name: str
+    """Name of the asset."""
+    created_at: str
+    """Timestamp of when the asset was created."""
+    size: int
+    """Size of the asset content in bytes."""
+
+    content_type: str | None = "json"
+    """Content type of the asset. Only `json` is allowed"""
+    description: str | None = None
+    """Description of the asset."""
+    visual: Visual | None = None
+    """Visual schema of the asset."""

--- a/nextmv/nextmv/cloud/assets.py
+++ b/nextmv/nextmv/cloud/assets.py
@@ -4,47 +4,32 @@ from nextmv.output import Visual
 
 class RunAsset(BaseModel):
     """
-    Represents downloadable information that is part of the `Output`.
+    Represents an asset associated with a Nextmv Cloud run.
 
-    You can import the `Asset` class directly from `nextmv`:
+    You can import the `RunAsset` class from `nextmv.cloud`:
 
     ```python
-    from nextmv import Asset
+    from nextmv.cloud import RunAsset
     ```
 
-    An asset contains content that can be serialized to JSON and optionally
-    includes visual information for rendering in the Nextmv Console.
+    A run asset represents metadata about an asset associated with a Nextmv Cloud run.
 
     Parameters
     ----------
+    id : str
+        Unique identifier of the asset.
+    run_id : str
+        Identifier of the run associated with the asset.
     name : str
         Name of the asset.
-    content : Any
-        Content of the asset. The type must be serializable to JSON.
-    content_type : str, optional
-        Content type of the asset. Only "json" is currently supported. Default is "json".
-    description : str, optional
-        Description of the asset. Default is None.
-    visual : Visual, optional
-        Visual schema of the asset. Default is None.
-
-    Raises
-    ------
-    ValueError
-        If the content_type is not "json".
-
-    Examples
-    --------
-    >>> from nextmv.output import Asset, Visual, VisualSchema
-    >>> visual = Visual(visual_schema=VisualSchema.CHARTJS, label="Solution Progress")
-    >>> asset = Asset(
-    ...     name="optimization_progress",
-    ...     content={"iterations": [1, 2, 3], "values": [10, 8, 7]},
-    ...     description="Optimization progress over iterations",
-    ...     visual=visual
-    ... )
-    >>> asset.name
-    'optimization_progress'
+    created_at : str
+        Timestamp of when the asset was created.
+    size : int
+        Size of the asset content in bytes.
+    content_type : str
+        Content type of the asset. Only `json` is allowed at the moment.
+    visual : Visual | None, optional
+        Visual schema of the asset, by default None.
     """
 
     id: str
@@ -57,10 +42,7 @@ class RunAsset(BaseModel):
     """Timestamp of when the asset was created."""
     size: int
     """Size of the asset content in bytes."""
-
-    content_type: str | None = "json"
-    """Content type of the asset. Only `json` is allowed"""
-    description: str | None = None
-    """Description of the asset."""
+    content_type: str
+    """Content type of the asset. Only `json` is allowed at the moment."""
     visual: Visual | None = None
     """Visual schema of the asset."""

--- a/nextmv/nextmv/output.py
+++ b/nextmv/nextmv/output.py
@@ -469,9 +469,17 @@ class Asset(BaseModel):
 
     name: str
     """Name of the asset."""
-    content: Any
-    """Content of the asset. The type must be serializable to JSON."""
 
+    id: str | None = None
+    """
+    The ID of the asset. This ID will be populated by the Nextmv platform and can be used
+    to download the asset later.
+    """
+    content: Any | None = None
+    """
+    Content of the asset. The type must be serializable to JSON. Can be empty when
+    fetching the asset metadata only (e.g.: via the asset list endpoint).
+    """
     content_type: str | None = "json"
     """Content type of the asset. Only `json` is allowed"""
     description: str | None = None


### PR DESCRIPTION
# Description

Allows fetching assets of runs.

## Changes

- Allows fetching assets of runs.

## Example

Find some different ways of using the asset download functionality below.

```python
import io
import os
import nextmv.cloud
import nextmv

client = nextmv.cloud.Client(api_key=os.environ["NEXTMV_API_KEY"])
app = nextmv.cloud.Application(client=client, id="<app-id>")

# Get the single asset of the run.
asset = app.list_assets(run_id="<run-id>")[0]

# Download the asset content and put it in a variable (will be a dict for JSON assets)
asset_content = app.download_asset(asset=asset)
print(f"Downloaded asset content: {asset_content}\n")

# Or to a BytesIO buffer
buffer = io.BytesIO()
app.download_asset(asset, buffer)
buffer.seek(0)
print(f"Downloaded asset to BytesIO: {buffer.getvalue()}\n")

# You can also save to a file
app.download_asset(asset, "polygons.json")

# Convert the RunAsset back to an original Asset (e.g., when emitting a sub-app asset in a workflow)
output_asset = nextmv.Asset(
    name=asset.name,
    content_type=asset.content_type,
    visual=asset.visual,
    content=asset_content,
)
```