### PR TITLE
Completes the `nextmv cloud run` command tree

### DIFF
--- a/nextmv/nextmv/cli/cloud/run/__init__.py
+++ b/nextmv/nextmv/cli/cloud/run/__init__.py
@@ -7,14 +7,22 @@ import typer
 from nextmv.cli.cloud.run.cancel import app as cancel_app
 from nextmv.cli.cloud.run.create import app as create_app
 from nextmv.cli.cloud.run.get import app as get_app
+from nextmv.cli.cloud.run.input import app as input_app
+from nextmv.cli.cloud.run.list import app as list_app
 from nextmv.cli.cloud.run.logs import app as logs_app
+from nextmv.cli.cloud.run.metadata import app as metadata_app
+from nextmv.cli.cloud.run.track import app as track_app
 
 # Set up subcommand application.
 app = typer.Typer()
 app.add_typer(cancel_app)
 app.add_typer(create_app)
 app.add_typer(get_app)
+app.add_typer(input_app)
+app.add_typer(list_app)
 app.add_typer(logs_app)
+app.add_typer(metadata_app)
+app.add_typer(track_app)
 
 
 @app.callback()

--- a/nextmv/nextmv/cli/cloud/run/__init__.py
+++ b/nextmv/nextmv/cli/cloud/run/__init__.py
@@ -7,12 +7,14 @@ import typer
 from nextmv.cli.cloud.run.cancel import app as cancel_app
 from nextmv.cli.cloud.run.create import app as create_app
 from nextmv.cli.cloud.run.get import app as get_app
+from nextmv.cli.cloud.run.logs import app as logs_app
 
 # Set up subcommand application.
 app = typer.Typer()
 app.add_typer(cancel_app)
 app.add_typer(create_app)
 app.add_typer(get_app)
+app.add_typer(logs_app)
 
 
 @app.callback()

--- a/nextmv/nextmv/cli/cloud/run/__init__.py
+++ b/nextmv/nextmv/cli/cloud/run/__init__.py
@@ -4,11 +4,15 @@ This module defines the cloud run command tree for the Nextmv CLI.
 
 import typer
 
+from nextmv.cli.cloud.run.cancel import app as cancel_app
 from nextmv.cli.cloud.run.create import app as create_app
+from nextmv.cli.cloud.run.get import app as get_app
 
 # Set up subcommand application.
 app = typer.Typer()
+app.add_typer(cancel_app)
 app.add_typer(create_app)
+app.add_typer(get_app)
 
 
 @app.callback()

--- a/nextmv/nextmv/cli/cloud/run/cancel.py
+++ b/nextmv/nextmv/cli/cloud/run/cancel.py
@@ -1,5 +1,5 @@
 """
-This module defines the community clone command for the Nextmv CLI.
+This module defines the cloud run cancel command for the Nextmv CLI.
 """
 
 import rich

--- a/nextmv/nextmv/cli/cloud/run/cancel.py
+++ b/nextmv/nextmv/cli/cloud/run/cancel.py
@@ -2,10 +2,10 @@
 This module defines the cloud run cancel command for the Nextmv CLI.
 """
 
-import rich
 import typer
 
 from nextmv.cli.configuration.config import build_app
+from nextmv.cli.message import success
 from nextmv.cli.options import AppIDOption, ProfileOption, RunIDOption
 
 # Set up subcommand application.
@@ -33,4 +33,4 @@ def cancel(
 
     cloud_app = build_app(app_id, profile)
     cloud_app.cancel_run(run_id)
-    rich.print(f":white_check_mark: Run [magenta]{run_id}[/magenta] canceled.")
+    success(f"Run [magenta]{run_id}[/magenta] canceled.")

--- a/nextmv/nextmv/cli/cloud/run/cancel.py
+++ b/nextmv/nextmv/cli/cloud/run/cancel.py
@@ -24,11 +24,11 @@ def cancel(
     [bold][underline]Examples[/underline][/bold]
 
     - Cancel the run with ID [magenta]burrow-123[/magenta] belonging to an app with ID [magenta]hare-app[/magenta].
-        $ [green]cat input.json | nextmv cloud run cancel --app-id hare-app --run-id burrow-123[/green]
+        $ [green]nextmv cloud run cancel --app-id hare-app --run-id burrow-123[/green]
 
     - Cancel the run with ID [magenta]burrow-123[/magenta] belonging to an app with ID [magenta]hare-app[/magenta].
       Use the profile named [magenta]hare[/magenta].
-        $ [green]cat input.json | nextmv cloud run cancel --app-id hare-app --run-id burrow-123 --profile hare[/green]
+        $ [green]nextmv cloud run cancel --app-id hare-app --run-id burrow-123 --profile hare[/green]
     """
 
     cloud_app = build_app(app_id, profile)

--- a/nextmv/nextmv/cli/cloud/run/cancel.py
+++ b/nextmv/nextmv/cli/cloud/run/cancel.py
@@ -1,0 +1,36 @@
+"""
+This module defines the community clone command for the Nextmv CLI.
+"""
+
+import rich
+import typer
+
+from nextmv.cli.configuration.config import build_app
+from nextmv.cli.options import AppIDOption, ProfileOption, RunIDOption
+
+# Set up subcommand application.
+app = typer.Typer()
+
+
+@app.command()
+def cancel(
+    app_id: AppIDOption,
+    run_id: RunIDOption,
+    profile: ProfileOption = None,
+) -> None:
+    """
+    Cancel a queued/running Nextmv Cloud application run.
+
+    [bold][underline]Examples[/underline][/bold]
+
+    - Cancel the run with ID [magenta]burrow-123[/magenta] belonging to an app with ID [magenta]hare-app[/magenta].
+        $ [green]cat input.json | nextmv cloud run cancel --app-id hare-app --run-id burrow-123[/green]
+
+    - Cancel the run with ID [magenta]burrow-123[/magenta] belonging to an app with ID [magenta]hare-app[/magenta].
+      Use the profile named [magenta]hare[/magenta].
+        $ [green]cat input.json | nextmv cloud run cancel --app-id hare-app --run-id burrow-123 --profile hare[/green]
+    """
+
+    cloud_app = build_app(app_id, profile)
+    cloud_app.cancel_run(run_id)
+    rich.print(f":white_check_mark: Run [magenta]{run_id}[/magenta] canceled.")

--- a/nextmv/nextmv/cli/cloud/run/create.py
+++ b/nextmv/nextmv/cli/cloud/run/create.py
@@ -5,6 +5,7 @@ This module defines the community clone command for the Nextmv CLI.
 import json
 import sys
 import tarfile
+from collections.abc import Callable
 from pathlib import Path
 from typing import Annotated, Any
 
@@ -339,6 +340,7 @@ def create(
         run_id=run_id,
         tail=tail,
         polling_options=polling_options,
+        result_callback=cloud_app.run_result_with_polling,
     )
 
 
