### PR TITLE
Adds the `nextmv cloud app` command tree

### DIFF
--- a/nextmv/nextmv/cli/cloud/__init__.py
+++ b/nextmv/nextmv/cli/cloud/__init__.py
@@ -4,10 +4,12 @@ This module defines the cloud command tree for the Nextmv CLI.
 
 import typer
 
+from nextmv.cli.cloud.app import app as app_app
 from nextmv.cli.cloud.run import app as run_app
 
 # Set up subcommand application.
 app = typer.Typer()
+app.add_typer(app_app, name="app")
 app.add_typer(run_app, name="run")
 
 

--- a/nextmv/nextmv/cli/cloud/app/__init__.py
+++ b/nextmv/nextmv/cli/cloud/app/__init__.py
@@ -1,0 +1,31 @@
+"""
+This module defines the cloud app command tree for the Nextmv CLI.
+"""
+
+import typer
+
+from nextmv.cli.cloud.app.create import app as create_app
+from nextmv.cli.cloud.app.delete import app as delete_app
+from nextmv.cli.cloud.app.exists import app as exists_app
+from nextmv.cli.cloud.app.get import app as get_app
+from nextmv.cli.cloud.app.list import app as list_app
+from nextmv.cli.cloud.app.push import app as push_app
+from nextmv.cli.cloud.app.update import app as update_app
+
+# Set up subcommand application.
+app = typer.Typer()
+app.add_typer(create_app)
+app.add_typer(delete_app)
+app.add_typer(exists_app)
+app.add_typer(get_app)
+app.add_typer(list_app)
+app.add_typer(push_app)
+app.add_typer(update_app)
+
+
+@app.callback()
+def callback() -> None:
+    """
+    Create, manage, and push Nextmv Cloud applications.
+    """
+    pass

--- a/nextmv/nextmv/cli/cloud/app/create.py
+++ b/nextmv/nextmv/cli/cloud/app/create.py
@@ -1,0 +1,145 @@
+"""
+This module defines the cloud app create command for the Nextmv CLI.
+"""
+
+from typing import Annotated
+
+import typer
+
+from nextmv.cli.configuration.config import build_client
+from nextmv.cli.message import info, print_json
+from nextmv.cli.options import ProfileOption
+from nextmv.cloud.application import Application
+
+# Set up subcommand application.
+app = typer.Typer()
+
+
+@app.command()
+def create(
+    name: Annotated[
+        str,
+        typer.Option(
+            "--name",
+            "-n",
+            help="A name for the application.",
+            metavar="NAME",
+        ),
+    ],
+    app_id: Annotated[
+        str | None,
+        typer.Option(
+            "--app-id",
+            "-a",
+            help="An optional ID for the Nextmv Cloud application. If not provided, a random ID will be generated.",
+            envvar="NEXTMV_APP_ID",
+            metavar="APP_ID",
+        ),
+    ] = None,
+    default_instance_id: Annotated[
+        str | None,
+        typer.Option(
+            "--default-instance-id",
+            "-i",
+            help="An optional default instance ID for the application.",
+            metavar="DEFAULT_INSTANCE_ID",
+        ),
+    ] = None,
+    default_experiment_instance: Annotated[
+        str | None,
+        typer.Option(
+            "--default-experiment-instance",
+            "-x",
+            help="An optional default experiment instance ID for the application.",
+            metavar="DEFAULT_EXPERIMENT_INSTANCE",
+        ),
+    ] = None,
+    description: Annotated[
+        str | None,
+        typer.Option(
+            "--description",
+            "-d",
+            help="An optional description for the application.",
+            metavar="DESCRIPTION",
+        ),
+    ] = None,
+    exist_ok: Annotated[
+        bool,
+        typer.Option(
+            "--exist-ok",
+            "-e",
+            help="If an application with the given ID already exists, do not raise an error, and simply return it.",
+        ),
+    ] = False,
+    is_workflow: Annotated[
+        bool,
+        typer.Option(
+            "--is-workflow",
+            "-w",
+            help="Whether the application is a workflow.",
+        ),
+    ] = False,
+    profile: ProfileOption = None,
+) -> None:
+    """
+    Create a new Nextmv Cloud application.
+
+    A Nextmv application is an entity that contains a decision model as
+    executable code. An application can make a run by taking an input,
+    executing the decision model, and producing an output.
+
+    Use the [code]--exist-ok[/code] flag to avoid errors when creating an
+    application with an ID that already exists. This is useful for scripts that
+    need to ensure an application exists without worrying about whether it was
+    created previously.
+
+    An application can be marked as a workflow using the
+    [code]--is-workflow[/code] flag. Workflows allow for more complex
+    decision-making processes by leveraging
+    [link=https://github.com/nextmv-io/nextpipe][bold]Nextpipe[/bold][/link] to
+    orchestrate multiple decision models.
+
+    [bold][underline]Examples[/underline][/bold]
+
+    - Create an application with the name [magenta]Hare App[/magenta]. A random ID will be generated.
+        $ [green]nextmv cloud app create --name "Hare App"[/green]
+
+    - Create an application with the specific ID [magenta]hare-app[/magenta].
+        $ [green]nextmv cloud app create --name "Hare App" --app-id hare-app[/green]
+
+    - Create an application with an ID and description.
+        $ [green]nextmv cloud app create --name "Hare App" --app-id hare-app \\
+            --description "An application for routing hares"[/green]
+
+    - Create an application, or get it if it already exists.
+        $ [green]nextmv cloud app create --name "Hare App" --app-id hare-app --exist-ok[/green]
+
+    - Create a workflow application.
+        $ [green]nextmv cloud app create --name "Hare Workflow" --app-id hare-workflow --is-workflow[/green]
+
+    - Create an application with a default instance ID.
+        $ [green]nextmv cloud app create --name "Hare App" --app-id hare-app \\
+            --default-instance-id burrow[/green]
+
+    - Create an application with a default experiment instance.
+        $ [green]nextmv cloud app create --name "Hare App" --app-id hare-app \\
+            --default-experiment-instance experiment-v1[/green]
+    """
+
+    client = build_client(profile)
+    if exist_ok:
+        info(msg="Creating or getting application...", emoji=":hourglass_flowing_sand:")
+    else:
+        info(msg="Creating application...", emoji=":hourglass_flowing_sand:")
+
+    cloud_app = Application.new(
+        client=client,
+        name=name,
+        id=app_id,
+        description=description,
+        is_workflow=is_workflow,
+        exist_ok=exist_ok,
+        default_instance_id=default_instance_id,
+        default_experiment_instance=default_experiment_instance,
+    )
+    print_json(cloud_app.to_dict())

