### PR TITLE
Adds the `community` command tree

### DIFF
--- a/nextmv/nextmv/cli/community/clone.py
+++ b/nextmv/nextmv/cli/community/clone.py
@@ -94,7 +94,7 @@ def clone(
 
         raise typer.Exit(code=1)
 
-    original_version = copy.deepcopy(version)
+    original_version = version
     if version == LATEST_VERSION:
         version = app_obj.get("latest_app_version")
 

--- a/nextmv/nextmv/cli/community/clone.py
+++ b/nextmv/nextmv/cli/community/clone.py
@@ -1,0 +1,62 @@
+"""
+This module defines the community clone command for the Nextmv CLI.
+"""
+
+from typing import Annotated
+
+import typer
+
+from nextmv.cli.options import ProfileOption
+
+# Set up subcommand application.
+app = typer.Typer()
+
+
+@app.command()
+def clone(
+    app: Annotated[
+        str,
+        typer.Option("--app", "-a", help="The name of the community app to clone.", metavar="COMMUNITY_APP"),
+    ],
+    directory: Annotated[
+        str | None,
+        typer.Option(
+            "--directory",
+            "-d",
+            help="The directory in which to clone the app. Default is the name of the app at current directory.",
+            metavar="DIRECTORY",
+        ),
+    ] = None,
+    version: Annotated[
+        str | None,
+        typer.Option(
+            "--version",
+            "-v",
+            help="The version of the community app to clone.",
+            metavar="VERSION",
+        ),
+    ] = "latest",
+    profile: ProfileOption = None,
+) -> None:
+    """
+    Clone a community app locally.
+
+    By default, the [magenta]latest[/magenta] version will be used. You can
+    specify a version with the [code]--version[/code] flag, and customize the
+    output directory with the [code]--directory[/code] flag. If you want to
+    list the available apps, use the [code]nextmv community list[/code] command.
+
+    [bold][underline]Examples[/underline][/bold]
+
+    - Clone the [magenta]go-nextroute[/magenta] community app (under the
+      [magenta]"go-nextroute"[/magenta] directory), using the [magenta]latest[/magenta] version.
+        [green]nextmv community clone --app go-nextroute[/green]
+
+    - Clone the [magenta]go-nextroute[/magenta] community app under the
+      [magenta]"~/sample/my_app"[/magenta] directory, using the [magenta]latest[/magenta] version.
+        [green]nextmv community clone --app go-nextroute --directory ~/sample/my_app[/green]
+
+    - Clone the [magenta]go-nextroute[/magenta] community app (under the
+      [magenta]"go-nextroute"[/magenta] directory), using version [magenta]v1.2.0[/magenta].
+        [green]nextmv community clone --app go-nextroute --version v1.2.0[/green]
+    """

--- a/nextmv/nextmv/cli/community/clone.py
+++ b/nextmv/nextmv/cli/community/clone.py
@@ -2,14 +2,26 @@
 This module defines the community clone command for the Nextmv CLI.
 """
 
+import copy
+import os
+import shutil
+import tarfile
+import tempfile
+from collections.abc import Callable
 from typing import Annotated
 
+import rich
 import typer
 
+from nextmv.cli.community.list import download_file, download_manifest, find_app, versions_table
+from nextmv.cli.error import error
 from nextmv.cli.options import ProfileOption
 
 # Set up subcommand application.
 app = typer.Typer()
+
+# Helpful constants.
+LATEST_VERSION = "latest"
 
 
 @app.command()
@@ -35,7 +47,7 @@ def clone(
             help="The version of the community app to clone.",
             metavar="VERSION",
         ),
-    ] = "latest",
+    ] = LATEST_VERSION,
     profile: ProfileOption = None,
 ) -> None:
     """
@@ -50,13 +62,210 @@ def clone(
 
     - Clone the [magenta]go-nextroute[/magenta] community app (under the
       [magenta]"go-nextroute"[/magenta] directory), using the [magenta]latest[/magenta] version.
-        [green]nextmv community clone --app go-nextroute[/green]
+        $ [green]nextmv community clone --app go-nextroute[/green]
 
     - Clone the [magenta]go-nextroute[/magenta] community app under the
       [magenta]"~/sample/my_app"[/magenta] directory, using the [magenta]latest[/magenta] version.
-        [green]nextmv community clone --app go-nextroute --directory ~/sample/my_app[/green]
+        $ [green]nextmv community clone --app go-nextroute --directory ~/sample/my_app[/green]
 
     - Clone the [magenta]go-nextroute[/magenta] community app (under the
       [magenta]"go-nextroute"[/magenta] directory), using version [magenta]v1.2.0[/magenta].
-        [green]nextmv community clone --app go-nextroute --version v1.2.0[/green]
+        $ [green]nextmv community clone --app go-nextroute --version v1.2.0[/green]
+
+    - Clone the [magenta]go-nextroute[/magenta] community app (under the
+      [magenta]"go-nextroute"[/magenta] directory), using the [magenta]latest[/magenta] version
+      and a profile named [magenta]hare[/magenta].
+        $ [green]nextmv community clone --app go-nextroute --profile hare[/green]
     """
+
+    manifest = download_manifest(profile=profile)
+    app_obj = find_app(manifest, app)
+
+    if version is not None and version == "":
+        error("The [code]--version[/code] flag cannot be an empty string.")
+
+    if not app_has_version(app_obj, version):
+        # We don't use error() here to allow printing something before exiting.
+        rich.print(
+            f"[red]Error:[/red] Version [magenta]{version}[/magenta] not found "
+            f"for community app [magenta]{app}[/magenta]. Available versions are:"
+        )
+        versions_table(manifest, app)
+
+        raise typer.Exit(code=1)
+
+    original_version = copy.deepcopy(version)
+    if version == LATEST_VERSION:
+        version = app_obj.get("latest_app_version")
+
+    destination = directory
+    if directory is None or directory == "":
+        destination = app
+
+    full_destination = get_valid_path(destination, os.stat)
+    os.makedirs(full_destination, exist_ok=True)
+
+    tarball = f"{app}_{version}.tar.gz"
+    s3_file_path = f"{app}/{version}/{tarball}"
+    downloaded_object = download_object(
+        file=s3_file_path,
+        path="community-apps",
+        output_dir=full_destination,
+        output_file=tarball,
+        profile=profile,
+    )
+
+    # Extract the tarball to a temporary directory to handle nested structure
+    with tempfile.TemporaryDirectory() as temp_dir:
+        with tarfile.open(downloaded_object, "r:gz") as tar:
+            tar.extractall(path=temp_dir)
+
+        # Find the extracted directory (typically the app name)
+        extracted_items = os.listdir(temp_dir)
+        if len(extracted_items) == 1 and os.path.isdir(os.path.join(temp_dir, extracted_items[0])):
+            # Move contents from the extracted directory to full_destination
+            extracted_dir = os.path.join(temp_dir, extracted_items[0])
+            for item in os.listdir(extracted_dir):
+                shutil.move(os.path.join(extracted_dir, item), full_destination)
+        else:
+            # If structure is unexpected, move everything directly
+            for item in extracted_items:
+                shutil.move(os.path.join(temp_dir, item), full_destination)
+
+    # Remove the tarball after extraction
+    os.remove(downloaded_object)
+
+    rich.print(
+        f":white_check_mark: Successfully cloned the [magenta]{app}[/magenta] community app, "
+        f"using version [magenta]{original_version}[/magenta] in path: [magenta]{full_destination}[/magenta]."
+    )
+
+
+def app_has_version(app_obj: dict, version: str) -> bool:
+    """
+    Check if the given app object has the specified version.
+
+    Parameters
+    ----------
+    app_obj : dict
+        The community app object.
+    version : str
+        The version to check.
+
+    Returns
+    -------
+    bool
+        True if the app has the specified version, False otherwise.
+    """
+
+    if version == LATEST_VERSION:
+        version = app_obj.get("latest_app_version")
+
+    if version in app_obj.get("app_versions", []):
+        return True
+
+    return False
+
+
+def get_valid_path(path: str, stat_fn: Callable[[str], os.stat_result], ending: str = "") -> str:
+    """
+    Validates and returns a non-existing path. If the path exists,
+    it will append a number to the path and return it. If the path does not
+    exist, it will return the path as is.
+
+    The ending parameter is used to check if the path ends with a specific
+    string. This is useful to specify if it is a file (like foo.json, in which
+    case the next iteration is foo-1.json) or a directory (like foo, in which
+    case the next iteration is foo-1).
+
+    Parameters
+    ----------
+    path : str
+        The initial path to validate.
+    stat_fn : Callable[[str], os.stat_result]
+        A function that takes a path and returns its stat result.
+    ending : str, optional
+        The expected ending of the path (e.g., file extension), by default "".
+
+    Returns
+    -------
+    str
+        A valid, non-existing path.
+
+    Raises
+    ------
+    Exception
+        If an unexpected error occurs during path validation
+    """
+    base_name = os.path.basename(path)
+    name_without_ending = base_name.removesuffix(ending) if ending else base_name
+
+    while True:
+        try:
+            stat_fn(path)
+            # If we get here, the path exists
+            # Get folder/file name number, increase it and create new path
+            name = os.path.basename(path)
+
+            # Get folder/file name number
+            parts = name.split("-")
+            last = parts[-1].removesuffix(ending) if ending else parts[-1]
+
+            # Save last folder name index to be changed
+            i = path.rfind(name)
+
+            try:
+                num = int(last)
+                # Increase number and create new path
+                if ending:
+                    temp_path = path[:i] + f"{name_without_ending}-{num + 1}{ending}"
+                else:
+                    temp_path = path[:i] + f"{base_name}-{num + 1}"
+                path = temp_path
+            except ValueError:
+                # If there is no number, add it
+                if ending:
+                    temp_path = path[:i] + f"{name_without_ending}-1{ending}"
+                else:
+                    temp_path = path[:i] + f"{name}-1"
+                path = temp_path
+
+        except FileNotFoundError:
+            # Path doesn't exist, we can use it
+            return path
+        except Exception:
+            # Re-raise unexpected errors
+            error(f"An unexpected error occurred while validating the path: {path}")
+
+
+def download_object(file: str, path: str, output_dir: str, output_file: str, profile: str | None = None) -> str:
+    """
+    Downloads an object from the internal bucket and saves it to the specified
+    output directory.
+
+    Parameters
+    ----------
+    file : str
+        The name of the file to download.
+    path : str
+        The directory in the bucket where the file is located.
+    output_dir : str
+        The local directory where the file will be saved.
+    output_file : str
+        The name of the output file.
+    profile : str | None
+        The profile name to use. If None, the default profile is used.
+
+    Returns
+    -------
+    str
+        The path to the downloaded file.
+    """
+
+    response = download_file(directory=path, file=file, profile=profile)
+    file_name = os.path.join(output_dir, output_file)
+
+    with open(file_name, "wb") as f:
+        f.write(response.content)
+
+    return file_name

--- a/nextmv/nextmv/cli/community/clone.py
+++ b/nextmv/nextmv/cli/community/clone.py
@@ -2,7 +2,6 @@
 This module defines the community clone command for the Nextmv CLI.
 """
 
-import copy
 import os
 import shutil
 import tarfile

--- a/nextmv/nextmv/cli/community/community.py
+++ b/nextmv/nextmv/cli/community/community.py
@@ -1,0 +1,24 @@
+"""
+This module defines the community command tree for the Nextmv CLI.
+"""
+
+import typer
+
+from nextmv.cli.community.clone import app as clone_app
+from nextmv.cli.community.list import app as list_app
+
+# Set up subcommand application.
+app = typer.Typer()
+app.add_typer(list_app)
+app.add_typer(clone_app)
+
+
+@app.callback()
+def callback() -> None:
+    """
+    Interact with community apps, which are pre-built decision models.
+
+    Community apps are maintained in the following GitHub repository:
+    [link=https://github.com/nextmv-io/community-apps][bold]nextmv-io/community-apps[/bold][/link].
+    """
+    pass

--- a/nextmv/nextmv/cli/community/list.py
+++ b/nextmv/nextmv/cli/community/list.py
@@ -136,6 +136,8 @@ def apps_list(manifest: dict[str, Any]) -> None:
 
     names = [app.get("name", "") for app in manifest.get("apps", [])]
     print("\n".join(names))
+
+
 def versions_table(manifest: dict[str, Any], app: str) -> None:
     """
     This function prints a table of versions for a specific community app.
@@ -184,7 +186,7 @@ def versions_list(manifest: dict[str, Any], app: str) -> None:
     for version in versions:
         versions_output += f"{version}\n"
 
-    print(versions_output.rstrip())
+    print("\n".join(app_obj.get("app_versions", [])))
 
 
 def download_file(

--- a/nextmv/nextmv/cli/community/list.py
+++ b/nextmv/nextmv/cli/community/list.py
@@ -134,14 +134,8 @@ def apps_list(manifest: dict[str, Any]) -> None:
         The community apps manifest.
     """
 
-    apps = ""
-    for app in manifest.get("apps", []):
-        name = app.get("name", "")
-        apps += f"{name}\n"
-
-    print(apps.rstrip())
-
-
+    names = [app.get("name", "") for app in manifest.get("apps", [])]
+    print("\n".join(names))
 def versions_table(manifest: dict[str, Any], app: str) -> None:
     """
     This function prints a table of versions for a specific community app.

--- a/nextmv/nextmv/cli/community/list.py
+++ b/nextmv/nextmv/cli/community/list.py
@@ -1,0 +1,242 @@
+"""
+This module defines the community list command for the Nextmv CLI.
+"""
+
+from typing import Annotated, Any
+
+import requests
+import typer
+import yaml
+from rich.console import Console
+from rich.table import Table
+
+from nextmv.cli.configuration.config import build_client
+from nextmv.cli.error import error
+from nextmv.cli.options import ProfileOption
+
+# Set up subcommand application.
+app = typer.Typer()
+console = Console()
+
+
+@app.command()
+def list(
+    app: Annotated[
+        str | None,
+        typer.Option("--app", "-a", help="The community app to list versions for.", metavar="COMMUNITY_APP"),
+    ] = None,
+    flat: Annotated[bool, typer.Option("--flat", "-f", help="Flatten the list output.")] = False,
+    profile: ProfileOption = None,
+) -> None:
+    """
+    List the available community apps
+
+    Use the [code]--app[/code] flag to list that app's versions. Use the
+    [code]--flat[/code] flag to to flatten the list of names/versions. If you
+    want to clone a community app locally, use the [code]nextmv community clone[/code] command.
+
+    [bold][underline]Examples[/underline][/bold]
+
+    - List the available community apps.
+        [green]nextmv community list[/green]
+
+    - List the available versions of the [magenta]go-nextroute[/magenta] community app.
+        [green]nextmv community list --app go-nextroute[/green]
+
+    - List the names of the available community apps as a flat list.
+        [green]nextmv community list --flat[/green]
+
+    - List the available versions of the [magenta]go-nextroute[/magenta] community app as a flat list.
+        [green]nextmv community list --app go-nextroute --flat[/green]
+
+    - List the available community apps using a profile named [magenta]hare[/magenta].
+        [green]nextmv community list --profile hare[/green]
+    """
+
+    if app is not None and app == "":
+        error("The [code]--app[/code] flag cannot be an empty string.")
+
+    manifest = download_manifest(profile=profile)
+    if flat and app is None:
+        apps_list(manifest)
+        typer.Exit()
+    elif not flat and app is None:
+        apps_table(manifest)
+        typer.Exit()
+    elif flat and app is not None and app != "":
+        versions_list(manifest, app)
+        typer.Exit()
+    elif not flat and app is not None and app != "":
+        versions_table(manifest, app)
+        typer.Exit()
+
+
+def download_manifest(profile: str | None = None) -> dict:
+    """
+    Downloads and returns the community apps manifest.
+
+    Parameters
+    ----------
+    profile : str | None
+        The profile name to use. If None, the default profile is used.
+
+    Returns
+    -------
+    dict
+        The community apps manifest as a dictionary.
+
+    Raises
+    requests.HTTPError
+        If the response status code is not 2xx.
+    """
+
+    response = download_file(directory="community-apps", file="manifest.yml", profile=profile)
+    manifest = yaml.safe_load(response.text)
+
+    return manifest
+
+
+def apps_table(manifest: dict[str, Any]) -> None:
+    """
+    This function prints a table of community apps from the manifest.
+
+    Parameters
+    ----------
+    manifest : dict[str, Any]
+        The community apps manifest.
+    """
+
+    table = Table("Name", "Type", "Latest", "Description", border_style="cyan", header_style="cyan")
+    for app in manifest.get("apps", []):
+        table.add_row(
+            app.get("name", ""),
+            app.get("type", ""),
+            app.get("latest_app_version", ""),
+            app.get("description", ""),
+        )
+
+    console.print(table)
+
+
+def apps_list(manifest: dict[str, Any]) -> None:
+    """
+    This function prints a flat list of community app names from the manifest.
+
+    Parameters
+    ----------
+    manifest : dict[str, Any]
+        The community apps manifest.
+    """
+
+    apps = ""
+    for app in manifest.get("apps", []):
+        name = app.get("name", "")
+        apps += f"{name}\n"
+
+    print(apps.rstrip())
+
+
+def versions_table(manifest: dict[str, Any], app: str) -> None:
+    """
+    This function prints a table of versions for a specific community app.
+
+    Parameters
+    ----------
+    manifest : dict[str, Any]
+        The community apps manifest.
+    app : str
+        The name of the community app.
+    """
+
+    for manifest_app in manifest.get("apps", []):
+        if manifest_app.get("name", "") == app:
+            app_obj = manifest_app
+            break
+
+    latest_version = app_obj.get("latest_app_version", "")
+
+    # Add the latest version with indicator
+    table = Table("Version", "Latest?", border_style="cyan", header_style="cyan")
+    table.add_row(f"[cyan underline]{latest_version}[/cyan underline]", "[cyan]<--[/cyan]")
+    table.add_row("", "")  # Empty row to separate latest from others.
+
+    # Add all other versions (excluding the latest)
+    versions = app_obj.get("app_versions", [])
+    for version in versions:
+        if version != latest_version:
+            table.add_row(version, "")
+
+    console.print(table)
+
+
+def versions_list(manifest: dict[str, Any], app: str) -> None:
+    """
+    This function prints a flat list of versions for a specific community app.
+
+    Parameters
+    ----------
+    manifest : dict[str, Any]
+        The community apps manifest.
+    app : str
+        The name of the community app.
+    """
+
+    for manifest_app in manifest.get("apps", []):
+        if manifest_app.get("name", "") == app:
+            app_obj = manifest_app
+            break
+
+    versions = app_obj.get("app_versions", [])
+    versions_output = ""
+    for version in versions:
+        versions_output += f"{version}\n"
+
+    print(versions_output.rstrip())
+
+
+def download_file(
+    directory: str,
+    file: str,
+    profile: str | None = None,
+) -> requests.Response:
+    """
+    Gets a file from an internal bucket and return it.
+
+    Parameters
+    ----------
+    directory : str
+        The directory in the bucket where the file is located.
+    file : str
+        The name of the file to download.
+    profile : str | None
+        The profile name to use. If None, the default profile is used.
+
+    Returns
+    -------
+    requests.Response
+        The response object containing the file data.
+
+    Raises
+    requests.HTTPError
+        If the response status code is not 2xx.
+    """
+
+    client = build_client(profile)
+
+    # Request the download URL for the file.
+    response = client.request(
+        method="GET",
+        endpoint="v0/internal/tools",
+        headers=client.headers | {"request-source": "cli"},  # Pass `client.headers` to preserve auth.
+        query_params={"file": f"{directory}/{file}"},
+    )
+
+    # Use the URL obtained to download the file.
+    body = response.json()
+    download_response = client.request(
+        method="GET",
+        endpoint=body.get("url"),
+        headers={"Content-Type": "application/json"},
+    )
+
+    return download_response

--- a/nextmv/nextmv/cli/community/list.py
+++ b/nextmv/nextmv/cli/community/list.py
@@ -65,16 +65,16 @@ def list(
     manifest = download_manifest(profile=profile)
     if flat and app is None:
         apps_list(manifest)
-        typer.Exit()
+        raise typer.Exit()
     elif not flat and app is None:
         apps_table(manifest)
-        typer.Exit()
+        raise typer.Exit()
     elif flat and app is not None and app != "":
         versions_list(manifest, app)
-        typer.Exit()
+        raise typer.Exit()
     elif not flat and app is not None and app != "":
         versions_table(manifest, app)
-        typer.Exit()
+        raise typer.Exit()
 
 
 def download_manifest(profile: str | None = None) -> dict:

--- a/nextmv/nextmv/cli/community/list.py
+++ b/nextmv/nextmv/cli/community/list.py
@@ -38,7 +38,7 @@ def list(
     List the available community apps
 
     Use the [code]--app[/code] flag to list that app's versions. Use the
-    [code]--flat[/code] flag to to flatten the list of names/versions. If you
+    [code]--flat[/code] flag to flatten the list of names/versions. If you
     want to clone a community app locally, use the [code]nextmv community clone[/code] command.
 
     [bold][underline]Examples[/underline][/bold]

--- a/nextmv/nextmv/cli/community/list.py
+++ b/nextmv/nextmv/cli/community/list.py
@@ -5,6 +5,7 @@ This module defines the community list command for the Nextmv CLI.
 from typing import Annotated, Any
 
 import requests
+import rich
 import typer
 import yaml
 from rich.console import Console
@@ -23,7 +24,12 @@ console = Console()
 def list(
     app: Annotated[
         str | None,
-        typer.Option("--app", "-a", help="The community app to list versions for.", metavar="COMMUNITY_APP"),
+        typer.Option(
+            "--app",
+            "-a",
+            help="The community app to list versions for.",
+            metavar="COMMUNITY_APP",
+        ),
     ] = None,
     flat: Annotated[bool, typer.Option("--flat", "-f", help="Flatten the list output.")] = False,
     profile: ProfileOption = None,
@@ -38,19 +44,19 @@ def list(
     [bold][underline]Examples[/underline][/bold]
 
     - List the available community apps.
-        [green]nextmv community list[/green]
+        $ [green]nextmv community list[/green]
 
     - List the available versions of the [magenta]go-nextroute[/magenta] community app.
-        [green]nextmv community list --app go-nextroute[/green]
+        $ [green]nextmv community list --app go-nextroute[/green]
 
     - List the names of the available community apps as a flat list.
-        [green]nextmv community list --flat[/green]
+        $ [green]nextmv community list --flat[/green]
 
     - List the available versions of the [magenta]go-nextroute[/magenta] community app as a flat list.
-        [green]nextmv community list --app go-nextroute --flat[/green]
+        $ [green]nextmv community list --app go-nextroute --flat[/green]
 
     - List the available community apps using a profile named [magenta]hare[/magenta].
-        [green]nextmv community list --profile hare[/green]
+        $ [green]nextmv community list --profile hare[/green]
     """
 
     if app is not None and app == "":
@@ -148,11 +154,7 @@ def versions_table(manifest: dict[str, Any], app: str) -> None:
         The name of the community app.
     """
 
-    for manifest_app in manifest.get("apps", []):
-        if manifest_app.get("name", "") == app:
-            app_obj = manifest_app
-            break
-
+    app_obj = find_app(manifest, app)
     latest_version = app_obj.get("latest_app_version", "")
 
     # Add the latest version with indicator
@@ -181,12 +183,9 @@ def versions_list(manifest: dict[str, Any], app: str) -> None:
         The name of the community app.
     """
 
-    for manifest_app in manifest.get("apps", []):
-        if manifest_app.get("name", "") == app:
-            app_obj = manifest_app
-            break
-
+    app_obj = find_app(manifest, app)
     versions = app_obj.get("app_versions", [])
+
     versions_output = ""
     for version in versions:
         versions_output += f"{version}\n"
@@ -240,3 +239,31 @@ def download_file(
     )
 
     return download_response
+
+
+def find_app(manifest: dict[str, Any], app: str) -> dict[str, Any] | None:
+    """
+    Finds and returns a community app from the manifest by its name.
+
+    Parameters
+    ----------
+    manifest : dict[str, Any]
+        The community apps manifest.
+    app : str
+        The name of the community app to find.
+
+    Returns
+    -------
+    dict[str, Any] | None
+        The community app dictionary if found, otherwise None.
+    """
+
+    for manifest_app in manifest.get("apps", []):
+        if manifest_app.get("name", "") == app:
+            return manifest_app
+
+    # We don't use error() here to allow printing something before exiting.
+    rich.print(f"[red]Error:[/red] Community app [magenta]{app}[/magenta] was not found. Here are the available apps:")
+    apps_table(manifest)
+
+    raise typer.Exit(code=1)

--- a/nextmv/nextmv/cli/configuration/config.py
+++ b/nextmv/nextmv/cli/configuration/config.py
@@ -61,13 +61,26 @@ def build_client(profile: str | None = None) -> Client:
     """
     Builds a `cloud.Client` using the API key and endpoint for the given
     profile. If no profile is given, the default profile is used. If either the
-    API key or endpoint is missing, an exception is raised. Is the config is
+    API key or endpoint is missing, an exception is raised. If the config is
     not available, an exception is raised.
 
     Parameters
     ----------
     profile : str | None
         The profile name to use. If None, the default profile is used.
+
+    Returns
+    -------
+    Client
+        A client configured with the API key and endpoint for the selected
+        profile or the default configuration.
+
+    Raises
+    ------
+    typer.Exit
+        If no configuration is found, if the requested profile does not exist,
+        or if the API key or endpoint (for either the selected profile or the
+        default configuration) is not set or is empty.
     """
 
     config = load_config()

--- a/nextmv/nextmv/cli/configuration/config.py
+++ b/nextmv/nextmv/cli/configuration/config.py
@@ -7,6 +7,9 @@ from typing import Any
 
 import yaml
 
+from nextmv.cli.error import error
+from nextmv.cloud.client import Client
+
 # Some useful constants.
 CONFIG_DIR = Path.home() / ".nextmv"
 CONFIG_FILE = CONFIG_DIR / "config.yaml"
@@ -52,6 +55,46 @@ def save_config(config: dict[str, Any]) -> None:
 
     with CONFIG_FILE.open("w") as file:
         yaml.safe_dump(config, file)
+
+
+def build_client(profile: str | None = None) -> Client:
+    """
+    Builds a `cloud.Client` using the API key and endpoint for the given
+    profile. If no profile is given, the default profile is used. If either the
+    API key or endpoint is missing, an exception is raised. Is the config is
+    not available, an exception is raised.
+
+    Parameters
+    ----------
+    profile : str | None
+        The profile name to use. If None, the default profile is used.
+    """
+
+    config = load_config()
+    if config == {}:
+        error("No configuration found. Please run [code]nextmv configuration create[/code].")
+
+    if profile is not None:
+        if profile not in config:
+            error(f"Profile [bold magenta]{profile}[/bold magenta] does not exist.")
+
+        api_key = config[profile].get(API_KEY_KEY)
+        if api_key is None or api_key == "":
+            error(f"API key for profile [bold magenta]{profile}[/bold magenta] is not set or is empty.")
+
+        endpoint = config[profile].get(ENDPOINT_KEY)
+        if endpoint is None or endpoint == "":
+            error(f"Endpoint for profile [bold magenta]{profile}[/bold magenta] is not set or is empty.")
+    else:
+        api_key = config.get(API_KEY_KEY)
+        if api_key is None or api_key == "":
+            error("Default API key is not set or is empty.")
+
+        endpoint = config.get(ENDPOINT_KEY)
+        if endpoint is None or endpoint == "":
+            error("Default endpoint is not set or is empty.")
+
+    return Client(api_key=api_key, url=f"https://{endpoint}")
 
 
 def obscure_api_key(api_key: str) -> str:

--- a/nextmv/nextmv/cli/configuration/create.py
+++ b/nextmv/nextmv/cli/configuration/create.py
@@ -4,8 +4,8 @@ This module defines the configuration create command for the Nextmv CLI.
 
 from typing import Annotated
 
+import rich
 import typer
-from rich import print
 
 from nextmv.cli.configuration.config import (
     API_KEY_KEY,
@@ -59,10 +59,10 @@ def create(
     [bold][underline]Examples[/underline][/bold]
 
     - Default configuration.
-        [green]nextmv configuration create --api-key NEXTMV_API_KEY[/green]
+        $ [green]nextmv configuration create --api-key NEXTMV_API_KEY[/green]
 
     - Configure a profile named [italic]hare[/italic].
-        [green]nextmv configuration create --api-key NEXTMV_API_KEY --profile hare[/green]
+        $ [green]nextmv configuration create --api-key NEXTMV_API_KEY --profile hare[/green]
     """
 
     if profile is not None and profile.strip().lower() == "default":
@@ -88,8 +88,8 @@ def create(
 
     save_config(config)
 
-    print(":white_check_mark: Configuration saved successfully.")
-    print(f"\t[bold]Profile[/bold]: {profile or 'Default'}")
-    print(f"\t[bold]API Key[/bold]: {obscure_api_key(api_key)}")
+    rich.print(":white_check_mark: Configuration saved successfully.")
+    rich.print(f"\t[bold]Profile[/bold]: {profile or 'Default'}")
+    rich.print(f"\t[bold]API Key[/bold]: {obscure_api_key(api_key)}")
     if endpoint != DEFAULT_ENDPOINT:
-        print(f"\t[bold]Endpoint[/bold]: {endpoint}")
+        rich.print(f"\t[bold]Endpoint[/bold]: {endpoint}")

--- a/nextmv/nextmv/cli/configuration/delete.py
+++ b/nextmv/nextmv/cli/configuration/delete.py
@@ -4,8 +4,8 @@ This module defines the configuration delete command for the Nextmv CLI.
 
 from typing import Annotated
 
+import rich
 import typer
-from rich import print
 from rich.prompt import Confirm
 
 from nextmv.cli.configuration.config import load_config, save_config
@@ -34,7 +34,7 @@ def delete(
     [bold][underline]Examples[/underline][/bold]
 
     - Delete a profile named [magenta]hare[/magenta].
-        [green]nextmv configuration delete --profile hare[/green]
+        $ [green]nextmv configuration delete --profile hare[/green]
     """
     config = load_config()
     if profile not in config:
@@ -46,10 +46,10 @@ def delete(
     )
 
     if not confirm:
-        print(f":bulb: Profile [bold magenta]{profile}[/bold magenta] will not be deleted.")
+        rich.print(f":bulb: Profile [bold magenta]{profile}[/bold magenta] will not be deleted.")
         return
 
     del config[profile]
     save_config(config)
 
-    print(f":white_check_mark: Profile [bold magenta]{profile}[/bold magenta] deleted successfully.")
+    rich.print(f":white_check_mark: Profile [bold magenta]{profile}[/bold magenta] deleted successfully.")

--- a/nextmv/nextmv/cli/configuration/delete.py
+++ b/nextmv/nextmv/cli/configuration/delete.py
@@ -33,23 +33,23 @@ def delete(
 
     [bold][underline]Examples[/underline][/bold]
 
-    - Delete a profile named [italic]hare[/italic].
+    - Delete a profile named [magenta]hare[/magenta].
         [green]nextmv configuration delete --profile hare[/green]
     """
     config = load_config()
     if profile not in config:
-        error(f"Profile [bold cyan]{profile}[/bold cyan] does not exist.")
+        error(f"Profile [bold magenta]{profile}[/bold magenta] does not exist.")
 
     confirm = Confirm.ask(
-        f"Are you sure you want to delete profile [bold cyan]{profile}[/bold cyan]? This action cannot be undone",
+        f"Are you sure you want to delete profile [bold magenta]{profile}[/bold magenta]? This action cannot be undone",
         default=False,
     )
 
     if not confirm:
-        print(f":bulb: Profile [bold cyan]{profile}[/bold cyan] will not be deleted.")
+        print(f":bulb: Profile [bold magenta]{profile}[/bold magenta] will not be deleted.")
         return
 
     del config[profile]
     save_config(config)
 
-    print(f":white_check_mark: Profile [bold cyan]{profile}[/bold cyan] deleted successfully.")
+    print(f":white_check_mark: Profile [bold magenta]{profile}[/bold magenta] deleted successfully.")

--- a/nextmv/nextmv/cli/configuration/list.py
+++ b/nextmv/nextmv/cli/configuration/list.py
@@ -22,7 +22,7 @@ def list() -> None:
     [bold][underline]Examples[/underline][/bold]
 
     - Show current configuration and all profiles.
-        [green]nextmv configuration list[/green]
+        $ [green]nextmv configuration list[/green]
     """
 
     config = load_config()

--- a/nextmv/nextmv/cli/error.py
+++ b/nextmv/nextmv/cli/error.py
@@ -1,5 +1,5 @@
+import rich
 import typer
-from rich import print
 
 
 def error(msg: str) -> None:
@@ -18,5 +18,5 @@ def error(msg: str) -> None:
         Exits the program with code 1.
     """
 
-    print(f"[red]Error:[/red] {msg}")
+    rich.print(f"[red]Error:[/red] {msg}")
     raise typer.Exit(code=1)

--- a/nextmv/nextmv/cli/main.py
+++ b/nextmv/nextmv/cli/main.py
@@ -15,8 +15,8 @@ epilog of the Typer application defined below.
 
 import os
 
+import rich
 import typer
-from rich import print
 from rich.prompt import Confirm
 
 from nextmv.cli.community.community import app as community_app
@@ -70,7 +70,7 @@ def handle_go_cli() -> None:
         if delete:
             remove_go_cli()
         else:
-            print(
+            rich.print(
                 ":bulb: You can delete the [italic red]deprecated[/italic red] Nextmv CLI "
                 f"later by removing [italic]{GO_CLI_PATH}[/italic]. Make sure you also clean up your [code]PATH[/code]."
             )
@@ -109,7 +109,7 @@ def go_cli_exists() -> bool:
     # Check if the Go CLI executable exists
     exists = GO_CLI_PATH.exists()
     if exists:
-        print(
+        rich.print(
             ":construction: A [italic red]deprecated[/italic red] Nextmv CLI is installed at "
             f"[italic]{GO_CLI_PATH}[/italic]. You must delete it to avoid conflicts."
         )
@@ -126,7 +126,7 @@ def remove_go_cli() -> None:
 
     if GO_CLI_PATH.exists():
         GO_CLI_PATH.unlink()
-        print(f":white_check_mark: Deleted deprecated {GO_CLI_PATH}.")
+        rich.print(f":white_check_mark: Deleted deprecated {GO_CLI_PATH}.")
 
     check_config_in_path()
 
@@ -140,7 +140,7 @@ def check_config_in_path() -> None:
     config_dir_str = str(CONFIG_DIR)
 
     if config_dir_str in path_dirs:
-        print(
+        rich.print(
             f":construction: [italic]{CONFIG_DIR}[/italic] was found in your [code]PATH[/code]. "
             f"You should remove any entries related to [italic]{CONFIG_DIR}[/italic] from your [code]PATH[/code]."
         )

--- a/nextmv/nextmv/cli/main.py
+++ b/nextmv/nextmv/cli/main.py
@@ -19,6 +19,7 @@ import typer
 from rich import print
 from rich.prompt import Confirm
 
+from nextmv.cli.community.community import app as community_app
 from nextmv.cli.configuration.config import CONFIG_DIR, GO_CLI_PATH, load_config
 from nextmv.cli.configuration.configuration import app as configuration_app
 from nextmv.cli.error import error
@@ -33,8 +34,10 @@ app = typer.Typer(
     no_args_is_help=True,
 )
 
-# Register subcommands.
-app.add_typer(configuration_app, name="configuration")  # Requires a name due to callback in configuration.py.
+# Register subcommands. The `name` parameter is required when the subcommand
+# module has a callback function defined.
+app.add_typer(community_app, name="community")
+app.add_typer(configuration_app, name="configuration")
 app.add_typer(version_app)
 
 

--- a/nextmv/nextmv/cli/options.py
+++ b/nextmv/nextmv/cli/options.py
@@ -9,14 +9,15 @@ from typing import Annotated
 
 import typer
 
-# Profile option - can be used in any command to specify which profile to use.
-# Usage: profile: ProfileOption = None
+# profile option - can be used in any command to specify which profile to use.
+# Define it as follows in commands or callbacks, as necessary:
+# profile: ProfileOption = None
 ProfileOption = Annotated[
     str | None,
     typer.Option(
         "--profile",
         "-p",
-        help="Specify the profile to use. Use [code]nextmv configuration[/code] to manage profiles.",
+        help="Profile to use for this action. Use [code]nextmv configuration[/code] to manage profiles.",
         envvar="NEXTMV_PROFILE",
         metavar="PROFILE_NAME",
     ),

--- a/nextmv/tests/cli/test_community.py
+++ b/nextmv/tests/cli/test_community.py
@@ -1,0 +1,665 @@
+"""
+Unit tests for the nextmv community CLI commands.
+"""
+
+import os
+import tempfile
+import unittest
+from unittest.mock import MagicMock, Mock, mock_open, patch
+
+from nextmv.cli.community.clone import app as clone_app
+from nextmv.cli.community.clone import app_has_version, download_object, get_valid_path
+from nextmv.cli.community.community import app as community_app
+from nextmv.cli.community.list import app as list_app
+from nextmv.cli.community.list import (
+    apps_list,
+    apps_table,
+    download_file,
+    download_manifest,
+    find_app,
+    versions_list,
+    versions_table,
+)
+from typer.testing import CliRunner
+
+
+class TestCommunityListCommand(unittest.TestCase):
+    """Tests for the community list command."""
+
+    def setUp(self):
+        self.runner = CliRunner()
+        self.app = list_app
+        self.sample_manifest = {
+            "apps": [
+                {
+                    "name": "go-nextroute",
+                    "type": "go",
+                    "latest_app_version": "v1.2.0",
+                    "description": "A routing app",
+                    "app_versions": ["v1.2.0", "v1.1.0", "v1.0.0"],
+                },
+                {
+                    "name": "python-knapsack",
+                    "type": "python",
+                    "latest_app_version": "v2.0.0",
+                    "description": "A knapsack solver",
+                    "app_versions": ["v2.0.0", "v1.5.0"],
+                },
+            ]
+        }
+
+    @patch("nextmv.cli.community.list.download_manifest")
+    @patch("nextmv.cli.community.list.apps_table")
+    def test_list_default_shows_apps_table(self, mock_apps_table, mock_download_manifest):
+        """Test that list without flags shows apps table."""
+        mock_download_manifest.return_value = self.sample_manifest
+
+        result = self.runner.invoke(self.app, [])
+
+        self.assertEqual(result.exit_code, 0)
+        mock_download_manifest.assert_called_once_with(profile=None)
+        mock_apps_table.assert_called_once_with(self.sample_manifest)
+
+    @patch("nextmv.cli.community.list.download_manifest")
+    @patch("nextmv.cli.community.list.apps_list")
+    def test_list_flat_shows_apps_list(self, mock_apps_list, mock_download_manifest):
+        """Test that list with --flat flag shows apps list."""
+        mock_download_manifest.return_value = self.sample_manifest
+
+        result = self.runner.invoke(self.app, ["--flat"])
+
+        self.assertEqual(result.exit_code, 0)
+        mock_download_manifest.assert_called_once_with(profile=None)
+        mock_apps_list.assert_called_once_with(self.sample_manifest)
+
+    @patch("nextmv.cli.community.list.download_manifest")
+    @patch("nextmv.cli.community.list.versions_table")
+    def test_list_with_app_shows_versions_table(self, mock_versions_table, mock_download_manifest):
+        """Test that list with --app flag shows versions table."""
+        mock_download_manifest.return_value = self.sample_manifest
+
+        result = self.runner.invoke(self.app, ["--app", "go-nextroute"])
+
+        self.assertEqual(result.exit_code, 0)
+        mock_download_manifest.assert_called_once_with(profile=None)
+        mock_versions_table.assert_called_once_with(self.sample_manifest, "go-nextroute")
+
+    @patch("nextmv.cli.community.list.download_manifest")
+    @patch("nextmv.cli.community.list.versions_list")
+    def test_list_with_app_and_flat_shows_versions_list(self, mock_versions_list, mock_download_manifest):
+        """Test that list with --app and --flat flags shows versions list."""
+        mock_download_manifest.return_value = self.sample_manifest
+
+        result = self.runner.invoke(self.app, ["--app", "go-nextroute", "--flat"])
+
+        self.assertEqual(result.exit_code, 0)
+        mock_download_manifest.assert_called_once_with(profile=None)
+        mock_versions_list.assert_called_once_with(self.sample_manifest, "go-nextroute")
+
+    @patch("nextmv.cli.community.list.download_manifest")
+    def test_list_with_empty_app_string_errors(self, mock_download_manifest):
+        """Test that list with empty --app string returns error."""
+        mock_download_manifest.return_value = self.sample_manifest
+
+        result = self.runner.invoke(self.app, ["--app", ""])
+
+        self.assertEqual(result.exit_code, 1)
+        self.assertIn("cannot be an empty string", result.output)
+
+    @patch("nextmv.cli.community.list.download_manifest")
+    @patch("nextmv.cli.community.list.apps_table")
+    def test_list_with_profile(self, mock_apps_table, mock_download_manifest):
+        """Test that list with --profile flag passes profile to download_manifest."""
+        mock_download_manifest.return_value = self.sample_manifest
+
+        result = self.runner.invoke(self.app, ["--profile", "test-profile"])
+
+        self.assertEqual(result.exit_code, 0)
+        mock_download_manifest.assert_called_once_with(profile="test-profile")
+
+
+class TestDownloadManifest(unittest.TestCase):
+    """Tests for the download_manifest function."""
+
+    @patch("nextmv.cli.community.list.download_file")
+    @patch("nextmv.cli.community.list.yaml.safe_load")
+    def test_download_manifest_success(self, mock_yaml_load, mock_download_file):
+        """Test successful manifest download."""
+        mock_response = Mock()
+        mock_response.text = "apps: []"
+        mock_download_file.return_value = mock_response
+        mock_yaml_load.return_value = {"apps": []}
+
+        result = download_manifest()
+
+        mock_download_file.assert_called_once_with(directory="community-apps", file="manifest.yml", profile=None)
+        mock_yaml_load.assert_called_once_with("apps: []")
+        self.assertEqual(result, {"apps": []})
+
+    @patch("nextmv.cli.community.list.download_file")
+    @patch("nextmv.cli.community.list.yaml.safe_load")
+    def test_download_manifest_with_profile(self, mock_yaml_load, mock_download_file):
+        """Test manifest download with custom profile."""
+        mock_response = Mock()
+        mock_response.text = "apps: []"
+        mock_download_file.return_value = mock_response
+        mock_yaml_load.return_value = {"apps": []}
+
+        _ = download_manifest(profile="custom-profile")
+
+        mock_download_file.assert_called_once_with(
+            directory="community-apps", file="manifest.yml", profile="custom-profile"
+        )
+
+
+class TestAppsTable(unittest.TestCase):
+    """Tests for the apps_table function."""
+
+    @patch("nextmv.cli.community.list.console")
+    def test_apps_table_prints_table(self, mock_console):
+        """Test that apps_table prints a table with correct data."""
+        manifest = {
+            "apps": [
+                {
+                    "name": "test-app",
+                    "type": "go",
+                    "latest_app_version": "v1.0.0",
+                    "description": "Test description",
+                }
+            ]
+        }
+
+        apps_table(manifest)
+
+        # Verify console.print was called
+        self.assertEqual(mock_console.print.call_count, 1)
+        # Get the table that was printed
+        table = mock_console.print.call_args[0][0]
+        self.assertEqual(table.columns[0].header, "Name")
+        self.assertEqual(table.columns[1].header, "Type")
+
+    @patch("nextmv.cli.community.list.console")
+    def test_apps_table_handles_empty_manifest(self, mock_console):
+        """Test that apps_table handles empty manifest."""
+        manifest = {"apps": []}
+
+        apps_table(manifest)
+
+        self.assertEqual(mock_console.print.call_count, 1)
+
+
+class TestAppsList(unittest.TestCase):
+    """Tests for the apps_list function."""
+
+    @patch("builtins.print")
+    def test_apps_list_prints_names(self, mock_print):
+        """Test that apps_list prints app names."""
+        manifest = {
+            "apps": [
+                {"name": "app1"},
+                {"name": "app2"},
+                {"name": "app3"},
+            ]
+        }
+
+        apps_list(manifest)
+
+        mock_print.assert_called_once_with("app1\napp2\napp3")
+
+    @patch("builtins.print")
+    def test_apps_list_handles_empty_manifest(self, mock_print):
+        """Test that apps_list handles empty manifest."""
+        manifest = {"apps": []}
+
+        apps_list(manifest)
+
+        mock_print.assert_called_once_with("")
+
+
+class TestVersionsTable(unittest.TestCase):
+    """Tests for the versions_table function."""
+
+    @patch("nextmv.cli.community.list.console")
+    def test_versions_table_shows_latest_first(self, mock_console):
+        """Test that versions_table shows latest version first with indicator."""
+        manifest = {
+            "apps": [
+                {
+                    "name": "test-app",
+                    "latest_app_version": "v2.0.0",
+                    "app_versions": ["v2.0.0", "v1.0.0"],
+                }
+            ]
+        }
+
+        versions_table(manifest, "test-app")
+
+        self.assertEqual(mock_console.print.call_count, 1)
+        table = mock_console.print.call_args[0][0]
+        self.assertEqual(table.columns[0].header, "Version")
+        self.assertEqual(table.columns[1].header, "Latest?")
+
+    @patch("nextmv.cli.community.list.console")
+    @patch("nextmv.cli.community.list.find_app")
+    def test_versions_table_calls_find_app(self, mock_find_app, mock_console):
+        """Test that versions_table calls find_app."""
+        mock_find_app.return_value = {
+            "latest_app_version": "v1.0.0",
+            "app_versions": ["v1.0.0"],
+        }
+
+        versions_table({}, "test-app")
+
+        mock_find_app.assert_called_once_with({}, "test-app")
+
+
+class TestVersionsList(unittest.TestCase):
+    """Tests for the versions_list function."""
+
+    @patch("builtins.print")
+    def test_versions_list_prints_versions(self, mock_print):
+        """Test that versions_list prints all versions."""
+        manifest = {
+            "apps": [
+                {
+                    "name": "test-app",
+                    "app_versions": ["v2.0.0", "v1.5.0", "v1.0.0"],
+                }
+            ]
+        }
+
+        versions_list(manifest, "test-app")
+
+        mock_print.assert_called_once_with("v2.0.0\nv1.5.0\nv1.0.0")
+
+    @patch("builtins.print")
+    @patch("nextmv.cli.community.list.find_app")
+    def test_versions_list_calls_find_app(self, mock_find_app, mock_print):
+        """Test that versions_list calls find_app."""
+        mock_find_app.return_value = {"app_versions": ["v1.0.0"]}
+
+        versions_list({}, "test-app")
+
+        mock_find_app.assert_called_once_with({}, "test-app")
+
+
+class TestDownloadFile(unittest.TestCase):
+    """Tests for the download_file function."""
+
+    @patch("nextmv.cli.community.list.build_client")
+    def test_download_file_makes_correct_requests(self, mock_build_client):
+        """Test that download_file makes correct API requests."""
+        mock_client = Mock()
+        mock_client.headers = {"Authorization": "Bearer token"}
+        mock_build_client.return_value = mock_client
+
+        # Mock first request response
+        mock_first_response = Mock()
+        mock_first_response.json.return_value = {"url": "https://example.com/file"}
+
+        # Mock second request response
+        mock_second_response = Mock()
+        mock_second_response.content = b"file content"
+
+        # Set up client.request to return different responses
+        mock_client.request.side_effect = [mock_first_response, mock_second_response]
+
+        result = download_file(directory="test-dir", file="test-file.txt", profile="test-profile")
+
+        # Verify build_client was called with profile
+        mock_build_client.assert_called_once_with("test-profile")
+
+        # Verify first request
+        first_call = mock_client.request.call_args_list[0]
+        self.assertEqual(first_call[1]["method"], "GET")
+        self.assertEqual(first_call[1]["endpoint"], "v0/internal/tools")
+        self.assertIn("Authorization", first_call[1]["headers"])
+        self.assertEqual(first_call[1]["query_params"], {"file": "test-dir/test-file.txt"})
+
+        # Verify second request
+        second_call = mock_client.request.call_args_list[1]
+        self.assertEqual(second_call[1]["method"], "GET")
+        self.assertEqual(second_call[1]["endpoint"], "https://example.com/file")
+
+        self.assertEqual(result, mock_second_response)
+
+
+class TestFindApp(unittest.TestCase):
+    """Tests for the find_app function."""
+
+    def setUp(self):
+        self.manifest = {
+            "apps": [
+                {"name": "app1", "description": "First app"},
+                {"name": "app2", "description": "Second app"},
+                {"name": "app3", "description": "Third app"},
+            ]
+        }
+
+    def test_find_app_returns_correct_app(self):
+        """Test that find_app returns the correct app."""
+        result = find_app(self.manifest, "app2")
+
+        self.assertEqual(result["name"], "app2")
+        self.assertEqual(result["description"], "Second app")
+
+    @patch("nextmv.cli.community.list.apps_table")
+    @patch("nextmv.cli.community.list.rich.print")
+    def test_find_app_raises_exit_when_not_found(self, mock_rich_print, mock_apps_table):
+        """Test that find_app raises typer.Exit when app not found."""
+        from typer import Exit
+
+        with self.assertRaises(Exit) as context:
+            find_app(self.manifest, "nonexistent-app")
+
+        self.assertEqual(context.exception.exit_code, 1)
+        mock_rich_print.assert_called_once()
+        mock_apps_table.assert_called_once_with(self.manifest)
+
+
+class TestCommunityCloneCommand(unittest.TestCase):
+    """Tests for the community clone command."""
+
+    def setUp(self):
+        self.runner = CliRunner()
+        self.app = clone_app
+        self.sample_manifest = {
+            "apps": [
+                {
+                    "name": "go-nextroute",
+                    "type": "go",
+                    "latest_app_version": "v1.2.0",
+                    "description": "A routing app",
+                    "app_versions": ["v1.2.0", "v1.1.0", "v1.0.0"],
+                },
+            ]
+        }
+
+    @patch("nextmv.cli.community.clone.os.remove")
+    @patch("nextmv.cli.community.clone.shutil.move")
+    @patch("nextmv.cli.community.clone.tarfile.open")
+    @patch("nextmv.cli.community.clone.download_object")
+    @patch("nextmv.cli.community.clone.get_valid_path")
+    @patch("nextmv.cli.community.clone.os.makedirs")
+    @patch("nextmv.cli.community.clone.app_has_version")
+    @patch("nextmv.cli.community.clone.find_app")
+    @patch("nextmv.cli.community.clone.download_manifest")
+    def test_clone_with_latest_version(
+        self,
+        mock_download_manifest,
+        mock_find_app,
+        mock_app_has_version,
+        mock_makedirs,
+        mock_get_valid_path,
+        mock_download_object,
+        mock_tarfile_open,
+        mock_shutil_move,
+        mock_os_remove,
+    ):
+        """Test cloning an app with latest version."""
+        mock_download_manifest.return_value = self.sample_manifest
+        mock_find_app.return_value = self.sample_manifest["apps"][0]
+        mock_app_has_version.return_value = True
+        mock_get_valid_path.return_value = "/test/path/go-nextroute"
+        mock_download_object.return_value = "/test/path/go-nextroute/tarball.tar.gz"
+
+        # Mock tarfile extraction
+        mock_tar = MagicMock()
+        mock_tarfile_open.return_value.__enter__.return_value = mock_tar
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Create a mock extracted directory
+            extracted_dir = os.path.join(temp_dir, "go-nextroute")
+            os.makedirs(extracted_dir)
+
+            with patch("nextmv.cli.community.clone.tempfile.TemporaryDirectory") as mock_tempdir:
+                mock_tempdir.return_value.__enter__.return_value = temp_dir
+                with patch("nextmv.cli.community.clone.os.listdir") as mock_listdir:
+                    mock_listdir.side_effect = [["go-nextroute"], ["file1.py", "file2.py"]]
+                    with patch("nextmv.cli.community.clone.os.path.isdir") as mock_isdir:
+                        mock_isdir.return_value = True
+
+                        result = self.runner.invoke(self.app, ["--app", "go-nextroute"])
+
+                        self.assertEqual(result.exit_code, 0)
+                        mock_download_manifest.assert_called_once_with(profile=None)
+                        mock_find_app.assert_called_once_with(self.sample_manifest, "go-nextroute")
+
+    @patch("nextmv.cli.community.clone.download_manifest")
+    @patch("nextmv.cli.community.clone.find_app")
+    def test_clone_with_empty_version_errors(self, mock_find_app, mock_download_manifest):
+        """Test that clone with empty --version string returns error."""
+        mock_download_manifest.return_value = self.sample_manifest
+        mock_find_app.return_value = self.sample_manifest["apps"][0]
+
+        result = self.runner.invoke(self.app, ["--app", "go-nextroute", "--version", ""])
+
+        self.assertEqual(result.exit_code, 1)
+        self.assertIn("cannot be an empty string", result.output)
+
+    @patch("nextmv.cli.community.clone.versions_table")
+    @patch("nextmv.cli.community.clone.app_has_version")
+    @patch("nextmv.cli.community.clone.find_app")
+    @patch("nextmv.cli.community.clone.download_manifest")
+    def test_clone_with_invalid_version_shows_available(
+        self, mock_download_manifest, mock_find_app, mock_app_has_version, mock_versions_table
+    ):
+        """Test that clone with invalid version shows available versions."""
+        mock_download_manifest.return_value = self.sample_manifest
+        mock_find_app.return_value = self.sample_manifest["apps"][0]
+        mock_app_has_version.return_value = False
+
+        result = self.runner.invoke(self.app, ["--app", "go-nextroute", "--version", "v99.0.0"])
+
+        self.assertEqual(result.exit_code, 1)
+        self.assertIn("Version", result.output)
+        self.assertIn("not found", result.output)
+        mock_versions_table.assert_called_once_with(self.sample_manifest, "go-nextroute")
+
+    @patch("nextmv.cli.community.clone.os.remove")
+    @patch("nextmv.cli.community.clone.shutil.move")
+    @patch("nextmv.cli.community.clone.tarfile.open")
+    @patch("nextmv.cli.community.clone.download_object")
+    @patch("nextmv.cli.community.clone.get_valid_path")
+    @patch("nextmv.cli.community.clone.os.makedirs")
+    @patch("nextmv.cli.community.clone.app_has_version")
+    @patch("nextmv.cli.community.clone.find_app")
+    @patch("nextmv.cli.community.clone.download_manifest")
+    def test_clone_with_custom_directory(
+        self,
+        mock_download_manifest,
+        mock_find_app,
+        mock_app_has_version,
+        mock_makedirs,
+        mock_get_valid_path,
+        mock_download_object,
+        mock_tarfile_open,
+        mock_shutil_move,
+        mock_os_remove,
+    ):
+        """Test cloning an app to a custom directory."""
+        mock_download_manifest.return_value = self.sample_manifest
+        mock_find_app.return_value = self.sample_manifest["apps"][0]
+        mock_app_has_version.return_value = True
+        mock_get_valid_path.return_value = "/custom/path"
+        mock_download_object.return_value = "/custom/path/tarball.tar.gz"
+
+        mock_tar = MagicMock()
+        mock_tarfile_open.return_value.__enter__.return_value = mock_tar
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            extracted_dir = os.path.join(temp_dir, "go-nextroute")
+            os.makedirs(extracted_dir)
+
+            with patch("nextmv.cli.community.clone.tempfile.TemporaryDirectory") as mock_tempdir:
+                mock_tempdir.return_value.__enter__.return_value = temp_dir
+                with patch("nextmv.cli.community.clone.os.listdir") as mock_listdir:
+                    mock_listdir.side_effect = [["go-nextroute"], ["file1.py"]]
+                    with patch("nextmv.cli.community.clone.os.path.isdir") as mock_isdir:
+                        mock_isdir.return_value = True
+
+                        result = self.runner.invoke(self.app, ["--app", "go-nextroute", "--directory", "/custom/path"])
+
+                        self.assertEqual(result.exit_code, 0)
+                        mock_get_valid_path.assert_called_once_with("/custom/path", os.stat)
+
+
+class TestAppHasVersion(unittest.TestCase):
+    """Tests for the app_has_version function."""
+
+    def test_app_has_version_returns_true_for_existing_version(self):
+        """Test that app_has_version returns True for existing version."""
+        app_obj = {
+            "latest_app_version": "v2.0.0",
+            "app_versions": ["v2.0.0", "v1.5.0", "v1.0.0"],
+        }
+
+        result = app_has_version(app_obj, "v1.5.0")
+
+        self.assertTrue(result)
+
+    def test_app_has_version_returns_false_for_nonexistent_version(self):
+        """Test that app_has_version returns False for nonexistent version."""
+        app_obj = {
+            "latest_app_version": "v2.0.0",
+            "app_versions": ["v2.0.0", "v1.5.0", "v1.0.0"],
+        }
+
+        result = app_has_version(app_obj, "v99.0.0")
+
+        self.assertFalse(result)
+
+    def test_app_has_version_handles_latest_keyword(self):
+        """Test that app_has_version handles 'latest' keyword."""
+        app_obj = {
+            "latest_app_version": "v2.0.0",
+            "app_versions": ["v2.0.0", "v1.5.0", "v1.0.0"],
+        }
+
+        result = app_has_version(app_obj, "latest")
+
+        self.assertTrue(result)
+
+
+class TestGetValidPath(unittest.TestCase):
+    """Tests for the get_valid_path function."""
+
+    def test_get_valid_path_returns_path_when_not_exists(self):
+        """Test that get_valid_path returns path when it doesn't exist."""
+
+        def mock_stat(path):
+            raise FileNotFoundError()
+
+        result = get_valid_path("/test/path", mock_stat)
+
+        self.assertEqual(result, "/test/path")
+
+    def test_get_valid_path_appends_number_when_exists(self):
+        """Test that get_valid_path appends number when path exists."""
+        call_count = [0]
+
+        def mock_stat(path):
+            call_count[0] += 1
+            if call_count[0] <= 2:
+                # First two calls: path exists
+                return os.stat_result((0, 0, 0, 0, 0, 0, 0, 0, 0, 0))
+            else:
+                # Third call: path doesn't exist
+                raise FileNotFoundError()
+
+        result = get_valid_path("/test/myapp", mock_stat)
+
+        self.assertEqual(result, "/test/myapp-2")
+
+    def test_get_valid_path_handles_file_extension(self):
+        """Test that get_valid_path handles file extensions correctly."""
+        call_count = [0]
+
+        def mock_stat(path):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return os.stat_result((0, 0, 0, 0, 0, 0, 0, 0, 0, 0))
+            else:
+                raise FileNotFoundError()
+
+        result = get_valid_path("/test/file.json", mock_stat, ending=".json")
+
+        self.assertEqual(result, "/test/file-1.json")
+
+    def test_get_valid_path_increments_existing_number(self):
+        """Test that get_valid_path increments existing number."""
+        existing_paths = {"/test/myapp-3", "/test/myapp-3-4"}
+
+        def mock_stat(path):
+            if path in existing_paths:
+                return os.stat_result((0, 0, 0, 0, 0, 0, 0, 0, 0, 0))
+            raise FileNotFoundError()
+
+        result = get_valid_path("/test/myapp-3", mock_stat)
+
+        # When path ends with a number, it appends incrementing numbers to the base name
+        self.assertEqual(result, "/test/myapp-3-5")
+
+
+class TestDownloadObject(unittest.TestCase):
+    """Tests for the download_object function."""
+
+    @patch("builtins.open", new_callable=mock_open)
+    @patch("nextmv.cli.community.clone.os.path.join")
+    @patch("nextmv.cli.community.clone.download_file")
+    def test_download_object_saves_file(self, mock_download_file, mock_path_join, mock_file):
+        """Test that download_object downloads and saves file."""
+        mock_response = Mock()
+        mock_response.content = b"file content"
+        mock_download_file.return_value = mock_response
+        mock_path_join.return_value = "/output/file.tar.gz"
+
+        result = download_object(
+            file="test-file.tar.gz", path="test-path", output_dir="/output", output_file="file.tar.gz", profile="test"
+        )
+
+        mock_download_file.assert_called_once_with(directory="test-path", file="test-file.tar.gz", profile="test")
+        mock_file.assert_called_once_with("/output/file.tar.gz", "wb")
+        mock_file().write.assert_called_once_with(b"file content")
+        self.assertEqual(result, "/output/file.tar.gz")
+
+
+class TestCommunityCommunityCommand(unittest.TestCase):
+    """Tests for the main community command."""
+
+    def setUp(self):
+        self.runner = CliRunner()
+        self.app = community_app
+
+    def test_community_help_shows_description(self):
+        """Test that community command shows help description."""
+        result = self.runner.invoke(self.app, ["--help"])
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("community apps", result.output.lower())
+
+    @patch("nextmv.cli.community.list.download_manifest")
+    @patch("nextmv.cli.community.list.apps_table")
+    def test_community_list_subcommand_works(self, mock_apps_table, mock_download_manifest):
+        """Test that community list subcommand is registered."""
+        mock_download_manifest.return_value = {"apps": []}
+
+        result = self.runner.invoke(self.app, ["list"])
+
+        self.assertEqual(result.exit_code, 0)
+
+    @patch("nextmv.cli.community.clone.download_manifest")
+    @patch("nextmv.cli.community.clone.find_app")
+    def test_community_clone_subcommand_works(self, mock_find_app, mock_download_manifest):
+        """Test that community clone subcommand is registered."""
+        mock_download_manifest.return_value = {"apps": []}
+
+        # This should fail because --app is required, but it proves the subcommand is registered
+        result = self.runner.invoke(self.app, ["clone"])
+
+        # Missing required option should give exit code 2
+        self.assertNotEqual(result.exit_code, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/nextmv/tests/cli/test_configuration.py
+++ b/nextmv/tests/cli/test_configuration.py
@@ -261,7 +261,7 @@ class TestConfigConstants(unittest.TestCase):
 class TestGoCliExists(unittest.TestCase):
     """Tests for the go_cli_exists function."""
 
-    @patch("nextmv.cli.main.print")
+    @patch("nextmv.cli.main.rich.print")
     @patch("nextmv.cli.main.check_config_in_path")
     @patch.object(Path, "exists")
     def test_go_cli_exists_returns_true_when_file_exists(self, mock_exists, mock_check_path, mock_print):
@@ -288,7 +288,7 @@ class TestGoCliExists(unittest.TestCase):
 class TestRemoveGoCli(unittest.TestCase):
     """Tests for the remove_go_cli function."""
 
-    @patch("nextmv.cli.main.print")
+    @patch("nextmv.cli.main.rich.print")
     @patch("nextmv.cli.main.check_config_in_path")
     @patch.object(Path, "unlink")
     @patch.object(Path, "exists")

--- a/nextmv/tests/cli/test_configuration.py
+++ b/nextmv/tests/cli/test_configuration.py
@@ -317,7 +317,7 @@ class TestRemoveGoCli(unittest.TestCase):
 class TestCheckConfigInPath(unittest.TestCase):
     """Tests for the check_config_in_path function."""
 
-    @patch("nextmv.cli.main.print")
+    @patch("nextmv.cli.main.rich.print")
     @patch.dict(os.environ, {"PATH": f"/usr/bin{os.pathsep}{CONFIG_DIR}{os.pathsep}/usr/local/bin"})
     def test_check_config_in_path_prints_warning_when_in_path(self, mock_print):
         """Test that a warning is printed when CONFIG_DIR is in PATH."""
@@ -327,7 +327,7 @@ class TestCheckConfigInPath(unittest.TestCase):
         call_args = str(mock_print.call_args)
         self.assertIn("PATH", call_args)
 
-    @patch("nextmv.cli.main.print")
+    @patch("nextmv.cli.main.rich.print")
     @patch.dict(os.environ, {"PATH": "/usr/bin:/usr/local/bin"})
     def test_check_config_in_path_no_warning_when_not_in_path(self, mock_print):
         """Test that no warning is printed when CONFIG_DIR is not in PATH."""


### PR DESCRIPTION
# Description

Adds the `community` command tree for interacting with community apps.

- `community` command added to the main command.

<img width="812" height="273" alt="image" src="https://github.com/user-attachments/assets/690cb477-9dda-4231-bcbb-679f869ebd0d" />

- Help of the `community` command.

<img width="815" height="241" alt="image" src="https://github.com/user-attachments/assets/098962a0-e779-4a3d-95bc-e1a582b04c33" />

- Help of the `community list` command.

<img width="975" height="470" alt="image" src="https://github.com/user-attachments/assets/2c6d5510-df44-4327-b178-d0699c5a7cf1" />

- Help of the `community clone` command.

<img width="1026" height="536" alt="image" src="https://github.com/user-attachments/assets/00c33554-4e6c-412d-9e64-957e61e671cc" />

- Listing the available apps.

<img width="917" height="479" alt="image" src="https://github.com/user-attachments/assets/e573c7af-e386-402d-b643-d9c10dc2c92f" />

- Cloning a community app.

<img width="978" height="189" alt="image" src="https://github.com/user-attachments/assets/88048c2f-d473-4bc8-aee8-2eb9493691a1" />