@@ -555,7 +557,6 @@ def handle_outputs(
     # Get the run result, using output directory if needed.
     kwargs = {
         "run_id": run_id,
-        "polling_options": polling_options,
     }
 
     if content_type not in {OutputFormat.JSON, OutputFormat.TEXT}:
@@ -564,7 +565,7 @@ def handle_outputs(
 
         kwargs["output_dir_path"] = output
 
-    run_result = cloud_app.run_result_with_polling(**kwargs)
+    run_result = result_callback(**kwargs)
 
     # If logs output is specified, write the logs to the specified file.
     if logs is not None:

--- a/nextmv/nextmv/cli/cloud/run/create.py
+++ b/nextmv/nextmv/cli/cloud/run/create.py
@@ -1,5 +1,5 @@
 """
-This module defines the community clone command for the Nextmv CLI.
+This module defines the cloud run create command for the Nextmv CLI.
 """
 
 import json
@@ -12,12 +12,13 @@ import rich
 import typer
 
 from nextmv.cli.cloud.run.get import handle_outputs
+from nextmv.cli.cloud.run.logs import handle_logs
 from nextmv.cli.configuration.config import build_app
-from nextmv.cli.message import error, info, success
+from nextmv.cli.message import error, success
 from nextmv.cli.options import AppIDOption, ProfileOption
 from nextmv.cloud.application import Application
 from nextmv.input import InputFormat
-from nextmv.polling import DEFAULT_POLLING_OPTIONS, PollingOptions
+from nextmv.polling import DEFAULT_POLLING_OPTIONS
 from nextmv.run import Format, FormatInput, RunConfiguration, RunQueuing, RunType, RunTypeConfiguration
 
 # Set up subcommand application.
@@ -46,7 +47,7 @@ def create(
             "--logs",
             "-l",
             help="Waits for the run to complete and saves the logs to this location.",
-            metavar="LOGS_OUTPUT",
+            metavar="LOGS_LOCATION",
             rich_help_panel="Output control",
         ),
     ] = None,
@@ -345,6 +346,7 @@ def create(
         tail=tail,
         logs=logs,
         polling_options=polling_options,
+        file_output=True,
     )
     handle_outputs(
         cloud_app=cloud_app,
@@ -510,63 +512,3 @@ def resolve_input_kwarg(
         return {"input_dir_path": input}
 
     error(f"Input path [magenta]{input}[/magenta] does not exist.")
-
-
-def handle_logs(
-    cloud_app: Application,
-    run_id: str,
-    tail: bool,
-    logs: str | None,
-    polling_options: PollingOptions,
-) -> None:
-    """
-    Handle retrieving and outputting logs from a run.
-
-    If neither ``tail`` is True nor ``logs`` is specified, this function
-    returns early without doing anything. Otherwise, logs are retrieved and
-    optionally written to a file.
-
-    When ``tail`` is True, logs are streamed in real-time to stderr as the run
-    executes. When ``logs`` is specified (without tailing), the function waits
-    for the run to complete and then fetches all logs at once. In both cases,
-    if a ``logs`` file path is provided, the logs are persisted to that file.
-
-    Parameters
-    ----------
-    cloud_app : Application
-        The cloud application instance used to interact with the Nextmv Cloud
-        API.
-    run_id : str
-        The unique identifier of the run to retrieve logs for.
-    tail : bool
-        If True, streams logs in real-time to stderr as the run executes.
-    logs : str | None
-        The file path where logs should be written. If None, logs are only
-        displayed to stderr (when tailing) and not persisted to a file.
-    polling_options : PollingOptions
-        Configuration options for polling behavior, including timeout and
-        interval settings.
-    """
-
-    if tail:
-        info(msg="Tailing logs...", emoji=":hourglass_flowing_sand:")
-        fetched_logs = cloud_app.run_logs_with_polling(
-            run_id=run_id,
-            polling_options=polling_options,
-            verbose=True,
-            rich_print=True,
-        )
-        if logs is None:
-            return
-
-        log_content = "".join(log_entry.log for log_entry in fetched_logs)
-    elif logs is not None:
-        info(msg="Getting run logs...", emoji=":hourglass_flowing_sand:")
-        cloud_app.run_result_with_polling(run_id=run_id, polling_options=polling_options)
-        run_logs = cloud_app.run_logs(run_id=run_id)
-        log_content = run_logs.log
-    else:
-        return
-
-    Path(logs).write_text(log_content)
-    success(f"Run logs written to [magenta]{logs}[/magenta].")

--- a/nextmv/nextmv/cli/cloud/run/create.py
+++ b/nextmv/nextmv/cli/cloud/run/create.py
@@ -8,13 +8,12 @@ import tarfile
 from pathlib import Path
 from typing import Annotated, Any
 
-import rich
 import typer
 
 from nextmv.cli.cloud.run.get import handle_outputs
 from nextmv.cli.cloud.run.logs import handle_logs
 from nextmv.cli.configuration.config import build_app
-from nextmv.cli.message import error, success
+from nextmv.cli.message import error, print_json, success
 from nextmv.cli.options import AppIDOption, ProfileOption
 from nextmv.cloud.application import Application
 from nextmv.input import InputFormat
@@ -34,9 +33,9 @@ def create(
         typer.Option(
             "--input",
             "-i",
-            help="The input location to use. File or directory depending on content type. "
+            help="The input path to use. File or directory depending on content type. "
             "Uses [magenta]stdin[/magenta] if not defined.",
-            metavar="INPUT_LOCATION",
+            metavar="INPUT_PATH",
             rich_help_panel="Input control",
         ),
     ] = None,
@@ -47,7 +46,7 @@ def create(
             "--logs",
             "-l",
             help="Waits for the run to complete and saves the logs to this location.",
-            metavar="LOGS_LOCATION",
+            metavar="LOGS_PATH",
             rich_help_panel="Output control",
         ),
     ] = None,
@@ -58,7 +57,7 @@ def create(
             "-u",
             help="Waits for the run to complete and save the output to this location. "
             "A file or directory will be created depending on content type. ",
-            metavar="OUTPUT_LOCATION",
+            metavar="OUTPUT_PATH",
             rich_help_panel="Output control",
         ),
     ] = None,
@@ -290,7 +289,7 @@ def create(
 
     # Validate that input is provided.
     stdin = sys.stdin.read().strip() if sys.stdin.isatty() is False else None
-    if stdin is None and input is None:
+    if stdin is None and (input is None or input == ""):
         error("Input data must be provided via the [code]--input[/code] flag or [magenta]stdin[/magenta].")
 
     # Instantiate the basic requirements to start a new run.
@@ -332,7 +331,7 @@ def create(
 
     # If we don't need to poll at all we are done.
     if not wait and not tail and output is None and logs is None:
-        rich.print({"run_id": run_id})
+        print_json({"run_id": run_id})
 
         return
 
@@ -362,11 +361,11 @@ def build_run_config(
     run_type: RunType,
     priority: int,
     no_queuing: bool,
-    execution_class: str | None,
-    content_type: InputFormat | None,
-    secret_collection_id: str | None,
-    integration_id: str | None,
-    definition_id: str | None,
+    execution_class: str | None = None,
+    content_type: InputFormat | None = None,
+    secret_collection_id: str | None = None,
+    integration_id: str | None = None,
+    definition_id: str | None = None,
 ) -> RunConfiguration:
     """
     Builds the run configuration for the new run.

--- a/nextmv/nextmv/cli/cloud/run/create.py
+++ b/nextmv/nextmv/cli/cloud/run/create.py
@@ -5,19 +5,18 @@ This module defines the community clone command for the Nextmv CLI.
 import json
 import sys
 import tarfile
-from collections.abc import Callable
 from pathlib import Path
 from typing import Annotated, Any
 
 import rich
 import typer
 
+from nextmv.cli.cloud.run.get import handle_outputs
 from nextmv.cli.configuration.config import build_app
 from nextmv.cli.message import error, info, success
 from nextmv.cli.options import AppIDOption, ProfileOption
 from nextmv.cloud.application import Application
 from nextmv.input import InputFormat
-from nextmv.output import OutputFormat
 from nextmv.polling import DEFAULT_POLLING_OPTIONS, PollingOptions
 from nextmv.run import Format, FormatInput, RunConfiguration, RunQueuing, RunType, RunTypeConfiguration
 
@@ -46,9 +45,7 @@ def create(
         typer.Option(
             "--logs",
             "-l",
-            help="Waits for the run to complete and saves the logs to this location. "
-            "Activates [code]--wait[/code] if not set. "
-            "Use [code]--tail[/code] to stream logs to [magenta]stdout[/magenta].",
+            help="Waits for the run to complete and saves the logs to this location.",
             metavar="LOGS_OUTPUT",
             rich_help_panel="Output control",
         ),
@@ -59,8 +56,7 @@ def create(
             "--output",
             "-u",
             help="Waits for the run to complete and save the output to this location. "
-            "A file or directory will be created depending on content type. "
-            "Activates [code]--wait[/code] if not set.",
+            "A file or directory will be created depending on content type. ",
             metavar="OUTPUT_LOCATION",
             rich_help_panel="Output control",
         ),
@@ -70,8 +66,8 @@ def create(
         typer.Option(
             "--tail",
             "-t",
-            help="Tail the logs until the run completes. Logs are streamed to [magenta]stdout[/magenta]. "
-            "Activates [code]--wait[/code] if not set. Specify log output location with [code]--logs[/code].",
+            help="Tail the logs until the run completes. Logs are streamed to [magenta]stderr[/magenta]. "
+            "Specify log output location with [code]--logs[/code].",
             rich_help_panel="Output control",
         ),
     ] = False,
@@ -80,9 +76,9 @@ def create(
         typer.Option(
             "--wait",
             "-w",
-            help="Wait for the run to complete. Activates polling for the result. "
-            "Run result is printed to [magenta]stdout[/magenta] for [magenta]json[/magenta], "
-            "to a directory for [magenta]multi-file[/magenta]. Specify output location with [code]--output[/code].",
+            help="Wait for the run to complete. Run result is printed to [magenta]stdout[/magenta] for "
+            "[magenta]json[/magenta], to a dir for [magenta]multi-file[/magenta]. "
+            "Specify output location with [code]--output[/code].",
             rich_help_panel="Output control",
         ),
     ] = False,
@@ -222,9 +218,9 @@ def create(
     output, depending on the content type.
 
     Use the [code]--tail[/code] flag to stream logs to
-    [magenta]stdout[/magenta] until the run completes, polling for results.
-    Using the [code]--logs[/code] flag will also activate waiting, and allows
-    you to specify a file to write the logs to.
+    [magenta]stderr[/magenta] until the run completes. Using the
+    [code]--logs[/code] flag will also activate waiting, and allows you to
+    specify a file to write the logs to.
 
     An application run executes against a specific instance. An instance
     represents the combination of executable code and configuration. You can
@@ -256,7 +252,7 @@ def create(
 
     - Read a [magenta]json[/magenta] input from an [magenta]input.json[/magenta] file, and
       submit a run to an app with ID [magenta]hare-app[/magenta], using the [magenta]latest[/magenta] instance.
-      Tail the run's logs, waiting for the run to complete and print the result to [magenta]stdout[/magenta].
+      Tail the run's logs, streaming to [magenta]stderr[/magenta].
         $ [green]nextmv cloud run create --app-id hare-app --input input.json --tail[/green]
 
     - Read a [magenta]json[/magenta] input from an [magenta]input.json[/magenta] file, and
@@ -266,14 +262,24 @@ def create(
 
     - Read a [magenta]json[/magenta] input from an [magenta]input.json[/magenta] file, and
       submit a run to an app with ID [magenta]hare-app[/magenta], using the [magenta]latest[/magenta] instance.
-      Wait for the run to complete, and write the result to an [magenta]output.json[/magenta] file
-      and the logs to a [magenta]logs.log[/magenta] file.
-        $ [green]nextmv cloud run create --app-id hare-app --input input.json \\
-            --output output.json --logs logs.log[/green]
+      Wait for the run to complete, and write the logs to a [magenta]logs.log[/magenta] file.
+        $ [green]nextmv cloud run create --app-id hare-app --input input.json --logs logs.log[/green]
+
+    - Read a [magenta]json[/magenta] input from an [magenta]input.json[/magenta] file, and submit a run to an app with
+      ID [magenta]hare-app[/magenta], using the [magenta]latest[/magenta] instance. Wait for the run to complete. Tail
+      the run's logs, streaming to [magenta]stderr[/magenta]. Write the logs to a [magenta]logs.log[/magenta] file.
+      Write the result to an [magenta]output.json[/magenta] file.
+        $ [green]nextmv cloud run create --app-id hare-app --input input.json --tail --logs logs.log \\
+            --output output.json [/green]
 
     - Read a [magenta]multi-file[/magenta] input from an [magenta]inputs[/magenta] directory, and
       submit a run to an app with ID [magenta]hare-app[/magenta], using the [magenta]default[/magenta] instance.
         $ [green]nextmv cloud run create --app-id hare-app --input inputs --instance-id default[/green]
+
+    - Read a [magenta]multi-file[/magenta] input from an [magenta]inputs[/magenta] directory, and
+      submit a run to an app with ID [magenta]hare-app[/magenta], using the [magenta]default[/magenta] instance.
+      Wait for the run to complete, and save the results to the default location (a directory named after the run ID).
+        $ [green]nextmv cloud run create --app-id hare-app --input inputs --instance-id default --wait[/green]
 
     - Read a [magenta]multi-file[/magenta] input from an [magenta]inputs[/magenta] directory, and
       submit a run to an app with ID [magenta]hare-app[/magenta], using the [magenta]burrow[/magenta] instance.
@@ -333,14 +339,20 @@ def create(
 
     # Handle what happens after the run is created for logging and result
     # retrieval.
-    handle_outputs(
+    handle_logs(
         cloud_app=cloud_app,
-        logs=logs,
-        output=output,
         run_id=run_id,
         tail=tail,
+        logs=logs,
         polling_options=polling_options,
-        result_callback=cloud_app.run_result_with_polling,
+    )
+    handle_outputs(
+        cloud_app=cloud_app,
+        run_id=run_id,
+        wait=wait,
+        output=output,
+        polling_options=polling_options,
+        skip_wait_check=False,
     )
 
 
@@ -500,106 +512,61 @@ def resolve_input_kwarg(
     error(f"Input path [magenta]{input}[/magenta] does not exist.")
 
 
-def handle_outputs(
+def handle_logs(
     cloud_app: Application,
-    logs: str | None,
-    output: str | None,
     run_id: str,
     tail: bool,
+    logs: str | None,
     polling_options: PollingOptions,
 ) -> None:
     """
-    Handles retrieving and outputting the results from a completed run. This
-    includes the logs.
+    Handle retrieving and outputting logs from a run.
 
-    This function retrieves the run result based on the output format and
-    either prints it to stdout, writes it to a file, or downloads it to a
-    directory depending on the content type (JSON, TEXT, multi-file, or
-    csv-archive). It also manages writing the run logs to a specified file if
-    requested.
+    If neither ``tail`` is True nor ``logs`` is specified, this function
+    returns early without doing anything. Otherwise, logs are retrieved and
+    optionally written to a file.
+
+    When ``tail`` is True, logs are streamed in real-time to stderr as the run
+    executes. When ``logs`` is specified (without tailing), the function waits
+    for the run to complete and then fetches all logs at once. In both cases,
+    if a ``logs`` file path is provided, the logs are persisted to that file.
 
     Parameters
     ----------
-    tail : bool
-        Whether to tail the logs until the run completes.
-    logs : str | None
-        The location to write the logs. If None, logs are not written to a file.
-    output : str | None
-        The location to write the output. For JSON/TEXT formats, this is a file
-        path. For multi-file/csv-archive formats, this is a directory path. If
-        None, JSON/TEXT output is printed to stdout and multi-file output uses
-        the run_id as the directory name.
     cloud_app : Application
-        The cloud application instance.
+        The cloud application instance used to interact with the Nextmv Cloud
+        API.
     run_id : str
-        The ID of the run to retrieve results for.
+        The unique identifier of the run to retrieve logs for.
+    tail : bool
+        If True, streams logs in real-time to stderr as the run executes.
+    logs : str | None
+        The file path where logs should be written. If None, logs are only
+        displayed to stderr (when tailing) and not persisted to a file.
     polling_options : PollingOptions
-        The polling options to use when waiting for the run to complete.
+        Configuration options for polling behavior, including timeout and
+        interval settings.
     """
 
-    # If logs tailing is enabled, use it as the polling strategy. We use the
-    # chance to gather the logs.
     if tail:
-        info(msg="Tailing logs and waiting for the run to complete...", emoji=":hourglass_flowing_sand:")
-        run_logs = cloud_app.run_logs_with_polling(
+        info(msg="Tailing logs...", emoji=":hourglass_flowing_sand:")
+        fetched_logs = cloud_app.run_logs_with_polling(
             run_id=run_id,
+            polling_options=polling_options,
             verbose=True,
             rich_print=True,
-            polling_options=polling_options,
         )
+        if logs is None:
+            return
+
+        log_content = "".join(log_entry.log for log_entry in fetched_logs)
+    elif logs is not None:
+        info(msg="Getting run logs...", emoji=":hourglass_flowing_sand:")
+        cloud_app.run_result_with_polling(run_id=run_id, polling_options=polling_options)
+        run_logs = cloud_app.run_logs(run_id=run_id)
+        log_content = run_logs.log
     else:
-        info(msg="Waiting for the run to complete...", emoji=":hourglass_flowing_sand:")
-
-    # Get the run metadata to determine how to operate with the output.
-    run_info = cloud_app.run_metadata(run_id=run_id)
-    content_type = run_info.metadata.format.format_output.output_type
-
-    # Get the run result, using output directory if needed.
-    kwargs = {
-        "run_id": run_id,
-    }
-
-    if content_type not in {OutputFormat.JSON, OutputFormat.TEXT}:
-        if output is None or output == "":
-            output = run_id
-
-        kwargs["output_dir_path"] = output
-
-    run_result = result_callback(**kwargs)
-
-    # If logs output is specified, write the logs to the specified file.
-    if logs is not None:
-        log_path = Path(logs)
-        if tail:
-            with log_path.open("w") as f:
-                for log_entry in run_logs:
-                    f.write(log_entry.log)
-
-        else:
-            run_logs = cloud_app.run_logs(run_id=run_id)
-            with log_path.open("w") as f:
-                f.write(run_logs.log)
-
-        success(f"Run logs written to [magenta]{logs}[/magenta].")
-
-    # Handle the case where output is embedded directly in the result: json and
-    # text.
-    if content_type in {OutputFormat.JSON, OutputFormat.TEXT}:
-        # If no output is specified, we print to stdout. Otherwise, we write
-        # to the specified output file.
-        if output is None:
-            rich.print(run_result.to_dict())
-        else:
-            with open(output, "w") as f:
-                json.dump(run_result.to_dict(), f, indent=2)
-
-            success(f"Run output written to [magenta]{output}[/magenta].")
-
         return
 
-    # At this point, we know that the output is multi-file or csv-archive, which
-    # means we need to handle the output directory.
-    success(f"Run outputs downloaded to [magenta]{output}[/magenta]. Here is the metadata:")
-    result_dict = run_result.to_dict()
-    del result_dict["output"]
-    rich.print(result_dict)
+    Path(logs).write_text(log_content)
+    success(f"Run logs written to [magenta]{logs}[/magenta].")

--- a/nextmv/nextmv/cli/cloud/run/get.py
+++ b/nextmv/nextmv/cli/cloud/run/get.py
@@ -1,5 +1,5 @@
 """
-This module defines the community clone command for the Nextmv CLI.
+This module defines the cloud run get command for the Nextmv CLI.
 """
 
 import json
@@ -27,9 +27,9 @@ def get(
         str | None,
         typer.Option(
             "--output",
-            "-u",
+            "-o",
             help="Waits for the run to complete and save the output to this location. "
-            "A file or directory will be created depending on content type. ",
+            "A file or directory will be created depending on content type.",
             metavar="OUTPUT_LOCATION",
         ),
     ] = None,
@@ -59,6 +59,30 @@ def get(
     for results. Using the [code]--output[/code] flag will also activate
     waiting, and allows you to specify a destination (file or dir) for the
     output, depending on the content type.
+
+    [bold][underline]Examples[/underline][/bold]
+
+    - Get the results of a run with ID [magenta]burrow-123[/magenta], belonging to an app with ID
+      [magenta]hare-app[/magenta].
+        $ [green]nextmv cloud run get --app-id hare-app --run-id burrow-123[/green]
+
+    - Get the results of a run with ID [magenta]burrow-123[/magenta], belonging to an app with ID
+      [magenta]hare-app[/magenta]. Wait for the run to complete if necessary.
+        $ [green]nextmv cloud run get --app-id hare-app --run-id burrow-123 --wait[/green]
+
+    - Get the results of a run with ID [magenta]burrow-123[/magenta], belonging to an app with ID
+      [magenta]hare-app[/magenta]. The app is a [magenta]json[/magenta] app.
+      Save the results to a [magenta]results.json[/magenta] file.
+        $ [green]nextmv cloud run get --app-id hare-app --run-id burrow-123 --output results.json[/green]
+
+    - Get the results of a run with ID [magenta]burrow-123[/magenta], belonging to an app with ID
+      [magenta]hare-app[/magenta]. The app is a [magenta]multi-file[/magenta] app.
+      Save the results to the [magenta]results[/magenta] dir.
+        $ [green]nextmv cloud run get --app-id hare-app --run-id burrow-123 --output results[/green]
+
+    - Get the results of a run with ID [magenta]burrow-123[/magenta], belonging to an app with ID
+      [magenta]hare-app[/magenta]. Use the profile named [magenta]hare[/magenta].
+        $ [green]nextmv cloud run get --app-id hare-app --run-id burrow-123 --profile hare[/green]
     """
 
     cloud_app = build_app(app_id, profile)

--- a/nextmv/nextmv/cli/cloud/run/get.py
+++ b/nextmv/nextmv/cli/cloud/run/get.py
@@ -2,14 +2,18 @@
 This module defines the community clone command for the Nextmv CLI.
 """
 
+import json
 from typing import Annotated
 
+import rich
 import typer
 
-from nextmv.cli.cloud.run.create import handle_logging, handle_results
 from nextmv.cli.configuration.config import build_app
+from nextmv.cli.message import info, success
 from nextmv.cli.options import AppIDOption, ProfileOption, RunIDOption
-from nextmv.polling import DEFAULT_POLLING_OPTIONS
+from nextmv.cloud.application import Application
+from nextmv.output import OutputFormat
+from nextmv.polling import DEFAULT_POLLING_OPTIONS, PollingOptions
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -19,35 +23,16 @@ app = typer.Typer()
 def get(
     app_id: AppIDOption,
     run_id: RunIDOption,
-    logs: Annotated[
-        str | None,
-        typer.Option(
-            "--logs",
-            "-l",
-            help="The location to stream the logs to. They will also be streamed to [magenta]stdout[/magenta]. "
-            "Activates [code]--tail[/code] if not set.",
-            metavar="LOGS_OUTPUT",
-        ),
-    ] = None,
     output: Annotated[
         str | None,
         typer.Option(
             "--output",
             "-u",
-            help="The output location to use. A file or directory will be created depending on content type."
-            "Activates [code]--wait[/code] if not set.",
-            metavar="OUTPUT_DATA",
+            help="Waits for the run to complete and save the output to this location. "
+            "A file or directory will be created depending on content type. ",
+            metavar="OUTPUT_LOCATION",
         ),
     ] = None,
-    tail: Annotated[
-        bool,
-        typer.Option(
-            "--tail",
-            "-t",
-            help="Tail the logs until the run completes. Logs are streamed to [magenta]stdout[/magenta]. "
-            "Activates [code]--wait[/code] if not set.",
-        ),
-    ] = False,
     timeout: Annotated[
         int,
         typer.Option(
@@ -60,9 +45,9 @@ def get(
         typer.Option(
             "--wait",
             "-w",
-            help="Wait for the run to complete. Activates polling for the result. "
-            "Run result is printed to [magenta]stdout[/magenta] for [magenta]json[/magenta], "
-            "to a directory for [magenta]multi-file[/magenta].",
+            help="Wait for the run to complete. Run result is printed to [magenta]stdout[/magenta] for "
+            "[magenta]json[/magenta], to a dir for [magenta]multi-file[/magenta]. "
+            "Specify output location with [code]--output[/code].",
         ),
     ] = False,
     profile: ProfileOption = None,
@@ -74,11 +59,6 @@ def get(
     for results. Using the [code]--output[/code] flag will also activate
     waiting, and allows you to specify a destination (file or dir) for the
     output, depending on the content type.
-
-    Use the [code]--tail[/code] flag to stream logs to
-    [magenta]stdout[/magenta] until the run completes, polling for results.
-    Using the [code]--logs[/code] flag will also activate tailing, and allows
-    you to specify a file to write the logs to.
     """
 
     cloud_app = build_app(app_id, profile)
@@ -87,16 +67,110 @@ def get(
     polling_options = DEFAULT_POLLING_OPTIONS
     polling_options.max_duration = timeout
 
-    handle_logging(
-        tail=tail,
-        logs=logs,
+    handle_outputs(
         cloud_app=cloud_app,
         run_id=run_id,
-        polling_options=polling_options,
-    )
-    handle_results(
+        wait=wait,
         output=output,
-        cloud_app=cloud_app,
-        run_id=run_id,
         polling_options=polling_options,
+        skip_wait_check=True,
     )
+
+
+def handle_outputs(
+    cloud_app: Application,
+    run_id: str,
+    wait: bool,
+    output: str | None,
+    polling_options: PollingOptions,
+    skip_wait_check: bool = False,
+) -> None:
+    """
+    Handle retrieving and outputting the results from a run.
+
+    If ``wait`` is False and ``output`` is not specified, this function returns
+    early without doing anything. Otherwise, results are retrieved using
+    polling (since the run may not yet be complete) and output accordingly.
+
+    The output behavior depends on the content type:
+
+    - **JSON/TEXT**: If ``output`` is specified, writes to the given file path.
+      Otherwise, prints to stdout.
+    - **MULTI_FILE/CSV_ARCHIVE**: Downloads files to a directory. If ``output``
+      is specified, uses that as the directory name. Otherwise, uses the
+      ``run_id`` as the directory name.
+
+    Parameters
+    ----------
+    cloud_app : Application
+        The cloud application instance used to interact with the Nextmv Cloud
+        API.
+    run_id : str
+        The unique identifier of the run to retrieve results for.
+    wait : bool
+        Whether to wait for the run to complete. If False and ``output`` is not
+        specified, the function returns early without retrieving results.
+    output : str | None
+        The location to write the output. For JSON/TEXT formats, this is a file
+        path. For MULTI_FILE/CSV_ARCHIVE formats, this is a directory path. If
+        None, JSON/TEXT output is printed to stdout and MULTI_FILE/CSV_ARCHIVE
+        output uses the ``run_id`` as the directory name.
+    polling_options : PollingOptions
+        Configuration options for polling behavior, including timeout and
+        interval settings.
+    skip_wait_check : bool, optional
+        If True, skips the early return check when both `wait` is False and
+        `output` is not specified. Default is False.
+    """
+
+    # If we don't need to wait, no output is specified, and we're not skipping
+    # the wait check, return early.
+    if not wait and (output is None or output == "") and not skip_wait_check:
+        return
+
+    # Get the run metadata to determine how to operate with the output.
+    run_info = cloud_app.run_metadata(run_id=run_id)
+    content_type = run_info.metadata.format.format_output.output_type
+
+    # Build kwargs for the result retrieval.
+    kwargs = {"run_id": run_id}
+
+    # For MULTI_FILE and CSV_ARCHIVE, we need output_dir_path.
+    if content_type not in {OutputFormat.JSON, OutputFormat.TEXT}:
+        output_dir = output if output else run_id
+        kwargs["output_dir_path"] = output_dir
+
+    # Always poll for results since we can't guarantee the run is done.
+    # If the run is already complete, polling returns immediately.
+    info(msg="Getting run results...", emoji=":hourglass_flowing_sand:")
+    wait = wait or (output is not None and output != "")
+    if wait:
+        kwargs["polling_options"] = polling_options
+        run_result = cloud_app.run_result_with_polling(**kwargs)
+    else:
+        run_result = cloud_app.run_result(**kwargs)
+
+    # Handle the case where output is embedded directly in the result: json and text.
+    if content_type in {OutputFormat.JSON, OutputFormat.TEXT}:
+        if output is None or output == "":
+            rich.print(run_result.to_dict())
+        else:
+            with open(output, "w") as f:
+                json.dump(run_result.to_dict(), f, indent=2)
+
+            success(f"Run output written to [magenta]{output}[/magenta].")
+
+        return
+
+    # At this point, we know that the output is multi-file or csv-archive.
+    result_dict = run_result.to_dict()
+    if "output" in result_dict and run_info.metadata.run_is_finalized():
+        del result_dict["output"]
+        success(f"Run outputs downloaded to [magenta]{output_dir}[/magenta]. Here is the metadata.")
+    else:
+        success(
+            f"Run is not finalized (status: [magenta]{run_info.metadata.status_v2.value}[/magenta]). "
+            "Here is the metadata."
+        )
+
+    rich.print(result_dict)

--- a/nextmv/nextmv/cli/cloud/run/get.py
+++ b/nextmv/nextmv/cli/cloud/run/get.py
@@ -1,0 +1,102 @@
+"""
+This module defines the community clone command for the Nextmv CLI.
+"""
+
+from typing import Annotated
+
+import typer
+
+from nextmv.cli.cloud.run.create import handle_logging, handle_results
+from nextmv.cli.configuration.config import build_app
+from nextmv.cli.options import AppIDOption, ProfileOption, RunIDOption
+from nextmv.polling import DEFAULT_POLLING_OPTIONS
+
+# Set up subcommand application.
+app = typer.Typer()
+
+
+@app.command()
+def get(
+    app_id: AppIDOption,
+    run_id: RunIDOption,
+    logs: Annotated[
+        str | None,
+        typer.Option(
+            "--logs",
+            "-l",
+            help="The location to stream the logs to. They will also be streamed to [magenta]stdout[/magenta]. "
+            "Activates [code]--tail[/code] if not set.",
+            metavar="LOGS_OUTPUT",
+        ),
+    ] = None,
+    output: Annotated[
+        str | None,
+        typer.Option(
+            "--output",
+            "-u",
+            help="The output location to use. A file or directory will be created depending on content type."
+            "Activates [code]--wait[/code] if not set.",
+            metavar="OUTPUT_DATA",
+        ),
+    ] = None,
+    tail: Annotated[
+        bool,
+        typer.Option(
+            "--tail",
+            "-t",
+            help="Tail the logs until the run completes. Logs are streamed to [magenta]stdout[/magenta]. "
+            "Activates [code]--wait[/code] if not set.",
+        ),
+    ] = False,
+    timeout: Annotated[
+        int,
+        typer.Option(
+            help="The maximum time in seconds to wait for results when polling. Poll indefinitely if not set.",
+            metavar="TIMEOUT_SECONDS",
+        ),
+    ] = -1,
+    wait: Annotated[
+        bool,
+        typer.Option(
+            "--wait",
+            "-w",
+            help="Wait for the run to complete. Activates polling for the result. "
+            "Run result is printed to [magenta]stdout[/magenta] for [magenta]json[/magenta], "
+            "to a directory for [magenta]multi-file[/magenta].",
+        ),
+    ] = False,
+    profile: ProfileOption = None,
+) -> None:
+    """
+    Get the result of a Nextmv Cloud application run.
+
+    Use the [code]--wait[/code] flag to wait for the run to complete, polling
+    for results. Using the [code]--output[/code] flag will also activate
+    waiting, and allows you to specify a destination (file or dir) for the
+    output, depending on the content type.
+
+    Use the [code]--tail[/code] flag to stream logs to
+    [magenta]stdout[/magenta] until the run completes, polling for results.
+    Using the [code]--logs[/code] flag will also activate tailing, and allows
+    you to specify a file to write the logs to.
+    """
+
+    cloud_app = build_app(app_id, profile)
+
+    # Build the polling options.
+    polling_options = DEFAULT_POLLING_OPTIONS
+    polling_options.max_duration = timeout
+
+    handle_logging(
+        tail=tail,
+        logs=logs,
+        cloud_app=cloud_app,
+        run_id=run_id,
+        polling_options=polling_options,
+    )
+    handle_results(
+        output=output,
+        cloud_app=cloud_app,
+        run_id=run_id,
+        polling_options=polling_options,
+    )

--- a/nextmv/nextmv/cli/cloud/run/get.py
+++ b/nextmv/nextmv/cli/cloud/run/get.py
@@ -5,11 +5,10 @@ This module defines the cloud run get command for the Nextmv CLI.
 import json
 from typing import Annotated
 
-import rich
 import typer
 
 from nextmv.cli.configuration.config import build_app
-from nextmv.cli.message import info, success
+from nextmv.cli.message import info, print_json, success
 from nextmv.cli.options import AppIDOption, ProfileOption, RunIDOption
 from nextmv.cloud.application import Application
 from nextmv.output import OutputFormat
@@ -30,7 +29,7 @@ def get(
             "-o",
             help="Waits for the run to complete and save the output to this location. "
             "A file or directory will be created depending on content type.",
-            metavar="OUTPUT_LOCATION",
+            metavar="OUTPUT_PATH",
         ),
     ] = None,
     timeout: Annotated[
@@ -53,7 +52,7 @@ def get(
     profile: ProfileOption = None,
 ) -> None:
     """
-    Get the result of a Nextmv Cloud application run.
+    Get the result (output) of a Nextmv Cloud application run.
 
     Use the [code]--wait[/code] flag to wait for the run to complete, polling
     for results. Using the [code]--output[/code] flag will also activate
@@ -161,7 +160,7 @@ def handle_outputs(
 
     # For MULTI_FILE and CSV_ARCHIVE, we need output_dir_path.
     if content_type not in {OutputFormat.JSON, OutputFormat.TEXT}:
-        output_dir = output if output else run_id
+        output_dir = f"{run_id}-output" if output is None or output == "" else output
         kwargs["output_dir_path"] = output_dir
 
     # Always poll for results since we can't guarantee the run is done.
@@ -177,7 +176,7 @@ def handle_outputs(
     # Handle the case where output is embedded directly in the result: json and text.
     if content_type in {OutputFormat.JSON, OutputFormat.TEXT}:
         if output is None or output == "":
-            rich.print(run_result.to_dict())
+            print_json(run_result.to_dict())
         else:
             with open(output, "w") as f:
                 json.dump(run_result.to_dict(), f, indent=2)
@@ -197,4 +196,4 @@ def handle_outputs(
             "Here is the metadata."
         )
 
-    rich.print(result_dict)
+    print_json(result_dict)

--- a/nextmv/nextmv/cli/cloud/run/input.py
+++ b/nextmv/nextmv/cli/cloud/run/input.py
@@ -1,5 +1,5 @@
 """
-This module defines the cloud run logs command for the Nextmv CLI.
+This module defines the cloud run input command for the Nextmv CLI.
 """
 
 import json

--- a/nextmv/nextmv/cli/cloud/run/input.py
+++ b/nextmv/nextmv/cli/cloud/run/input.py
@@ -1,0 +1,86 @@
+"""
+This module defines the cloud run logs command for the Nextmv CLI.
+"""
+
+import json
+from typing import Annotated
+
+import typer
+
+from nextmv.cli.configuration.config import build_app
+from nextmv.cli.message import info, print_json, success
+from nextmv.cli.options import AppIDOption, ProfileOption, RunIDOption
+from nextmv.output import OutputFormat
+
+# Set up subcommand application.
+app = typer.Typer()
+
+
+@app.command()
+def input(
+    app_id: AppIDOption,
+    run_id: RunIDOption,
+    output: Annotated[
+        str | None,
+        typer.Option(
+            "--output",
+            "-o",
+            help="Saves the input to this location.",
+            metavar="OUTPUT_PATH",
+        ),
+    ] = None,
+    profile: ProfileOption = None,
+) -> None:
+    """
+    Get the input of a Nextmv Cloud application run.
+
+    By default, the input is fetched and printed to [magenta]stdout[/magenta].
+    Use the [code]--output[/code] flag to save the input to a file.
+
+    [bold][underline]Examples[/underline][/bold]
+
+    - Get the input of a run with ID [magenta]burrow-123[/magenta], belonging to an app with ID
+      [magenta]hare-app[/magenta]. Input is printed to [magenta]stdout[/magenta].
+        $ [green]nextmv cloud run input --app-id hare-app --run-id burrow-123[/green]
+
+    - Get the input of a run with ID [magenta]burrow-123[/magenta], belonging to an app with ID
+      [magenta]hare-app[/magenta]. Save the input to a [magenta]input.json[/magenta] file.
+        $ [green]nextmv cloud run input --app-id hare-app --run-id burrow-123 --output input.json[/green]
+
+    - Get the input of a run with ID [magenta]burrow-123[/magenta], belonging to an app with ID
+      [magenta]hare-app[/magenta]. Use the profile named [magenta]hare[/magenta].
+        $ [green]nextmv cloud run input --app-id hare-app --run-id burrow-123 --profile hare[/green]
+    """
+
+    cloud_app = build_app(app_id, profile)
+    info(msg="Getting run input...", emoji=":hourglass_flowing_sand:")
+
+    # First get the content type to check what we should do with the input,
+    # based on its format.
+    run_info = cloud_app.run_metadata(run_id)
+
+    # If the input is multi-file, we need to provide an `output_dir_path` to
+    # save the files to.
+    if run_info.metadata.format.format_output.output_type not in {OutputFormat.JSON, OutputFormat.TEXT}:
+        # If no output path is provided, use the run ID as the directory name.
+        output = f"{run_id}-input" if output is None or output == "" else output
+        cloud_app.run_input(run_id=run_id, output_dir_path=output)
+        success(msg=f"Run input saved to [magenta]{output}[/magenta].")
+
+        return
+
+    # At this point, we know the input is JSON or text, so we can fetch it
+    # normally. The method internally will take care of large inputs.
+    run_input = cloud_app.run_input(run_id=run_id)
+
+    # If an output path is provided, save the input to that file.
+    if output is not None and output != "":
+        with open(output, "w") as f:
+            json.dump(run_input, f, indent=2)
+
+        success(msg=f"Run input saved to [magenta]{output}[/magenta].")
+
+        return
+
+    # Otherwise, print the input to stdout.
+    print_json(data=run_input)

--- a/nextmv/nextmv/cli/cloud/run/input.py
+++ b/nextmv/nextmv/cli/cloud/run/input.py
@@ -61,7 +61,7 @@ def input(
 
     # If the input is multi-file, we need to provide an `output_dir_path` to
     # save the files to.
-    if run_info.metadata.format.format_output.output_type not in {OutputFormat.JSON, OutputFormat.TEXT}:
+    if run_info.metadata.format.format_input.input_type not in {OutputFormat.JSON, OutputFormat.TEXT}:
         # If no output path is provided, use the run ID as the directory name.
         output = f"{run_id}-input" if output is None or output == "" else output
         cloud_app.run_input(run_id=run_id, output_dir_path=output)

--- a/nextmv/nextmv/cli/cloud/run/list.py
+++ b/nextmv/nextmv/cli/cloud/run/list.py
@@ -1,5 +1,5 @@
 """
-This module defines the cloud run logs command for the Nextmv CLI.
+This module defines the cloud run list command for the Nextmv CLI.
 """
 
 import json

--- a/nextmv/nextmv/cli/cloud/run/list.py
+++ b/nextmv/nextmv/cli/cloud/run/list.py
@@ -1,0 +1,65 @@
+"""
+This module defines the cloud run logs command for the Nextmv CLI.
+"""
+
+import json
+from typing import Annotated
+
+import typer
+
+from nextmv.cli.configuration.config import build_app
+from nextmv.cli.message import info, print_json, success
+from nextmv.cli.options import AppIDOption, ProfileOption
+
+# Set up subcommand application.
+app = typer.Typer()
+
+
+@app.command()
+def list(
+    app_id: AppIDOption,
+    output: Annotated[
+        str | None,
+        typer.Option(
+            "--output",
+            "-o",
+            help="Saves the list of runs to this location.",
+            metavar="OUTPUT_PATH",
+        ),
+    ] = None,
+    profile: ProfileOption = None,
+) -> None:
+    """
+    Get the list of runs for a Nextmv Cloud application.
+
+    By default, the list of runs is fetched and printed to [magenta]stdout[/magenta].
+    Use the [code]--output[/code] flag to save the list to a file.
+
+    [bold][underline]Examples[/underline][/bold]
+
+    - Get the list of runs for an app with ID [magenta]hare-app[/magenta]. List is printed to [magenta]stdout[/magenta].
+        $ [green]nextmv cloud run list --app-id hare-app[/green]
+
+    - Get the list of runs for an app with ID [magenta]hare-app[/magenta]. Save the list to a
+      [magenta]runs.json[/magenta] file.
+        $ [green]nextmv cloud run list --app-id hare-app --output runs.json[/green]
+
+    - Get the list of runs for an app with ID [magenta]hare-app[/magenta].
+      Use the profile named [magenta]hare[/magenta].
+        $ [green]nextmv cloud run list --app-id hare-app --profile hare[/green]
+    """
+
+    cloud_app = build_app(app_id, profile)
+    info(msg="Getting app runs...", emoji=":hourglass_flowing_sand:")
+    runs = cloud_app.list_runs()
+    runs_dicts = [run.to_dict() for run in runs]
+
+    if output is not None:
+        with open(output, "w") as f:
+            json.dump(runs_dicts, f, indent=2)
+
+        success(msg=f"Run list saved to [magenta]{output}[/magenta].")
+
+        return
+
+    print_json(runs_dicts)

--- a/nextmv/nextmv/cli/cloud/run/logs.py
+++ b/nextmv/nextmv/cli/cloud/run/logs.py
@@ -1,0 +1,167 @@
+"""
+This module defines the cloud run logs command for the Nextmv CLI.
+"""
+
+import sys
+from pathlib import Path
+from typing import Annotated
+
+import rich
+import typer
+
+from nextmv.cli.configuration.config import build_app
+from nextmv.cli.message import info, success
+from nextmv.cli.options import AppIDOption, ProfileOption, RunIDOption
+from nextmv.cloud.application import Application
+from nextmv.polling import DEFAULT_POLLING_OPTIONS, PollingOptions
+
+# Set up subcommand application.
+app = typer.Typer()
+
+
+@app.command()
+def logs(
+    app_id: AppIDOption,
+    run_id: RunIDOption,
+    output: Annotated[
+        str | None,
+        typer.Option(
+            "--output",
+            "-o",
+            help="Waits for the run to complete and saves the logs to this location.",
+            metavar="LOGS_LOCATION",
+        ),
+    ] = None,
+    tail: Annotated[
+        bool,
+        typer.Option(
+            "--tail",
+            "-t",
+            help="Tail the logs until the run completes. Logs are streamed to [magenta]stderr[/magenta]. "
+            "Specify log output location with [code]--output[/code].",
+        ),
+    ] = False,
+    timeout: Annotated[
+        int,
+        typer.Option(
+            help="The maximum time in seconds to wait for results when polling. Poll indefinitely if not set.",
+            metavar="TIMEOUT_SECONDS",
+        ),
+    ] = -1,
+    profile: ProfileOption = None,
+) -> None:
+    """
+    Get the logs of a Nextmv Cloud application run.
+
+    By default, the logs are fetched and printed to [magenta]stderr[/magenta].
+    Use the [code]--tail[/code] flag to stream logs to
+    [magenta]stderr[/magenta] until the run completes. Using the
+    [code]--output[/code] flag will also activate waiting, and allows you to
+    specify a file to write the logs to.
+
+    [bold][underline]Examples[/underline][/bold]
+
+    - Get the logs of a run with ID [magenta]burrow-123[/magenta], belonging to an app with ID
+      [magenta]hare-app[/magenta]. Logs are printed to [magenta]stderr[/magenta].
+        $ [green]nextmv cloud run logs --app-id hare-app --run-id burrow-123[/green]
+
+    - Get the logs of a run with ID [magenta]burrow-123[/magenta], belonging to an app with ID
+      [magenta]hare-app[/magenta]. Tail the logs until the run completes.
+        $ [green]nextmv cloud run logs --app-id hare-app --run-id burrow-123 --tail[/green]
+
+    - Get the logs of a run with ID [magenta]burrow-123[/magenta], belonging to an app with ID
+      [magenta]hare-app[/magenta]. Save the logs to a [magenta]logs.log[/magenta] file.
+        $ [green]nextmv cloud run logs --app-id hare-app --run-id burrow-123 --output logs.log[/green]
+
+    - Get the logs of a run with ID [magenta]burrow-123[/magenta], belonging to an app with ID
+      [magenta]hare-app[/magenta]. Tail the logs and save them to a [magenta]logs.log[/magenta] file.
+        $ [green]nextmv cloud run logs --app-id hare-app --run-id burrow-123 --tail --output logs.log[/green]
+
+    - Get the logs of a run with ID [magenta]burrow-123[/magenta], belonging to an app with ID
+      [magenta]hare-app[/magenta]. Use the profile named [magenta]hare[/magenta].
+        $ [green]nextmv cloud run logs --app-id hare-app --run-id burrow-123 --profile hare[/green]
+    """
+
+    cloud_app = build_app(app_id, profile)
+
+    # Build the polling options.
+    polling_options = DEFAULT_POLLING_OPTIONS
+    polling_options.max_duration = timeout
+
+    handle_logs(
+        cloud_app=cloud_app,
+        run_id=run_id,
+        tail=tail,
+        logs=output,
+        polling_options=polling_options,
+        file_output=output is not None,
+    )
+
+
+def handle_logs(
+    cloud_app: Application,
+    run_id: str,
+    tail: bool,
+    logs: str | None,
+    polling_options: PollingOptions,
+    file_output: bool,
+) -> None:
+    """
+    Handle retrieving and outputting logs from a run.
+
+    If neither `tail` is True nor `logs` is specified, this function
+    returns early without doing anything. Otherwise, logs are retrieved and
+    optionally written to a file.
+
+    When `tail` is True, logs are streamed in real-time to stderr as the run
+    executes. When `logs` is specified (without tailing), the function waits
+    for the run to complete and then fetches all logs at once. In both cases,
+    if a `logs` file path is provided, the logs are persisted to that file.
+
+    Parameters
+    ----------
+    cloud_app : Application
+        The cloud application instance used to interact with the Nextmv Cloud
+        API.
+    run_id : str
+        The unique identifier of the run to retrieve logs for.
+    tail : bool
+        If True, streams logs in real-time to stderr as the run executes.
+    logs : str | None
+        The file path where logs should be written. If None, logs are only
+        displayed to stderr (when tailing) and not persisted to a file.
+    polling_options : PollingOptions
+        Configuration options for polling behavior, including timeout and
+        interval settings.
+    file_output : bool
+        Indicates whether logs should be written to a file. If False, logs are
+        only printed to stderr, no matter the status of the run.
+    """
+
+    if tail:
+        info(msg="Tailing logs...", emoji=":hourglass_flowing_sand:")
+        fetched_logs = cloud_app.run_logs_with_polling(
+            run_id=run_id,
+            polling_options=polling_options,
+            verbose=True,
+            rich_print=True,
+        )
+        if logs is None:
+            return
+
+        log_content = "".join(log_entry.log for log_entry in fetched_logs)
+    elif logs is not None and logs != "" and file_output:
+        info(msg="Getting run logs...", emoji=":hourglass_flowing_sand:")
+        cloud_app.run_result_with_polling(run_id=run_id, polling_options=polling_options)
+        run_logs = cloud_app.run_logs(run_id=run_id)
+        log_content = run_logs.log
+    elif not file_output:
+        info(msg="Getting run logs...", emoji=":hourglass_flowing_sand:")
+        run_logs = cloud_app.run_logs(run_id=run_id)
+        rich.print(run_logs.log, file=sys.stderr)
+        return
+    else:
+        return
+
+    Path(logs).write_text(log_content)
+    success(f"Run logs written to [magenta]{logs}[/magenta].")

--- a/nextmv/nextmv/cli/cloud/run/logs.py
+++ b/nextmv/nextmv/cli/cloud/run/logs.py
@@ -29,7 +29,7 @@ def logs(
             "--output",
             "-o",
             help="Waits for the run to complete and saves the logs to this location.",
-            metavar="LOGS_LOCATION",
+            metavar="OUTPUT_PATH",
         ),
     ] = None,
     tail: Annotated[

--- a/nextmv/nextmv/cli/cloud/run/metadata.py
+++ b/nextmv/nextmv/cli/cloud/run/metadata.py
@@ -1,0 +1,67 @@
+"""
+This module defines the cloud run logs command for the Nextmv CLI.
+"""
+
+import json
+from typing import Annotated
+
+import typer
+
+from nextmv.cli.configuration.config import build_app
+from nextmv.cli.message import info, print_json, success
+from nextmv.cli.options import AppIDOption, ProfileOption, RunIDOption
+
+# Set up subcommand application.
+app = typer.Typer()
+
+
+@app.command()
+def metadata(
+    app_id: AppIDOption,
+    run_id: RunIDOption,
+    output: Annotated[
+        str | None,
+        typer.Option(
+            "--output",
+            "-o",
+            help="Saves the metadata to this location.",
+            metavar="OUTPUT_PATH",
+        ),
+    ] = None,
+    profile: ProfileOption = None,
+) -> None:
+    """
+    Get the metadata of a Nextmv Cloud application run.
+
+    By default, the metadata is fetched and printed to [magenta]stdout[/magenta].
+    Use the [code]--output[/code] flag to save the metadata to a file.
+
+    [bold][underline]Examples[/underline][/bold]
+
+    - Get the metadata of a run with ID [magenta]burrow-123[/magenta], belonging to an app with ID
+      [magenta]hare-app[/magenta]. Metadata is printed to [magenta]stdout[/magenta].
+        $ [green]nextmv cloud run metadata --app-id hare-app --run-id burrow-123[/green]
+
+    - Get the metadata of a run with ID [magenta]burrow-123[/magenta], belonging to an app with ID
+      [magenta]hare-app[/magenta]. Save the metadata to a [magenta]metadata.json[/magenta] file.
+        $ [green]nextmv cloud run metadata --app-id hare-app --run-id burrow-123 --output metadata.json[/green]
+
+    - Get the metadata of a run with ID [magenta]burrow-123[/magenta], belonging to an app with ID
+      [magenta]hare-app[/magenta]. Use the profile named [magenta]hare[/magenta].
+        $ [green]nextmv cloud run metadata --app-id hare-app --run-id burrow-123 --profile hare[/green]
+    """
+
+    cloud_app = build_app(app_id, profile)
+    info(msg="Getting run metadata...", emoji=":hourglass_flowing_sand:")
+    run_info = cloud_app.run_metadata(run_id)
+    info_dict = run_info.to_dict()
+
+    if output is not None:
+        with open(output, "w") as f:
+            json.dump(info_dict, f, indent=2)
+
+        success(msg=f"Run metadata saved to [magenta]{output}[/magenta].")
+
+        return
+
+    print_json(info_dict)

--- a/nextmv/nextmv/cli/cloud/run/metadata.py
+++ b/nextmv/nextmv/cli/cloud/run/metadata.py
@@ -1,5 +1,5 @@
 """
-This module defines the cloud run logs command for the Nextmv CLI.
+This module defines the cloud run metadata command for the Nextmv CLI.
 """
 
 import json

--- a/nextmv/nextmv/cli/cloud/run/track.py
+++ b/nextmv/nextmv/cli/cloud/run/track.py
@@ -1,5 +1,5 @@
 """
-This module defines the cloud run create command for the Nextmv CLI.
+This module defines the cloud run track command for the Nextmv CLI.
 """
 
 import json

--- a/nextmv/nextmv/cli/cloud/run/track.py
+++ b/nextmv/nextmv/cli/cloud/run/track.py
@@ -1,0 +1,502 @@
+"""
+This module defines the cloud run create command for the Nextmv CLI.
+"""
+
+import json
+import sys
+from pathlib import Path
+from typing import Annotated
+
+import typer
+
+from nextmv.cli.cloud.run.create import build_run_config
+from nextmv.cli.configuration.config import build_app
+from nextmv.cli.message import error, print_json
+from nextmv.cli.options import AppIDOption, ProfileOption
+from nextmv.input import InputFormat
+from nextmv.run import RunType, TrackedRun, TrackedRunStatus
+
+# Set up subcommand application.
+app = typer.Typer()
+
+
+@app.command()
+def track(
+    app_id: AppIDOption,
+    # Options for controlling the tracked run.
+    output: Annotated[
+        str,
+        typer.Option(
+            "--output",
+            "-o",
+            help="The output of the run being tracked. A file or directory depending on content type.",
+            metavar="OUTPUT_PATH",
+            rich_help_panel="Tracked run control",
+        ),
+    ],
+    status: Annotated[
+        TrackedRunStatus,
+        typer.Option(
+            "--status",
+            "-s",
+            help="Status of the tracked run. Allowed values are: "
+            f"{[v.value for v in TrackedRunStatus.__members__.values()]}",
+            metavar="STATUS",
+            rich_help_panel="Tracked run control",
+        ),
+    ],
+    assets: Annotated[
+        str | None,
+        typer.Option(
+            help="The assets of the run being tracked. A [magenta]json[/magenta] file to read the assets from.",
+            metavar="ASSETS_PATH",
+            rich_help_panel="Tracked run control",
+        ),
+    ] = None,
+    content_type: Annotated[
+        InputFormat | None,
+        typer.Option(
+            "--content-type",
+            "-c",
+            help="The content type of the run to track. Allowed values are: "
+            f"{[v.value for v in InputFormat.__members__.values()]}",
+            metavar="CONTENT_TYPE",
+            rich_help_panel="Tracked run control",
+        ),
+    ] = InputFormat.JSON,
+    description: Annotated[
+        str | None,
+        typer.Option(
+            help="An optional description for the tracked run.",
+            metavar="DESCRIPTION",
+            rich_help_panel="Tracked run control",
+        ),
+    ] = None,
+    duration: Annotated[
+        int,
+        typer.Option(
+            "--duration",
+            "-d",
+            help="The duration of the run being tracked, in milliseconds.",
+            metavar="DURATION_MS",
+            rich_help_panel="Tracked run control",
+        ),
+    ] = 0,
+    error_msg: Annotated[
+        str | None,
+        typer.Option(
+            "--error-msg",
+            "-e",
+            help="An error message if the run being tracked failed.",
+            metavar="ERROR_MESSAGE",
+            rich_help_panel="Tracked run control",
+        ),
+    ] = None,
+    input: Annotated[
+        str | None,
+        typer.Option(
+            "--input",
+            "-i",
+            help="The input of the run being tracked. File or directory depending on content type. "
+            "Uses [magenta]stdin[/magenta] if not defined.",
+            metavar="INPUT_PATH",
+            rich_help_panel="Tracked run control",
+        ),
+    ] = None,
+    logs: Annotated[
+        str | None,
+        typer.Option(
+            "--logs",
+            "-l",
+            help="The logs of the run being tracked. A utf-8 encoded text file to read the logs from.",
+            metavar="LOGS_PATH",
+            rich_help_panel="Tracked run control",
+        ),
+    ] = None,
+    name: Annotated[
+        str | None,
+        typer.Option(
+            "--name",
+            "-n",
+            help="An optional name for the tracked run.",
+            metavar="NAME",
+            rich_help_panel="Tracked run control",
+        ),
+    ] = None,
+    statistics: Annotated[
+        str | None,
+        typer.Option(
+            help="The statistics of the run being tracked. A [magenta]json[/magenta] file to read the statistics from.",
+            metavar="STATISTICS_PATH",
+            rich_help_panel="Tracked run control",
+        ),
+    ] = None,
+    # Options for run configuration.
+    instance_id: Annotated[
+        str | None,
+        typer.Option(
+            help="The instance ID to use for the run.",
+            metavar="INSTANCE_ID",
+            rich_help_panel="Run configuration",
+        ),
+    ] = "latest",
+    profile: ProfileOption = None,
+) -> None:
+    """
+    Track an external run as a Nextmv Cloud application run.
+
+    Please see the help of the [code]--content-type[/code] option for details
+    on valid content types.
+
+    If the content type is [magenta]json[/magenta] or [magenta]text[/magenta],
+    then input for the run can be given through [magenta]stdin[/magenta]. The
+    [code]--input[/code] option allows you to specify a file or directory path
+    for the input, instead of using [magenta]stdin[/magenta]. In the case of
+    [magenta]multi-file[/magenta] content type, the input must be given through
+    a directory specified via the [code]--input[/code] option.
+
+    The [code]--output[/code] option allows you to specify a file or directory
+    path for the output of the run. The behavior depends on the content type.
+    If the content type is [magenta]json[/magenta] or [magenta]text[/magenta],
+    then a file path must be provided. If the content type is
+    [magenta]multi-file[/magenta], then a directory path must be provided.
+
+    Run logs, assets, and statistics can be provided via files using the
+    [code]--logs[/code], [code]--assets[/code], and [code]--statistics[/code]
+    options, respectively. Assets and statistics must be provided as
+    [magenta]json[/magenta] files, while logs must be provided as a utf-8
+    encoded text file.
+
+    [bold][underline]Examples[/underline][/bold]
+
+    - Track a [magenta]successful[/magenta] [magenta]json[/magenta] run via [magenta]stdin[/magenta]
+      input, for an app with ID [magenta]hare-app[/magenta].
+        $ [green]cat input.json | nextmv cloud run track --app-id hare-app --status succeeded[/green]
+
+    - Track a [magenta]successful[/magenta] [magenta]json[/magenta] run with input from an
+      [magenta]input.json[/magenta] file and output from an
+      [magenta]output.json[/magenta] file, for an app with ID
+      [magenta]hare-app[/magenta].
+        $ [green]nextmv cloud run track --app-id hare-app --status succeeded --input input.json \\
+            --output output.json[/green]
+
+    - Track a [magenta]successful[/magenta] [magenta]json[/magenta] run including logs from a
+      [magenta]logs.log[/magenta] file, for an app with ID
+      [magenta]hare-app[/magenta].
+        $ [green]nextmv cloud run track --app-id hare-app --status succeeded --input input.json \\
+            --output output.json --logs logs.log[/green]
+
+    - Track a [magenta]successful[/magenta] [magenta]json[/magenta] run with assets and statistics
+      from [magenta]json[/magenta] files, for an app with ID
+      [magenta]hare-app[/magenta].
+        $ [green]nextmv cloud run track --app-id hare-app --status succeeded --input input.json \\
+            --output output.json --assets assets.json --statistics statistics.json[/green]
+
+    - Track a [magenta]failed[/magenta] run with an error message, for an app with ID
+      [magenta]hare-app[/magenta].
+        $ [green]nextmv cloud run track --app-id hare-app --status failed --input input.json \\
+            --error-msg "Solver timed out"[/green]
+
+    - Track a [magenta]successful[/magenta] [magenta]text[/magenta] run with text content type,
+      for an app with ID [magenta]hare-app[/magenta].
+        $ [green]nextmv cloud run track --app-id hare-app --status succeeded --input input.txt \\
+            --output output.txt --content-type text[/green]
+
+    - Track a [magenta]successful[/magenta] [magenta]multi-file[/magenta] run from an
+      [magenta]inputs[/magenta] directory with output to an
+      [magenta]outputs[/magenta] directory, for an app with ID
+      [magenta]hare-app[/magenta], using the [magenta]default[/magenta]
+      instance.
+        $ [green]nextmv cloud run track --app-id hare-app --status succeeded --input inputs \\
+            --output outputs --content-type multi-file --instance-id default[/green]
+
+    - Track a [magenta]successful[/magenta] run with a name, description, and duration, for an app
+      with ID [magenta]hare-app[/magenta].
+        $ [green]nextmv cloud run track --app-id hare-app --status succeeded --input input.json \\
+            --output output.json --name "Production run" --description "Weekly optimization" --duration 5000[/green]
+
+    - Track a [magenta]successful[/magenta] [magenta]json[/magenta] run with all available options,
+      for an app with ID [magenta]hare-app[/magenta].
+        $ [green]nextmv cloud run track --app-id hare-app --status succeeded --input input.json \\
+            --output output.json --logs logs.log --assets assets.json --statistics statistics.json \\
+                --name "Full run" --description "Complete example" --duration 10000 --instance-id burrow[/green]
+    """
+
+    # Validate that input is provided.
+    stdin = sys.stdin.read().strip() if sys.stdin.isatty() is False else None
+    if stdin is None and (input is None or input == ""):
+        error("Input data must be provided via the [code]--input[/code] flag or [magenta]stdin[/magenta].")
+
+    # Instantiate the basic requirements to start a new run.
+    cloud_app = build_app(app_id, profile)
+    config = build_run_config(
+        run_type=RunType.EXTERNAL,
+        priority=6,
+        no_queuing=False,
+        content_type=content_type,
+    )
+
+    # Handles the default instance.
+    if instance_id == "default":
+        instance_id = ""
+
+    # Build the tracked run input.
+    tracked_run = build_tracked_run_input(
+        status=status,
+        duration=duration,
+        error_msg=error_msg,
+        name=name,
+        description=description,
+        stdin=stdin,
+        input=input,
+        content_type=content_type,
+        output=output,
+        assets=assets,
+        logs=logs,
+        statistics=statistics,
+    )
+
+    # Actually track the run.
+    run_id = cloud_app.track_run(
+        tracked_run=tracked_run,
+        instance_id=instance_id,
+        configuration=config,
+    )
+
+    print_json({"run_id": run_id})
+
+
+def build_tracked_run_input(
+    status: TrackedRunStatus,
+    duration: int,
+    error_msg: str | None,
+    name: str | None,
+    description: str | None,
+    stdin: str | None,
+    input: str | None,
+    content_type: InputFormat,
+    output: str,
+    assets: str | None = None,
+    logs: str | None = None,
+    statistics: str | None = None,
+) -> TrackedRun:
+    """
+    Builds the tracked run input for tracking a run. Starts by creating a
+    TrackedRun object with the provided status, duration, error message, name,
+    and description. Then resolves the input and output using helper functions.
+    Finally, it reads the assets, logs, and statistics from the provided file
+    paths, if any, and assigns them to the TrackedRun object.
+
+    Parameters
+    ----------
+    status : TrackedRunStatus
+        The status of the tracked run.
+    duration : int
+        The duration of the tracked run in milliseconds.
+    error_msg : str | None
+        An error message if the run failed.
+    name : str | None
+        An optional name for the tracked run.
+    description : str | None
+        An optional description for the tracked run.
+    stdin : str | None
+        The input provided via stdin, if any.
+    input : str | None
+        The input file or directory path, if any.
+    content_type : InputFormat
+        The content type of the input (json or text).
+    output : str
+        The output file or directory path.
+    assets : str | None
+        The assets file path, if any.
+    logs : str | None
+        The logs file path, if any.
+    statistics : str | None
+        The statistics file path, if any.
+    """
+    tracked_run = TrackedRun(
+        status=TrackedRunStatus(status),
+        duration=duration,
+        error=error_msg,
+        name=name,
+        description=description,
+    )
+    tracked_run = resolve_input(
+        tracked_run=tracked_run,
+        stdin=stdin,
+        input=input,
+        content_type=content_type,
+    )
+    tracked_run = resolve_output(
+        tracked_run=tracked_run,
+        output=output,
+        content_type=content_type,
+    )
+
+    # Handle the assets, which should be a JSON file.
+    if assets is not None and assets != "":
+        try:
+            with open(assets) as f:
+                tracked_run.assets = json.load(f)
+        except json.JSONDecodeError as e:
+            error(f"Failed to parse assets file [magenta]{assets}[/magenta] as [magenta]json[/magenta]: {e}.")
+
+    # Handle the logs, which should be a text file.
+    if logs is not None and logs != "":
+        try:
+            log_content = Path(logs).read_text()
+            tracked_run.logs = log_content
+        except Exception as e:
+            error(f"Failed to read logs file [magenta]{logs}[/magenta]: {e}.")
+
+    # Handle the statistics, which should be a JSON file.
+    if statistics is not None and statistics != "":
+        try:
+            with open(statistics) as f:
+                tracked_run.statistics = json.load(f)
+        except json.JSONDecodeError as e:
+            error(f"Failed to parse statistics file [magenta]{statistics}[/magenta] as [magenta]json[/magenta]: {e}.")
+
+    return tracked_run
+
+
+def resolve_input(
+    tracked_run: TrackedRun,
+    stdin: str | None,
+    input: str | None,
+    content_type: InputFormat,
+) -> TrackedRun:
+    """
+    Resolves the input for the tracked run, either from stdin or from a
+    file/directory.
+
+    Parameters
+    ----------
+    tracked_run : TrackedRun
+        The tracked run to set the input for.
+    stdin : str | None
+        The input provided via stdin, if any.
+    input : str | None
+        The input file or directory path, if any.
+    content_type : InputFormat
+        The content type of the input (json or text).
+
+    Returns
+    -------
+    TrackedRun
+        The tracked run with the resolved input.
+    """
+    if stdin is not None:
+        # Handle the case where stdin is provided as JSON for a JSON app.
+        try:
+            input_data = json.loads(stdin)
+            if content_type != InputFormat.JSON:
+                error(
+                    "Input provided via [magenta]stdin[/magenta] is [magenta]json[/magenta], "
+                    f"but the specified content type is {content_type.value}. "
+                    "[code]--content-type[/code] should be set to [magenta]json[/magenta]."
+                )
+
+        except json.JSONDecodeError:
+            input_data = stdin
+            if content_type != InputFormat.TEXT:
+                error(
+                    "Input provided via [magenta]stdin[/magenta] is [magenta]text[/magenta], "
+                    f"but the specified content type is {content_type.value}. "
+                    "[code]--content-type[/code] should be set to [magenta]text[/magenta]."
+                )
+
+        tracked_run.input = input_data
+
+        return tracked_run
+
+    # We know that input was defined because otherwise we would have failed
+    # early if both stdin and input were undefined.
+    input_path = Path(input)
+
+    if input_path.is_file():
+        if content_type == InputFormat.JSON:
+            try:
+                with input_path.open("r") as f:
+                    input_data = json.load(f)
+
+                tracked_run.input = input_data
+
+                return tracked_run
+
+            except json.JSONDecodeError as e:
+                error(f"Failed to parse input file [magenta]{input}[/magenta] as [magenta]json[/magenta]: {e}.")
+
+        elif content_type == InputFormat.TEXT:
+            input_data = input_path.read_text()
+            tracked_run.input = input_data
+
+            return tracked_run
+
+        else:
+            error(f"Unsupported content type [magenta]{content_type.value}[/magenta] for file input.")
+
+    # If the input is a directory, we give the path directly to the run method.
+    # Internally, the files will be tarred and uploaded.
+    if input_path.is_dir():
+        tracked_run.input_dir_path = input
+
+        return tracked_run
+
+    error(f"Input path [magenta]{input}[/magenta] does not exist.")
+
+
+def resolve_output(
+    tracked_run: TrackedRun,
+    output: str,
+    content_type: InputFormat,
+) -> TrackedRun:
+    """
+    Resolves the output for the tracked run.
+
+    Parameters
+    ----------
+    tracked_run : TrackedRun
+        The tracked run to set the output for.
+    output : str
+        The output file or directory path.
+    content_type : InputFormat
+        The content type of the output (json or text).
+
+    Returns
+    -------
+    TrackedRun
+        The tracked run with the resolved output.
+    """
+
+    output_path = Path(output)
+    if output_path.is_file():
+        if content_type == InputFormat.JSON:
+            try:
+                with output_path.open("r") as f:
+                    output_data = json.load(f)
+
+                tracked_run.output = output_data
+
+                return tracked_run
+
+            except json.JSONDecodeError as e:
+                error(f"Failed to parse output file [magenta]{output}[/magenta] as [magenta]json[/magenta]: {e}.")
+
+        elif content_type == InputFormat.TEXT:
+            output_data = output_path.read_text()
+            tracked_run.output = output_data
+
+            return tracked_run
+
+        else:
+            error(f"Unsupported content type [magenta]{content_type.value}[/magenta] for file output.")
+
+    # If the output is a directory, we give the path directly to the run method.
+    # Internally, the files will be downloaded and extracted.
+    if output_path.is_dir():
+        tracked_run.output_dir_path = output
+
+        return tracked_run
+
+    error(f"Output path [magenta]{output}[/magenta] does not exist.")

--- a/nextmv/nextmv/cli/configuration/create.py
+++ b/nextmv/nextmv/cli/configuration/create.py
@@ -60,7 +60,7 @@ def create(
     - Default configuration.
         $ [green]nextmv configuration create --api-key NEXTMV_API_KEY[/green]
 
-    - Configure a profile named [italic]hare[/italic].
+    - Configure a profile named [magenta]hare[/magenta].
         $ [green]nextmv configuration create --api-key NEXTMV_API_KEY --profile hare[/green]
     """
 

--- a/nextmv/nextmv/cli/main.py
+++ b/nextmv/nextmv/cli/main.py
@@ -87,7 +87,7 @@ def handle_go_cli() -> None:
         else:
             info(
                 msg="You can delete the [italic red]deprecated[/italic red] Nextmv CLI later by removing "
-                f"[italic]{GO_CLI_PATH}[/italic]. Make sure you also clean up your [code]PATH[/code].",
+                f"[magenta]{GO_CLI_PATH}[/magenta]. Make sure you also clean up your [code]PATH[/code].",
                 emoji=":bulb:",
             )
 
@@ -127,7 +127,7 @@ def go_cli_exists() -> bool:
     if exists:
         warning(
             "A [italic red]deprecated[/italic red] Nextmv CLI is installed at "
-            f"[italic]{GO_CLI_PATH}[/italic]. You must delete it to avoid conflicts."
+            f"[magenta]{GO_CLI_PATH}[/magenta]. You must delete it to avoid conflicts."
         )
 
     check_config_in_path()
@@ -157,6 +157,6 @@ def check_config_in_path() -> None:
 
     if config_dir_str in path_dirs:
         warning(
-            f"[italic]{CONFIG_DIR}[/italic] was found in your [code]PATH[/code]. "
-            f"You should remove any entries related to [italic]{CONFIG_DIR}[/italic] from your [code]PATH[/code]."
+            f"[magenta]{CONFIG_DIR}[/magenta] was found in your [code]PATH[/code]. "
+            f"You should remove any entries related to [magenta]{CONFIG_DIR}[/magenta] from your [code]PATH[/code]."
         )

--- a/nextmv/nextmv/cli/main.py
+++ b/nextmv/nextmv/cli/main.py
@@ -79,7 +79,7 @@ def handle_go_cli() -> None:
     if exists:
         delete = Confirm.ask(
             "Do you want to delete the [italic red]deprecated[/italic red] Nextmv CLI "
-            f"at [italic]{GO_CLI_PATH}[/italic] now?",
+            f"at [magenta]{GO_CLI_PATH}[/magenta] now?",
             default=True,
         )
         if delete:

--- a/nextmv/nextmv/cli/message.py
+++ b/nextmv/nextmv/cli/message.py
@@ -1,9 +1,10 @@
 """
 The message module is used to print messages to the user with pre-defined
-formatting. User messages are always printed to stderr.
+formatting. Logging, in general, is always printed to stderr.
 """
 
 import sys
+from typing import Any
 
 import rich
 import typer
@@ -91,3 +92,16 @@ def info(msg: str, emoji: str | None = None) -> None:
         return
 
     rich.print(msg, file=sys.stderr)
+
+
+def print_json(data: dict[str, Any]) -> None:
+    """
+    Pretty-print a dictionary as JSON to stdout.
+
+    Parameters
+    ----------
+    data : dict[str, Any]
+        The dictionary data to print as JSON.
+    """
+
+    rich.print_json(data=data)

--- a/nextmv/nextmv/cli/message.py
+++ b/nextmv/nextmv/cli/message.py
@@ -94,14 +94,14 @@ def info(msg: str, emoji: str | None = None) -> None:
     rich.print(msg, file=sys.stderr)
 
 
-def print_json(data: dict[str, Any]) -> None:
+def print_json(data: dict[str, Any] | list[dict[str, Any]]) -> None:
     """
-    Pretty-print a dictionary as JSON to stdout.
+    Pretty-print json-serializable data as JSON to stdout.
 
     Parameters
     ----------
-    data : dict[str, Any]
-        The dictionary data to print as JSON.
+    data : dict[str, Any] | list[dict[str, Any]]
+        The data to print as JSON.
     """
 
     rich.print_json(data=data)

--- a/nextmv/nextmv/cli/options.py
+++ b/nextmv/nextmv/cli/options.py
@@ -36,3 +36,17 @@ AppIDOption = Annotated[
         metavar="APP_ID",
     ),
 ]
+
+# run_id option - can be used in any command that requires a run ID.
+# Define it as follows in commands or callbacks, as necessary:
+# run_id: RunIDOption
+RunIDOption = Annotated[
+    str,
+    typer.Option(
+        "--run-id",
+        "-r",
+        help="The Nextmv Cloud run ID to use for this action.",
+        envvar="NEXTMV_RUN_ID",
+        metavar="RUN_ID",
+    ),
+]

--- a/nextmv/nextmv/cloud/application.py
+++ b/nextmv/nextmv/cloud/application.py
@@ -2674,8 +2674,8 @@ class Application:
         run_id : str
             ID of the run to retrieve the input for.
         output_dir_path : Optional[str], default="."
-            Path to a directory where non-JSON output files will be saved. This
-            is required if the output is non-JSON. If the directory does not
+            Path to a directory where non-JSON input files will be saved. This
+            is required if the input is non-JSON. If the directory does not
             exist, it will be created. Uses the current directory by default.
 
         Returns

--- a/nextmv/nextmv/cloud/application.py
+++ b/nextmv/nextmv/cloud/application.py
@@ -2659,24 +2659,31 @@ class Application:
                 file.write(download_response.content)
             return None
 
-    def run_input(self, run_id: str) -> dict[str, Any]:
+    def run_input(self, run_id: str, output_dir_path: str | None = ".") -> dict[str, Any] | None:
         """
         Get the input of a run.
 
         Retrieves the input data that was used for a specific run. This method
         handles both small and large inputs automatically - if the input size
         exceeds the maximum allowed size, it will fetch the input from a
-        download URL.
+        download URL. If the content format of the run is `csv-archive` or
+        `multi-file`, then the `output_dir_path` parameter must be specified.
 
         Parameters
         ----------
         run_id : str
             ID of the run to retrieve the input for.
+        output_dir_path : Optional[str], default="."
+            Path to a directory where non-JSON output files will be saved. This
+            is required if the output is non-JSON. If the directory does not
+            exist, it will be created. Uses the current directory by default.
 
         Returns
         -------
-        dict[str, Any]
-            Input data of the run as a dictionary.
+        dict[str, Any] | None
+            Input data of the run as a dictionary. If the input format is
+            non-JSON (e.g., csv-archive or multi-file), the method returns None
+            after saving the input files to the specified `output_dir_path`.
 
         Raises
         ------
@@ -2693,7 +2700,11 @@ class Application:
 
         query_params = None
         large = False
-        if run_information.metadata.input_size > _MAX_RUN_SIZE:
+        if (
+            run_information.metadata.input_size > _MAX_RUN_SIZE
+            or run_information.metadata.format.format_output.output_type
+            in {OutputFormat.CSV_ARCHIVE, OutputFormat.MULTI_FILE}
+        ):
             query_params = {"format": "url"}
             large = True
 
@@ -2712,6 +2723,26 @@ class Application:
             headers={"Content-Type": "application/json"},
         )
 
+        # See whether we can attach the output directly or need to save to the given
+        # directory
+        if run_information.metadata.format.format_output.output_type != OutputFormat.JSON:
+            if not output_dir_path or output_dir_path == "":
+                raise ValueError(
+                    "If the output format is not JSON, an output_dir_path must be provided.",
+                )
+            if not os.path.exists(output_dir_path):
+                os.makedirs(output_dir_path, exist_ok=True)
+
+            # Save .tar.gz file to a temp directory and extract contents to output_dir_path
+            with tempfile.TemporaryDirectory() as tmpdirname:
+                temp_tar_path = os.path.join(tmpdirname, f"{run_id}.tar.gz")
+                with open(temp_tar_path, "wb") as f:
+                    f.write(download_response.content)
+                shutil.unpack_archive(temp_tar_path, output_dir_path)
+
+            return
+
+        # JSON output can be returned directly.
         return download_response.json()
 
     def run_metadata(self, run_id: str) -> RunInformation:

--- a/nextmv/nextmv/cloud/application.py
+++ b/nextmv/nextmv/cloud/application.py
@@ -2725,10 +2725,10 @@ class Application:
 
         # See whether we can attach the output directly or need to save to the given
         # directory
-        if run_information.metadata.format.format_output.output_type != OutputFormat.JSON:
+        if run_information.metadata.format.format_input.input_type != OutputFormat.JSON:
             if not output_dir_path or output_dir_path == "":
                 raise ValueError(
-                    "If the output format is not JSON, an output_dir_path must be provided.",
+                    "If the input format is not JSON, an output_dir_path must be provided.",
                 )
             if not os.path.exists(output_dir_path):
                 os.makedirs(output_dir_path, exist_ok=True)

--- a/nextmv/nextmv/cloud/application.py
+++ b/nextmv/nextmv/cloud/application.py
@@ -2723,7 +2723,7 @@ class Application:
             headers={"Content-Type": "application/json"},
         )
 
-        # See whether we can attach the output directly or need to save to the given
+        # See whether we can return the input directly or need to save to the given
         # directory
         if run_information.metadata.format.format_output.output_type != OutputFormat.JSON:
             if not output_dir_path or output_dir_path == "":

--- a/nextmv/nextmv/cloud/application.py
+++ b/nextmv/nextmv/cloud/application.py
@@ -2742,7 +2742,7 @@ class Application:
 
             return
 
-        # JSON output can be returned directly.
+        # JSON input can be returned directly.
         return download_response.json()
 
     def run_metadata(self, run_id: str) -> RunInformation:

--- a/nextmv/nextmv/cloud/application.py
+++ b/nextmv/nextmv/cloud/application.py
@@ -2870,7 +2870,7 @@ class Application:
                     if rich_print:
                         rich.print(msg, file=sys.stderr)
                     else:
-                        print(msg)
+                        log(msg)
 
                 logs.append(log_entry)
 
@@ -2994,11 +2994,7 @@ class Application:
 
         def polling_func() -> tuple[Any, bool]:
             run_information = self.run_metadata(run_id=run_id)
-            if run_information.metadata.status_v2 in {
-                StatusV2.succeeded,
-                StatusV2.failed,
-                StatusV2.canceled,
-            }:
+            if run_information.metadata.run_is_finalized():
                 return run_information, True
 
             return None, False

--- a/nextmv/nextmv/cloud/application.py
+++ b/nextmv/nextmv/cloud/application.py
@@ -2702,8 +2702,8 @@ class Application:
         large = False
         if (
             run_information.metadata.input_size > _MAX_RUN_SIZE
-            or run_information.metadata.format.format_output.output_type
-            in {OutputFormat.CSV_ARCHIVE, OutputFormat.MULTI_FILE}
+            or run_information.metadata.format.format_input.input_type
+            in {InputFormat.CSV_ARCHIVE, InputFormat.MULTI_FILE}
         ):
             query_params = {"format": "url"}
             large = True

--- a/nextmv/nextmv/local/application.py
+++ b/nextmv/nextmv/local/application.py
@@ -699,11 +699,7 @@ class Application:
 
         def polling_func() -> tuple[Any, bool]:
             run_information = self.run_metadata(run_id=run_id)
-            if run_information.metadata.status_v2 in {
-                StatusV2.succeeded,
-                StatusV2.failed,
-                StatusV2.canceled,
-            }:
+            if run_information.metadata.run_is_finalized():
                 return run_information, True
 
             return None, False

--- a/nextmv/nextmv/run.py
+++ b/nextmv/nextmv/run.py
@@ -1449,8 +1449,8 @@ class TrackedRun:
     output : Output or dict[str, Any] or str, optional
         The output of the run being tracked. Please note that if the output
         format is JSON, then the output data must be JSON serializable. If both
-        `output` and `output_dir_path` are specified, the `output` is ignored, and
-        the files in the directory are used instead. Defaults to None.
+        `output` and `output_dir_path` are specified, the `output` is ignored,
+        and the files in the directory are used instead. Defaults to None.
     duration : int, optional
         The duration of the run being tracked, in milliseconds. This field is
         optional. Defaults to None.
@@ -1458,39 +1458,41 @@ class TrackedRun:
         An error message if the run failed. You should only specify this if the
         run failed (the `status` is `TrackedRunStatus.FAILED`), otherwise an
         exception will be raised. This field is optional. Defaults to None.
-    logs : list[str], optional
-        The logs of the run being tracked. Each element of the list is a line in
-        the log. This field is optional. Defaults to None.
+    logs : str or list[str], optional
+        The logs of the run being tracked. If the logs are provided as a list,
+        each element of the list is a line in the log. This field is optional.
+        Defaults to None.
     name : str, optional
         Optional name for the run being tracked. Defaults to None.
     description : str, optional
         Optional description for the run being tracked. Defaults to None.
     input_dir_path : str, optional
         Path to a directory containing input files. If specified, the calling
-        function will package the files in the directory into a tar file and upload
-        it as a large input. This is useful for non-JSON input formats, such as
-        when working with `CSV_ARCHIVE` or `MULTI_FILE`. If both `input` and
-        `input_dir_path` are specified, the `input` is ignored, and the files in
-        the directory are used instead. Defaults to None.
+        function will package the files in the directory into a tar file and
+        upload it as a large input. This is useful for non-JSON input formats,
+        such as when working with `CSV_ARCHIVE` or `MULTI_FILE`. If both
+        `input` and `input_dir_path` are specified, the `input` is ignored, and
+        the files in the directory are used instead. Defaults to None.
     output_dir_path : str, optional
         Path to a directory containing output files. If specified, the calling
-        function will package the files in the directory into a tar file and upload
-        it as a large output. This is useful for non-JSON output formats, such as
-        when working with `CSV_ARCHIVE` or `MULTI_FILE`. If both `output` and
-        `output_dir_path` are specified, the `output` is ignored, and the files
-        are saved in the directory instead. Defaults to None.
+        function will package the files in the directory into a tar file and
+        upload it as a large output. This is useful for non-JSON output
+        formats, such as when working with `CSV_ARCHIVE` or `MULTI_FILE`. If
+        both `output` and `output_dir_path` are specified, the `output` is
+        ignored, and the files are saved in the directory instead. Defaults to
+        None.
     statistics : Statistics or dict[str, Any], optional
         Statistics of the run being tracked. Only use this field if you want to
-        track statistics for `CSV_ARCHIVE` or `MULTI_FILE` output formats. If you
-        are working with `JSON` or `TEXT` output formats, this field will be
-        ignored, as the statistics are extracted directly from the `output`.
+        track statistics for `CSV_ARCHIVE` or `MULTI_FILE` output formats. If
+        you are working with `JSON` or `TEXT` output formats, this field will
+        be ignored, as the statistics are extracted directly from the `output`.
         This field is optional. Defaults to None.
     assets : list[Asset or dict[str, Any]], optional
-        Assets associated with the run being tracked. Only use this field if you
-        want to track assets for `CSV_ARCHIVE` or `MULTI_FILE` output formats.
-        If you are working with `JSON` or `TEXT` output formats, this field will
-        be ignored, as the assets are extracted directly from the `output`.
-        This field is optional. Defaults to None.
+        Assets associated with the run being tracked. Only use this field if
+        you want to track assets for `CSV_ARCHIVE` or `MULTI_FILE` output
+        formats. If you are working with `JSON` or `TEXT` output formats, this
+        field will be ignored, as the assets are extracted directly from the
+        `output`. This field is optional. Defaults to None.
 
     Examples
     --------
@@ -1536,8 +1538,8 @@ class TrackedRun:
     ------
     ValueError
         If the status value is invalid, if an error message is provided for a
-        successful run, or if input/output formats are not JSON or
-        input/output dicts are not JSON serializable.
+        successful run, or if input/output formats are not JSON or input/output
+        dicts are not JSON serializable.
     """
 
     status: TrackedRunStatus
@@ -1562,8 +1564,8 @@ class TrackedRun:
     error: str | None = None
     """An error message if the run failed. You should only specify this if the
     run failed, otherwise an exception will be raised."""
-    logs: list[str] | None = None
-    """The logs of the run being tracked. Each element of the list is a line in
+    logs: str | list[str] | None = None
+    """The logs of the run being tracked. If a list, each element is a line in
     the log."""
     name: str | None = None
     """

--- a/nextmv/nextmv/run.py
+++ b/nextmv/nextmv/run.py
@@ -687,6 +687,23 @@ class Metadata(BaseModel):
     statistics: dict[str, Any] | None = None
     """User defined statistics of the run."""
 
+    def run_is_finalized(self) -> bool:
+        """
+        Checks if the run has reached a finalized state.
+
+        Returns
+        -------
+        bool
+            True if the run status is one of `succeeded`, `failed`, or
+            `canceled`. False otherwise.
+        """
+
+        return self.status_v2 in {
+            StatusV2.succeeded,
+            StatusV2.failed,
+            StatusV2.canceled,
+        }
+
 
 class SyncedRun(BaseModel):
     """


### PR DESCRIPTION
# Description

Adds the following commands:

- `cancel`: cancels a run.
- `get`: gets the result (output) of a run.
- `input`: gets the input of a run.
- `list`: lists all runs belonging to an app.
- `logs`: gets or tails the logs of a run.
- `metadata`: gets the metadata of a run.
- `track` (new ✨): tracks an external run.

Adds style corrections here and there. Once the style corrections have somewhat stabilized, the contributor's guide will be redacted.

Sorry for the long PR 👼🏻 .