--- a/nextmv/nextmv/cli/cloud/app/delete.py
+++ b/nextmv/nextmv/cli/cloud/app/delete.py
@@ -40,7 +40,7 @@ def delete(
         $ [green]nextmv cloud app delete --app-id hare-app[/green]
 
     - Delete the application with the ID [magenta]hare-app[/magenta] without confirmation prompt.
-        $ [green]nextmv cloud app delete --app-id hare-app --yes[/green
+        $ [green]nextmv cloud app delete --app-id hare-app --yes[/green]
     """
 
     if not yes:

--- a/nextmv/nextmv/cli/cloud/app/delete.py
+++ b/nextmv/nextmv/cli/cloud/app/delete.py
@@ -1,0 +1,58 @@
+"""
+This module defines the cloud app delete command for the Nextmv CLI.
+"""
+
+from typing import Annotated
+
+import typer
+from rich.prompt import Confirm
+
+from nextmv.cli.configuration.config import build_app
+from nextmv.cli.message import info, success
+from nextmv.cli.options import AppIDOption, ProfileOption
+
+# Set up subcommand application.
+app = typer.Typer()
+
+
+@app.command()
+def delete(
+    app_id: AppIDOption,
+    yes: Annotated[
+        bool,
+        typer.Option(
+            "--yes",
+            "-y",
+            help="Agree to deletion confirmation prompt. Useful for non-interactive sessions.",
+        ),
+    ] = False,
+    profile: ProfileOption = None,
+) -> None:
+    """
+    Deletes a Nextmv Cloud application.
+
+    This action is permanent and cannot be undone. Use the [code]--yes[/code]
+    flag to skip the confirmation prompt.
+
+    [bold][underline]Examples[/underline][/bold]
+
+    - Delete the application with the ID [magenta]hare-app[/magenta].
+        $ [green]nextmv cloud app delete --app-id hare-app[/green]
+
+    - Delete the application with the ID [magenta]hare-app[/magenta] without confirmation prompt.
+        $ [green]nextmv cloud app delete --app-id hare-app --yes[/green
+    """
+
+    if not yes:
+        confirm = Confirm.ask(
+            f"Are you sure you want to delete application [magenta]{app_id}[/magenta]? This action cannot be undone",
+            default=False,
+        )
+
+        if not confirm:
+            info(msg=f"Application [magenta]{app_id}[/magenta] will not be deleted.", emoji=":bulb:")
+            return
+
+    cloud_app = build_app(app_id=app_id, profile=profile)
+    cloud_app.delete()
+    success(f"Application [magenta]{app_id}[/magenta] deleted successfully.")

--- a/nextmv/nextmv/cli/cloud/app/exists.py
+++ b/nextmv/nextmv/cli/cloud/app/exists.py
@@ -1,0 +1,44 @@
+"""
+This module defines the cloud app exists command for the Nextmv CLI.
+"""
+
+import typer
+
+from nextmv.cli.configuration.config import build_client
+from nextmv.cli.message import info, print_json
+from nextmv.cli.options import AppIDOption, ProfileOption
+from nextmv.cloud.application import Application
+
+# Set up subcommand application.
+app = typer.Typer()
+
+
+@app.command()
+def exists(
+    app_id: AppIDOption,
+    profile: ProfileOption = None,
+) -> None:
+    """
+    Check if a Nextmv Cloud application exists.
+
+    This command is useful in scripting applications to verify the existence of
+    a Nextmv Cloud application by its ID.
+
+    [bold][underline]Examples[/underline][/bold]
+
+    - Check if the application with the ID [magenta]hare-app[/magenta] exists.
+        $ [green]nextmv cloud app exists --app-id hare-app[/green]
+
+    - Check if the application with the ID [magenta]hare-app[/magenta] exists.
+      Use the profile named [magenta]hare[/magenta].
+        $ [green]nextmv cloud app exists --app-id hare-app --profile hare[/green]
+    """
+
+    client = build_client(profile)
+    info(msg="Checking if application exists...", emoji=":hourglass_flowing_sand:")
+
+    ok = Application.exists(
+        client=client,
+        id=app_id,
+    )
+    print_json({"exists": ok})

--- a/nextmv/nextmv/cli/cloud/app/get.py
+++ b/nextmv/nextmv/cli/cloud/app/get.py
@@ -1,0 +1,66 @@
+"""
+This module defines the cloud app get command for the Nextmv CLI.
+"""
+
+import json
+from typing import Annotated
+
+import typer
+
+from nextmv.cli.configuration.config import build_client
+from nextmv.cli.message import info, print_json, success
+from nextmv.cli.options import AppIDOption, ProfileOption
+from nextmv.cloud.application import Application
+
+# Set up subcommand application.
+app = typer.Typer()
+
+
+@app.command()
+def get(
+    app_id: AppIDOption,
+    output: Annotated[
+        str | None,
+        typer.Option(
+            "--output",
+            "-o",
+            help="Saves the app information to this location.",
+            metavar="OUTPUT_PATH",
+        ),
+    ] = None,
+    profile: ProfileOption = None,
+) -> None:
+    """
+    Get a Nextmv Cloud application.
+
+    This command is useful to get the attributes of an existing Nextmv Cloud
+    application by its ID.
+
+    [bold][underline]Examples[/underline][/bold]
+
+    - Get the application with the ID [magenta]hare-app[/magenta].
+        $ [green]nextmv cloud app get --app-id hare-app[/green]
+
+    - Get the application with the ID [magenta]hare-app[/magenta] and save the information to an
+      [magenta]app.json[/magenta] file.
+        $ [green]nextmv cloud app get --app-id hare-app --output app.json
+    """
+
+    client = build_client(profile)
+    info(msg="Getting application...", emoji=":hourglass_flowing_sand:")
+
+    cloud_app = Application.get(
+        client=client,
+        id=app_id,
+    )
+    cloud_app_dict = cloud_app.to_dict()
+
+    if output is not None:
+        with open(output, "w") as f:
+            json.dump(cloud_app_dict, f, indent=2)
+
+        success(msg=f"Application information saved to [magenta]{output}[/magenta].")
+
+        return
+
+    print_json(cloud_app_dict)

--- a/nextmv/nextmv/cli/cloud/app/get.py
+++ b/nextmv/nextmv/cli/cloud/app/get.py
@@ -43,7 +43,7 @@ def get(
 
     - Get the application with the ID [magenta]hare-app[/magenta] and save the information to an
       [magenta]app.json[/magenta] file.
-        $ [green]nextmv cloud app get --app-id hare-app --output app.json
+        $ [green]nextmv cloud app get --app-id hare-app --output app.json[/green]
     """
 
     client = build_client(profile)

--- a/nextmv/nextmv/cli/cloud/app/list.py
+++ b/nextmv/nextmv/cli/cloud/app/list.py
@@ -1,0 +1,61 @@
+"""
+This module defines the cloud app list command for the Nextmv CLI.
+"""
+
+import json
+from typing import Annotated
+
+import typer
+
+from nextmv.cli.configuration.config import build_client
+from nextmv.cli.message import info, print_json, success
+from nextmv.cli.options import ProfileOption
+from nextmv.cloud.application import list_applications
+
+# Set up subcommand application.
+app = typer.Typer()
+
+
+@app.command()
+def list(
+    output: Annotated[
+        str | None,
+        typer.Option(
+            "--output",
+            "-o",
+            help="Saves the app list information to this location.",
+            metavar="OUTPUT_PATH",
+        ),
+    ] = None,
+    profile: ProfileOption = None,
+) -> None:
+    """
+    List all Nextmv Cloud applications.
+
+    [bold][underline]Examples[/underline][/bold]
+
+    - List all applications.
+        $ [green]nextmv cloud app list[/green]
+
+    - List all applications using the profile named [magenta]hare[/magenta].
+        $ [green]nextmv cloud app list --profile hare[/green]
+
+    - List all applications and save the information to an [magenta]apps.json[/magenta] file.
+        $ [green]nextmv cloud app list --output apps.json[/green]
+    """
+
+    client = build_client(profile)
+    info(msg="Listing applications...", emoji=":hourglass_flowing_sand:")
+
+    cloud_apps = list_applications(client)
+    cloud_apps_dicts = [app.to_dict() for app in cloud_apps]
+
+    if output is not None:
+        with open(output, "w") as f:
+            json.dump(cloud_apps_dicts, f, indent=2)
+
+        success(msg=f"Application list information saved to [magenta]{output}[/magenta].")
+
+        return
+
+    print_json(cloud_apps_dicts)

--- a/nextmv/nextmv/cli/cloud/app/push.py
+++ b/nextmv/nextmv/cli/cloud/app/push.py
@@ -1,0 +1,75 @@
+"""
+This module defines the cloud app push command for the Nextmv CLI.
+"""
+
+from typing import Annotated
+
+import typer
+
+from nextmv.cli.configuration.config import build_app
+from nextmv.cli.options import AppIDOption, ProfileOption
+from nextmv.manifest import Manifest
+
+# Set up subcommand application.
+app = typer.Typer()
+
+
+@app.command()
+def push(
+    app_id: AppIDOption,
+    app_dir: Annotated[
+        str | None,
+        typer.Option(
+            "--app-dir",
+            "-d",
+            help="The path to the application's root directory.",
+            metavar="APP_DIR",
+        ),
+    ] = ".",
+    manifest: Annotated[
+        str | None,
+        typer.Option(
+            "--manifest",
+            "-m",
+            help="Path to the application manifest file ([magenta]app.yaml[/magenta]).",
+            metavar="MANIFEST_PATH",
+        ),
+    ] = None,
+    profile: ProfileOption = None,
+) -> None:
+    """
+    Push (deploy) a Nextmv application to Nextmv Cloud.
+
+    Use the [code]--app-dir[/code] option to specify the path to your
+    application's root directory. By default, the current working directory is
+    used.
+
+    You can also provide a custom manifest file using the [code]--manifest[/code]
+    option. If not provided, the CLI will look for a file named [magenta]app.yaml[/magenta]
+    in the application's root.
+
+    [bold][underline]Examples[/underline][/bold]
+
+    - Push an application, with ID [magenta]hare-app[/magenta], from the current directory.
+        $ [green]nextmv cloud app push --app-id hare-app[/green]
+
+    - Push an application, with ID [magenta]hare-app[/magenta], from the [magenta]./my-app[/magenta] directory.
+        $ [green]nextmv cloud app push --app-id hare-app --app-dir ./my-app[/green]
+
+    - Push an application, with ID [magenta]hare-app[/magenta], using a custom manifest file.
+        $ [green]nextmv cloud app push --app-id hare-app --manifest ./custom-manifest.yaml[/green]
+
+    - Push an application, with ID [magenta]hare-app[/magenta], from a specific
+      [magenta]./my-app[/magenta] directory with a custom manifest under [magenta]./custom-manifest.yaml[/magenta].
+        $ [green]nextmv cloud app push --app-id hare-app --app-dir ./my-app \\
+            --manifest ./custom-manifest.yaml[/green]
+    """
+
+    cloud_app = build_app(app_id=app_id, profile=profile)
+    loaded_manifest = Manifest.from_yaml(dirpath=manifest) if manifest is not None and manifest != "" else None
+    cloud_app.push(
+        manifest=loaded_manifest,
+        app_dir=app_dir,
+        verbose=True,
+        rich_print=True,
+    )

--- a/nextmv/nextmv/cli/cloud/app/update.py
+++ b/nextmv/nextmv/cli/cloud/app/update.py
@@ -1,0 +1,124 @@
+"""
+This module defines the cloud app update command for the Nextmv CLI.
+"""
+
+import json
+from typing import Annotated
+
+import typer
+
+from nextmv.cli.configuration.config import build_app
+from nextmv.cli.message import error, print_json, success
+from nextmv.cli.options import AppIDOption, ProfileOption
+
+# Set up subcommand application.
+app = typer.Typer()
+
+
+@app.command()
+def update(
+    app_id: AppIDOption,
+    name: Annotated[
+        str | None,
+        typer.Option(
+            "--name",
+            "-n",
+            help="A new name for the application.",
+            metavar="NAME",
+        ),
+    ] = None,
+    default_instance_id: Annotated[
+        str | None,
+        typer.Option(
+            "--default-instance-id",
+            "-i",
+            help="A new default instance ID for the application.",
+            metavar="DEFAULT_INSTANCE_ID",
+        ),
+    ] = None,
+    default_experiment_instance: Annotated[
+        str | None,
+        typer.Option(
+            "--default-experiment-instance",
+            "-x",
+            help="A new default experiment instance ID for the application.",
+            metavar="DEFAULT_EXPERIMENT_INSTANCE",
+        ),
+    ] = None,
+    description: Annotated[
+        str | None,
+        typer.Option(
+            "--description",
+            "-d",
+            help="A new description for the application.",
+            metavar="DESCRIPTION",
+        ),
+    ] = None,
+    output: Annotated[
+        str | None,
+        typer.Option(
+            "--output",
+            "-o",
+            help="Saves the updated app information to this location.",
+            metavar="OUTPUT_PATH",
+        ),
+    ] = None,
+    profile: ProfileOption = None,
+) -> None:
+    """
+    Updates a Nextmv Cloud application.
+
+    Please note that you cannot change the type of an application, you must
+    create a new one.
+
+    [bold][underline]Examples[/underline][/bold]
+
+    - Update an application's name.
+        $ [green]nextmv cloud app update --app-id hare-app --name "New Hare App"[/green]
+
+    - Update an application's description.
+        $ [green]nextmv cloud app update --app-id hare-app --name "Hare App" \\
+            --description "An updated description for routing hares"[/green]
+
+    - Update an application's default instance ID.
+        $ [green]nextmv cloud app update --app-id hare-app --name "Hare App" \\
+            --default-instance-id burrow[/green]
+
+    - Update an application's default experiment instance.
+        $ [green]nextmv cloud app update --app-id hare-app --name "Hare App" \\
+            --default-experiment-instance experiment-v1[/green]
+
+    - Update multiple application properties at once.
+        $ [green]nextmv cloud app update --app-id hare-app --name "Hare App" \\
+            --description "Updated description" --default-instance-id burrow \\
+            --default-experiment-instance experiment-v1[/green]
+
+    - Update an application and save the updated information to an [magenta]updated_app.json[/magenta] file.
+        $ [green]nextmv cloud app update --app-id hare-app --name "New Hare App" --output updated_app.json[/green]
+    """
+
+    if name is None and description is None and default_instance_id is None and default_experiment_instance is None:
+        error(
+            "Provide at lease one option to update: [code]--name[/code], [code]--description[/code], "
+            "[code]--default-instance-id[/code], or [code]--default-experiment-instance[/code]."
+        )
+
+    cloud_app = build_app(app_id=app_id, profile=profile)
+    updated_app = cloud_app.update(
+        name=name,
+        description=description,
+        default_instance_id=default_instance_id,
+        default_experiment_instance=default_experiment_instance,
+    )
+    success(f"Application [magenta]{app_id}[/magenta] updated successfully.")
+    updated_app_dict = updated_app.to_dict()
+
+    if output is not None:
+        with open(output, "w") as f:
+            json.dump(updated_app_dict, f, indent=2)
+
+        success(msg=f"Udpated application information saved to [magenta]{output}[/magenta].")
+
+        return
+
+    print_json(updated_app_dict)

--- a/nextmv/nextmv/cli/cloud/app/update.py
+++ b/nextmv/nextmv/cli/cloud/app/update.py
@@ -99,7 +99,7 @@ def update(
 
     if name is None and description is None and default_instance_id is None and default_experiment_instance is None:
         error(
-            "Provide at lease one option to update: [code]--name[/code], [code]--description[/code], "
+            "Provide at least one option to update: [code]--name[/code], [code]--description[/code], "
             "[code]--default-instance-id[/code], or [code]--default-experiment-instance[/code]."
         )
 

--- a/nextmv/nextmv/cli/cloud/app/update.py
+++ b/nextmv/nextmv/cli/cloud/app/update.py
@@ -117,7 +117,7 @@ def update(
         with open(output, "w") as f:
             json.dump(updated_app_dict, f, indent=2)
 
-        success(msg=f"Udpated application information saved to [magenta]{output}[/magenta].")
+        success(msg=f"Updated application information saved to [magenta]{output}[/magenta].")
 
         return
 

--- a/nextmv/nextmv/cli/cloud/run/cancel.py
+++ b/nextmv/nextmv/cli/cloud/run/cancel.py
@@ -5,7 +5,7 @@ This module defines the cloud run cancel command for the Nextmv CLI.
 import typer
 
 from nextmv.cli.configuration.config import build_app
-from nextmv.cli.message import success
+from nextmv.cli.message import info, success
 from nextmv.cli.options import AppIDOption, ProfileOption, RunIDOption
 
 # Set up subcommand application.
@@ -31,6 +31,7 @@ def cancel(
         $ [green]nextmv cloud run cancel --app-id hare-app --run-id burrow-123 --profile hare[/green]
     """
 
-    cloud_app = build_app(app_id, profile)
+    cloud_app = build_app(app_id=app_id, profile=profile)
+    info(msg=f"Canceling run [magenta]{run_id}[/magenta]...", emoji=":hourglass_flowing_sand:")
     cloud_app.cancel_run(run_id)
     success(f"Run [magenta]{run_id}[/magenta] canceled.")

--- a/nextmv/nextmv/cli/cloud/run/create.py
+++ b/nextmv/nextmv/cli/cloud/run/create.py
@@ -293,7 +293,7 @@ def create(
         error("Input data must be provided via the [code]--input[/code] flag or [magenta]stdin[/magenta].")
 
     # Instantiate the basic requirements to start a new run.
-    cloud_app = build_app(app_id, profile)
+    cloud_app = build_app(app_id=app_id, profile=profile)
     config = build_run_config(
         run_type=run_type,
         priority=priority,

--- a/nextmv/nextmv/cli/cloud/run/get.py
+++ b/nextmv/nextmv/cli/cloud/run/get.py
@@ -84,7 +84,7 @@ def get(
         $ [green]nextmv cloud run get --app-id hare-app --run-id burrow-123 --profile hare[/green]
     """
 
-    cloud_app = build_app(app_id, profile)
+    cloud_app = build_app(app_id=app_id, profile=profile)
 
     # Build the polling options.
     polling_options = DEFAULT_POLLING_OPTIONS

--- a/nextmv/nextmv/cli/cloud/run/input.py
+++ b/nextmv/nextmv/cli/cloud/run/input.py
@@ -52,7 +52,7 @@ def input(
         $ [green]nextmv cloud run input --app-id hare-app --run-id burrow-123 --profile hare[/green]
     """
 
-    cloud_app = build_app(app_id, profile)
+    cloud_app = build_app(app_id=app_id, profile=profile)
     info(msg="Getting run input...", emoji=":hourglass_flowing_sand:")
 
     # First get the content type to check what we should do with the input,

--- a/nextmv/nextmv/cli/cloud/run/list.py
+++ b/nextmv/nextmv/cli/cloud/run/list.py
@@ -49,8 +49,8 @@ def list(
         $ [green]nextmv cloud run list --app-id hare-app --profile hare[/green]
     """
 
-    cloud_app = build_app(app_id, profile)
-    info(msg="Getting app runs...", emoji=":hourglass_flowing_sand:")
+    cloud_app = build_app(app_id=app_id, profile=profile)
+    info(msg="Listing app runs...", emoji=":hourglass_flowing_sand:")
     runs = cloud_app.list_runs()
     runs_dicts = [run.to_dict() for run in runs]
 

--- a/nextmv/nextmv/cli/cloud/run/logs.py
+++ b/nextmv/nextmv/cli/cloud/run/logs.py
@@ -82,7 +82,7 @@ def logs(
         $ [green]nextmv cloud run logs --app-id hare-app --run-id burrow-123 --profile hare[/green]
     """
 
-    cloud_app = build_app(app_id, profile)
+    cloud_app = build_app(app_id=app_id, profile=profile)
 
     # Build the polling options.
     polling_options = DEFAULT_POLLING_OPTIONS

--- a/nextmv/nextmv/cli/cloud/run/metadata.py
+++ b/nextmv/nextmv/cli/cloud/run/metadata.py
@@ -51,7 +51,7 @@ def metadata(
         $ [green]nextmv cloud run metadata --app-id hare-app --run-id burrow-123 --profile hare[/green]
     """
 
-    cloud_app = build_app(app_id, profile)
+    cloud_app = build_app(app_id=app_id, profile=profile)
     info(msg="Getting run metadata...", emoji=":hourglass_flowing_sand:")
     run_info = cloud_app.run_metadata(run_id)
     info_dict = run_info.to_dict()

--- a/nextmv/nextmv/cli/cloud/run/track.py
+++ b/nextmv/nextmv/cli/cloud/run/track.py
@@ -11,7 +11,7 @@ import typer
 
 from nextmv.cli.cloud.run.create import build_run_config
 from nextmv.cli.configuration.config import build_app
-from nextmv.cli.message import error, print_json
+from nextmv.cli.message import error, info, print_json
 from nextmv.cli.options import AppIDOption, ProfileOption
 from nextmv.input import InputFormat
 from nextmv.run import RunType, TrackedRun, TrackedRunStatus
@@ -228,7 +228,7 @@ def track(
         error("Input data must be provided via the [code]--input[/code] flag or [magenta]stdin[/magenta].")
 
     # Instantiate the basic requirements to start a new run.
-    cloud_app = build_app(app_id, profile)
+    cloud_app = build_app(app_id=app_id, profile=profile)
     config = build_run_config(
         run_type=RunType.EXTERNAL,
         priority=6,
@@ -257,6 +257,7 @@ def track(
     )
 
     # Actually track the run.
+    info(msg="Tracking run...", emoji=":hourglass_flowing_sand:")
     run_id = cloud_app.track_run(
         tracked_run=tracked_run,
         instance_id=instance_id,

--- a/nextmv/nextmv/cli/configuration/delete.py
+++ b/nextmv/nextmv/cli/configuration/delete.py
@@ -26,27 +26,40 @@ def delete(
             metavar="PROFILE_NAME",
         ),
     ],
+    yes: Annotated[
+        bool,
+        typer.Option(
+            "--yes",
+            "-y",
+            help="Agree to deletion confirmation prompt. Useful for non-interactive sessions.",
+        ),
+    ] = False,
 ) -> None:
     """
-    Delete a profile from the configuration.
+    Delete a profile from the configuration. Use the [code]--yes[/code]
+    flag to skip the confirmation prompt.
 
     [bold][underline]Examples[/underline][/bold]
 
     - Delete a profile named [magenta]hare[/magenta].
         $ [green]nextmv configuration delete --profile hare[/green]
+
+    - Delete a profile named [magenta]hare[/magenta] without confirmation prompt.
+        $ [green]nextmv configuration delete --profile hare --yes[/green]
     """
     config = load_config()
     if profile not in config:
         error(f"Profile [magenta]{profile}[/magenta] does not exist.")
 
-    confirm = Confirm.ask(
-        f"Are you sure you want to delete profile [magenta]{profile}[/magenta]? This action cannot be undone",
-        default=False,
-    )
+    if not yes:
+        confirm = Confirm.ask(
+            f"Are you sure you want to delete profile [magenta]{profile}[/magenta]? This action cannot be undone",
+            default=False,
+        )
 
-    if not confirm:
-        info(msg=f"Profile [magenta]{profile}[/magenta] will not be deleted.", emoji=":bulb:")
-        return
+        if not confirm:
+            info(msg=f"Profile [magenta]{profile}[/magenta] will not be deleted.", emoji=":bulb:")
+            return
 
     del config[profile]
     save_config(config)

--- a/nextmv/nextmv/cli/main.py
+++ b/nextmv/nextmv/cli/main.py
@@ -35,6 +35,7 @@ app = typer.Typer(
     context_settings={"help_option_names": ["--help", "-h"]},
     no_args_is_help=True,
     invoke_without_command=True,
+    pretty_exceptions_show_locals=False,
 )
 
 # Register subcommands. The `name` parameter is required when the subcommand

--- a/nextmv/nextmv/cli/version.py
+++ b/nextmv/nextmv/cli/version.py
@@ -14,6 +14,11 @@ app = typer.Typer()
 def version() -> None:
     """
     Show the current version of the Nextmv CLI.
+
+    [bold][underline]Examples[/underline][/bold]
+
+    - Show the version.
+        $ [green]nextmv version[/green]
     """
 
     version_callback(True)

--- a/nextmv/nextmv/cloud/__init__.py
+++ b/nextmv/nextmv/cloud/__init__.py
@@ -15,6 +15,7 @@ from nextmv.manifest import ManifestPythonModel as ManifestPythonModel
 from nextmv.manifest import ManifestRuntime as ManifestRuntime
 from nextmv.manifest import ManifestType as ManifestType
 from nextmv.polling import PollingOptions as PollingOptions
+from nextmv.polling import poll as poll
 from nextmv.run import ErrorLog as ErrorLog
 from nextmv.run import ExternalRunResult as ExternalRunResult
 from nextmv.run import Format as Format
@@ -56,7 +57,8 @@ from .account import Account as Account
 from .account import Queue as Queue
 from .account import QueuedRun as QueuedRun
 from .application import Application as Application
-from .application import poll as poll
+from .application import ApplicationType as ApplicationType
+from .application import list_applications as list_applications
 from .assets import RunAsset as RunAsset
 from .batch_experiment import BatchExperiment as BatchExperiment
 from .batch_experiment import BatchExperimentInformation as BatchExperimentInformation

--- a/nextmv/nextmv/cloud/application.py
+++ b/nextmv/nextmv/cloud/application.py
@@ -3535,7 +3535,7 @@ class Application(BaseModel):
         if description is not None:
             payload["description"] = description
         if default_instance_id is not None:
-            payload["default_instance_id"] = default_instance_id
+            payload["default_instance"] = default_instance_id
         if default_experiment_instance is not None:
             payload["default_experiment_instance"] = default_experiment_instance
 

--- a/nextmv/nextmv/cloud/application.py
+++ b/nextmv/nextmv/cloud/application.py
@@ -7,19 +7,15 @@ and inputs.
 
 Classes
 -------
-DownloadURL
-    Result of getting a download URL.
-PollingOptions
-    Options for polling when waiting for run results.
-UploadURL
-    Result of getting an upload URL.
+ApplicationType
+    Enumeration of application types in Nextmv Cloud.
 Application
     Class for interacting with applications in Nextmv Cloud.
 
 Functions
 ---------
-poll
-    Function to poll for results with configurable options.
+list_application
+    Function to list applications in Nextmv Cloud.
 """
 
 import io
@@ -30,12 +26,13 @@ import shutil
 import sys
 import tarfile
 import tempfile
-from dataclasses import dataclass
 from datetime import datetime
+from enum import Enum
 from typing import Any
 
 import requests
 import rich
+from pydantic import AliasChoices, Field
 
 from nextmv._serialization import deflated_serialize_json
 from nextmv.base_model import BaseModel
@@ -88,8 +85,45 @@ from nextmv.status import StatusV2
 _MAX_RUN_SIZE: int = 5 * 1024 * 1024
 
 
-@dataclass
-class Application:
+class ApplicationType(str, Enum):
+    """
+    Enumeration of application types in Nextmv Cloud.
+
+    You can import the `ApplicationType` class directly from `cloud`:
+
+    ```python
+    from nextmv.cloud import ApplicationType
+    ```
+
+    Attributes
+    ----------
+    CUSTOM : str
+        Custom application type, which is the most common. Represents a standard
+        application that you can push code to.
+    SUBSCRIPTION : str
+        Subscription application type. You cannot push code to subscription
+        applications, but only subscribe to them through the marketplace.
+    PIPELINE : str
+        Pipeline application type that refers to workflows.
+    """
+
+    CUSTOM = "custom"
+    """
+    Custom application type, which is the most common. Represents a standard
+    application that you can push code to.
+    """
+    SUBSCRIPTION = "subscription"
+    """
+    Subscription application type. You cannot push code to subscription
+    applications, but only subscribe to them through the marketplace.
+    """
+    PIPELINE = "pipeline"
+    """
+    Pipeline application type that refers to workflows.
+    """
+
+
+class Application(BaseModel):
     """
     A published decision model that can be executed.
 
@@ -125,21 +159,44 @@ class Application:
     >>> instances = app.list_instances()
     """
 
-    client: Client
-    """Client to use for interacting with the Nextmv Cloud API."""
+    # Actual API attributes of an application.
     id: str
     """ID of the application."""
-
-    default_instance_id: str = None
+    name: str | None = None
+    """Name of the application."""
+    description: str | None = None
+    """Description of the application."""
+    type: ApplicationType | None = None
+    """Type of the application."""
+    default_instance_id: str | None = Field(
+        serialization_alias="default_instance",
+        validation_alias=AliasChoices("default_instance", "default_instance_id"),
+        default=None,
+    )
     """Default instance ID to use for submitting runs."""
-    endpoint: str = "v1/applications/{id}"
-    """Base endpoint for the application."""
-    experiments_endpoint: str = "{base}/experiments"
-    """Base endpoint for the experiments in the application."""
-    ensembles_endpoint: str = "{base}/ensembles"
-    """Base endpoint for managing the ensemble definitions in the application"""
+    default_experiment_instance: str | None = None
+    """Default experiment instance ID to use for experiments."""
+    subscription_id: str | None = None
+    """Subscription ID if the application is a subscription type."""
+    locked: bool = False
+    """Whether the application is locked."""
+    created_at: datetime | None = None
+    """Creation timestamp of the application."""
+    updated_at: datetime | None = None
+    """Last update timestamp of the application."""
 
-    def __post_init__(self):
+    # SDK-specific attributes for convenience when using methods.
+    client: Client = Field(exclude=True)
+    """Client to use for interacting with the Nextmv Cloud API."""
+    endpoint: str = Field(exclude=True, default="v1/applications/{id}")
+    """Base endpoint for the application."""
+    experiments_endpoint: str = Field(exclude=True, default="{base}/experiments")
+    """Base endpoint for the experiments in the application."""
+    ensembles_endpoint: str = Field(exclude=True, default="{base}/ensembles")
+    """Base endpoint for managing the ensemble definitions in the
+    application"""
+
+    def model_post_init(self, __context) -> None:
         """Initialize the endpoint and experiments_endpoint attributes.
 
         This method is automatically called after class initialization to
@@ -150,6 +207,39 @@ class Application:
         self.ensembles_endpoint = self.ensembles_endpoint.format(base=self.endpoint)
 
     @classmethod
+    def get(cls, client: Client, id: str) -> "Application":
+        """
+        Retrieve an application directly from Nextmv Cloud.
+
+        This function is useful if you want to populate an `Application` class
+        by fetching the attributes directly from Nextm Cloud.
+
+        Parameters
+        ----------
+        client : Client
+            Client to use for interacting with the Nextmv Cloud API.
+        id : str
+            ID of the application to retrieve.
+
+        Returns
+        -------
+        Application
+            The requested application.
+
+        Raises
+        ------
+        requests.HTTPError
+            If the response status code is not 2xx.
+        """
+
+        response = client.request(
+            method="GET",
+            endpoint=f"v1/applications/{id}",
+        )
+
+        return cls.from_dict({"client": client} | response.json())
+
+    @classmethod
     def new(
         cls,
         client: Client,
@@ -158,6 +248,8 @@ class Application:
         description: str | None = None,
         is_workflow: bool | None = None,
         exist_ok: bool = False,
+        default_instance_id: str | None = None,
+        default_experiment_instance: str | None = None,
     ) -> "Application":
         """
         Create a new application directly in Nextmv Cloud.
@@ -180,6 +272,10 @@ class Application:
         exist_ok : bool, default=False
             If True and an application with the same ID already exists,
             return the existing application instead of creating a new one.
+        default_instance_id : str, optional
+            Default instance ID to use for submitting runs.
+        default_experiment_instance : str, optional
+            Default experiment instance ID to use for experiments.
 
         Returns
         -------
@@ -197,7 +293,12 @@ class Application:
             id = safe_id("app")
 
         if exist_ok and cls.exists(client=client, id=id):
-            return Application(client=client, id=id)
+            response = client.request(
+                method="GET",
+                endpoint=f"v1/applications/{id}",
+            )
+
+            return cls.from_dict({"client": client} | response.json())
 
         payload = {
             "name": name,
@@ -210,13 +311,19 @@ class Application:
         if is_workflow is not None:
             payload["is_pipeline"] = is_workflow
 
+        if default_instance_id is not None:
+            payload["default_instance"] = default_instance_id
+
+        if default_experiment_instance is not None:
+            payload["default_experiment_instance"] = default_experiment_instance
+
         response = client.request(
             method="POST",
             endpoint="v1/applications",
             payload=payload,
         )
 
-        return cls(client=client, id=response.json()["id"])
+        return cls.from_dict({"client": client} | response.json())
 
     def acceptance_test(self, acceptance_test_id: str) -> AcceptanceTest:
         """
@@ -2408,6 +2515,7 @@ class Application:
         verbose: bool = False,
         model: Model | None = None,
         model_configuration: ModelConfiguration | None = None,
+        rich_print: bool = False,
     ) -> None:
         """
         Push an app to Nextmv Cloud.
@@ -2441,6 +2549,8 @@ class Application:
         model_configuration : Optional[ModelConfiguration], default=None
             Configuration for the Python-native model. Must be specified together
             with `model`.
+        rich_print : bool, default=False
+            Whether to use rich printing when verbose output is enabled.
 
         Returns
         -------
@@ -2518,7 +2628,10 @@ class Application:
         """
 
         if verbose:
-            log("💽 Starting build for Nextmv application.")
+            if rich_print:
+                rich.print(f":cd: Starting build for Nextmv application [magenta]{self.id}[/magenta].", file=sys.stderr)
+            else:
+                log("💽 Starting build for Nextmv application.")
 
         if app_dir is None or app_dir == "":
             app_dir = "."
@@ -2535,10 +2648,10 @@ class Application:
         if (model is None and model_configuration is not None) or (model is not None and model_configuration is None):
             raise ValueError("model and model_configuration must be provided together")
 
-        package._run_build_command(app_dir, manifest.build, verbose)
-        package._run_pre_push_command(app_dir, manifest.pre_push, verbose)
-        tar_file, output_dir = package._package(app_dir, manifest, model, model_configuration, verbose)
-        self.__update_app_binary(tar_file, manifest, verbose)
+        package._run_build_command(app_dir, manifest.build, verbose, rich_print)
+        package._run_pre_push_command(app_dir, manifest.pre_push, verbose, rich_print)
+        tar_file, output_dir = package._package(app_dir, manifest, model, model_configuration, verbose, rich_print)
+        self.__update_app_binary(tar_file, manifest, verbose, rich_print)
 
         try:
             shutil.rmtree(output_dir)
@@ -3381,6 +3494,59 @@ class Application:
             output_dir_path=output_dir_path,
         )
 
+    def update(
+        self,
+        name: str | None = None,
+        description: str | None = None,
+        default_instance_id: str | None = None,
+        default_experiment_instance: str | None = None,
+    ) -> "Application":
+        """
+        Update the application.
+
+        Parameters
+        ----------
+        name : Optional[str], default=None
+            Optional name of the application.
+        description : Optional[str], default=None
+            Optional description of the application.
+        default_instance_id : Optional[str], default=None
+            Optional default instance ID for the application.
+        default_experiment_instance : Optional[str], default=None
+            Optional default experiment instance ID for the application.
+
+        Returns
+        -------
+        Application
+            The updated application.
+
+        Raises
+        ------
+        requests.HTTPError
+            If the response status code is not 2xx.
+        """
+
+        app = self.get(client=self.client, id=self.id)
+        app_dict = app.to_dict()
+        payload = app_dict
+
+        if name is not None:
+            payload["name"] = name
+        if description is not None:
+            payload["description"] = description
+        if default_instance_id is not None:
+            payload["default_instance_id"] = default_instance_id
+        if default_experiment_instance is not None:
+            payload["default_experiment_instance"] = default_experiment_instance
+
+        response = self.client.request(
+            method="PUT",
+            endpoint=self.endpoint,
+            payload=payload,
+        )
+
+        return Application.from_dict({"client": self.client} | response.json())
+
     def update_batch_experiment(
         self,
         batch_experiment_id: str,
@@ -4081,11 +4247,15 @@ class Application:
         tar_file: str,
         manifest: Manifest,
         verbose: bool = False,
+        rich_print: bool = False,
     ) -> None:
         """Updates the application binary in Cloud."""
 
         if verbose:
-            log(f'🌟 Pushing to application: "{self.id}".')
+            if rich_print:
+                rich.print(f":star2: Pushing to application: [magenta]{self.id}[/magenta].", file=sys.stderr)
+            else:
+                log(f'🌟 Pushing to application: "{self.id}".')
 
         endpoint = f"{self.endpoint}/binary"
         response = self.client.request(
@@ -4109,17 +4279,18 @@ class Application:
         )
 
         if verbose:
-            log(f'💥️ Successfully pushed to application: "{self.id}".')
-            log(
-                json.dumps(
-                    {
-                        "app_id": self.id,
-                        "endpoint": self.client.url,
-                        "instance_url": f"{self.endpoint}/runs?instance_id=latest",
-                    },
-                    indent=2,
-                )
-            )
+            data = {
+                "app_id": self.id,
+                "endpoint": self.client.url,
+                "instance_url": f"{self.endpoint}/runs?instance_id=latest",
+            }
+
+            if rich_print:
+                rich.print(f":boom: Successfully pushed to application: [magenta]{self.id}[/magenta].", file=sys.stderr)
+                rich.print_json(data=data)
+            else:
+                log(f'💥️ Successfully pushed to application: "{self.id}".')
+                log(json.dumps(data, indent=2))
 
     def __console_url(self, run_id: str) -> str:
         """Auxiliary method to get the console URL for a run."""
@@ -4303,6 +4474,45 @@ class Application:
         configuration_dict = configuration.to_dict()
 
         return configuration_dict
+
+
+def list_applications(client: Client) -> list[Application]:
+    """
+    List all Nextmv Cloud applications.
+
+    You can import the `list_applications` function directly from `cloud`:
+
+    ```python
+    from nextmv.cloud import list_applications
+    ```
+
+    Parameters
+    ----------
+    client : Client
+        The Nextmv Cloud client used to make API requests.
+
+    Returns
+    -------
+    list[Application]
+        A list of Nextmv Cloud applications.
+
+    Raises
+    -------
+    requests.HTTPError
+        If the response status code is not 2xx.
+    """
+
+    response = client.request(
+        method="GET",
+        endpoint="v1/applications",
+    )
+
+    applications = []
+    for app_data in response.json() or []:
+        app = Application.from_dict({"client": client} | app_data)
+        applications.append(app)
+
+    return applications
 
 
 def _is_not_exist_error(e: requests.HTTPError) -> bool:

--- a/nextmv/nextmv/cloud/application.py
+++ b/nextmv/nextmv/cloud/application.py
@@ -212,7 +212,7 @@ class Application(BaseModel):
         Retrieve an application directly from Nextmv Cloud.
 
         This function is useful if you want to populate an `Application` class
-        by fetching the attributes directly from Nextm Cloud.
+        by fetching the attributes directly from Nextmv Cloud.
 
         Parameters
         ----------

--- a/nextmv/nextmv/cloud/package.py
+++ b/nextmv/nextmv/cloud/package.py
@@ -6,8 +6,11 @@ import platform
 import re
 import shutil
 import subprocess
+import sys
 import tarfile
 import tempfile
+
+import rich
 
 from nextmv.logger import log
 from nextmv.manifest import MANIFEST_FILE_NAME, Manifest, ManifestBuild, ManifestType
@@ -21,18 +24,19 @@ _MANDATORY_FILES_PER_TYPE = {
 }
 
 
-def _package(
+def _package(  # noqa: C901 # complexity attributed to printing.
     app_dir: str,
     manifest: Manifest,
     model: Model | None = None,
     model_configuration: ModelConfiguration | None = None,
     verbose: bool = False,
+    rich_print: bool = False,
 ) -> tuple[str, str]:
     """Package the app into a tarball."""
 
     with tempfile.TemporaryDirectory(prefix="nextmv-temp-") as temp_dir:
         if manifest.type == ManifestType.PYTHON:
-            __handle_python(app_dir, temp_dir, manifest, model, model_configuration, verbose)
+            __handle_python(app_dir, temp_dir, manifest, model, model_configuration, verbose, rich_print)
 
         found, missing, files = __find_files(app_dir, manifest.files)
         __confirm_mandatory_files(manifest, found)
@@ -55,7 +59,13 @@ def _package(
                 raise Exception(f"error copying asset files {file['absolute_path']}: {e}") from e
 
         if verbose:
-            log(f'📋 Copied files listed in "{MANIFEST_FILE_NAME}" manifest.')
+            if rich_print:
+                rich.print(
+                    f":clipboard: Copied files listed in [magenta]{MANIFEST_FILE_NAME}[/magenta] manifest.",
+                    file=sys.stderr,
+                )
+            else:
+                log(f'📋 Copied files listed in "{MANIFEST_FILE_NAME}" manifest.')
 
         if manifest.type == ManifestType.PYTHON:
             _cleanup_python_model(app_dir, model_configuration, verbose)
@@ -66,9 +76,22 @@ def _package(
         if verbose:
             try:
                 size = __human_friendly_file_size(tar_file)
-                log(f"📦 Packaged application ({file_count_msg}, {size}).")
+                if rich_print:
+                    rich.print(
+                        ":package: Packaged application "
+                        f"([magenta]{file_count_msg}[/magenta], [magenta]{size}[/magenta]).",
+                        file=sys.stderr,
+                    )
+                else:
+                    log(f"📦 Packaged application ({file_count_msg}, {size}).")
             except Exception:
-                log(f"📦 Packaged application ({file_count_msg}).")
+                if rich_print:
+                    rich.print(
+                        f":package: Packaged application ([magenta]{file_count_msg}[/magenta]).",
+                        file=sys.stderr,
+                    )
+                else:
+                    log(f"📦 Packaged application ({file_count_msg}).")
 
         return tar_file, output_dir
 
@@ -77,6 +100,7 @@ def _run_build_command(
     app_dir: str,
     manifest_build: ManifestBuild | None = None,
     verbose: bool = False,
+    rich_print: bool = False,
 ) -> None:
     """Run the build command specified in the manifest."""
 
@@ -85,7 +109,12 @@ def _run_build_command(
 
     elements = manifest_build.command.split(" ")
     command_str = " ".join(elements)
-    log(f'🚧 Running build command: "{command_str}"')
+
+    if verbose:
+        if rich_print:
+            rich.print(f":construction: Running build command: [magenta]{command_str}[/magenta]", file=sys.stderr)
+        else:
+            log(f'🚧 Running build command: "{command_str}"')
     try:
         result = subprocess.run(
             elements,
@@ -120,6 +149,7 @@ def _run_pre_push_command(
     app_dir: str,
     pre_push_command: str | None = None,
     verbose: bool = False,
+    rich_print: bool = False,
 ) -> None:
     """Run the pre-push command specified in the manifest."""
 
@@ -129,7 +159,11 @@ def _run_pre_push_command(
     elements = _get_shell_command_elements(pre_push_command)
 
     command_str = " ".join(elements)
-    log(f'🔨 Running pre-push command: "{command_str}"')
+    if verbose:
+        if rich_print:
+            rich.print(f":hammer: Running pre-push command: [magenta]{command_str}[/magenta]", file=sys.stderr)
+        else:
+            log(f'🔨 Running pre-push command: "{command_str}"')
     try:
         result = subprocess.run(
             elements,
@@ -227,16 +261,23 @@ def __handle_python(
     model: Model | None = None,
     model_configuration: ModelConfiguration | None = None,
     verbose: bool = False,
+    rich_print: bool = False,
 ) -> None:
     """Handles the Python-specific packaging logic."""
 
     if model is not None and model_configuration is not None:
         if verbose:
-            log("🔮 Encoding Python model.")
+            if rich_print:
+                rich.print(":crystal_ball: Encoding Python model.", file=sys.stderr)
+            else:
+                log("🔮 Encoding Python model.")
         model.save(app_dir, model_configuration)
 
     if verbose:
-        log("🐍 Bundling Python dependencies.")
+        if rich_print:
+            rich.print(":snake: Bundling Python dependencies.", file=sys.stderr)
+        else:
+            log("🐍 Bundling Python dependencies.")
     __install_dependencies(manifest, app_dir, temp_dir)
 
 


### PR DESCRIPTION
# Description

Adds the following commands to `nextmv cloud app`:

- `create`: creates a new app.
- `delete`: deletes an app.
- `exists`: checks if an app already exists with the given ID.
- `get`: gets the information of an app.
- `list`: lists all the existing apps.
- `push`: pushes an app.
- `update`: updates the information of an app.

To achieve this, some modifications had to be done to the `cloud.Application` class:

- Introduce the `get`, and `update` methods.
- Add more fields to the actual class and allow a person to build the app from calling the Cloud API with the `get` and `new` methods.
- Adds rich printing when pushing.

Lastly, the `ApplicationType` class was introduced alongside the `list_apps` method.