### PR TITLE
Adds the `nextmv cloud version` command tree

### DIFF
--- a/nextmv/nextmv/cli/cloud/__init__.py
+++ b/nextmv/nextmv/cli/cloud/__init__.py
@@ -6,11 +6,13 @@ import typer
 
 from nextmv.cli.cloud.app import app as app_app
 from nextmv.cli.cloud.run import app as run_app
+from nextmv.cli.cloud.version import app as version_app
 
 # Set up subcommand application.
 app = typer.Typer()
 app.add_typer(app_app, name="app")
 app.add_typer(run_app, name="run")
+app.add_typer(version_app, name="version")
 
 
 @app.callback()

--- a/nextmv/nextmv/cli/cloud/app/__init__.py
+++ b/nextmv/nextmv/cli/cloud/app/__init__.py
@@ -27,5 +27,9 @@ app.add_typer(update_app)
 def callback() -> None:
     """
     Create, manage, and push Nextmv Cloud applications.
+
+    A Nextmv application is an entity that contains a decision model as
+    executable code. An application can make a run by taking an input,
+    executing the decision model, and producing an output.
     """
     pass

--- a/nextmv/nextmv/cli/cloud/app/create.py
+++ b/nextmv/nextmv/cli/cloud/app/create.py
@@ -84,10 +84,6 @@ def create(
     """
     Create a new Nextmv Cloud application.
 
-    A Nextmv application is an entity that contains a decision model as
-    executable code. An application can make a run by taking an input,
-    executing the decision model, and producing an output.
-
     Use the [code]--exist-ok[/code] flag to avoid errors when creating an
     application with an ID that already exists. This is useful for scripts that
     need to ensure an application exists without worrying about whether it was

--- a/nextmv/nextmv/cli/cloud/run/__init__.py
+++ b/nextmv/nextmv/cli/cloud/run/__init__.py
@@ -29,5 +29,9 @@ app.add_typer(track_app)
 def callback() -> None:
     """
     Create and manage Nextmv Cloud application runs.
+
+    A run represents the execution of a decision model within a Nextmv Cloud
+    application. Each run takes an input, processes it using the decision model,
+    and produces an output.
     """
     pass

--- a/nextmv/nextmv/cli/cloud/version/__init__.py
+++ b/nextmv/nextmv/cli/cloud/version/__init__.py
@@ -1,0 +1,33 @@
+"""
+This module defines the cloud version command tree for the Nextmv CLI.
+"""
+
+import typer
+
+from nextmv.cli.cloud.version.create import app as create_app
+from nextmv.cli.cloud.version.delete import app as delete_app
+from nextmv.cli.cloud.version.exists import app as exists_app
+from nextmv.cli.cloud.version.get import app as get_app
+from nextmv.cli.cloud.version.list import app as list_app
+from nextmv.cli.cloud.version.update import app as update_app
+
+# Set up subcommand application.
+app = typer.Typer()
+app.add_typer(create_app)
+app.add_typer(delete_app)
+app.add_typer(exists_app)
+app.add_typer(get_app)
+app.add_typer(list_app)
+app.add_typer(update_app)
+
+
+@app.callback()
+def callback() -> None:
+    """
+    Create and manage Nextmv Cloud application versions.
+
+    A version represents a snapshot of an application's code at a specific
+    point in time. Versions are used to track changes to the decision model.
+    You can think of versions as Git tags for your Nextmv Cloud applications.
+    """
+    pass

--- a/nextmv/nextmv/cli/cloud/version/create.py
+++ b/nextmv/nextmv/cli/cloud/version/create.py
@@ -1,0 +1,101 @@
+"""
+This module defines the cloud version create command for the Nextmv CLI.
+"""
+
+from typing import Annotated
+
+import typer
+
+from nextmv.cli.configuration.config import build_app
+from nextmv.cli.message import error, in_progress, print_json
+from nextmv.cli.options import AppIDOption, ProfileOption
+
+# Set up subcommand application.
+app = typer.Typer()
+
+
+@app.command()
+def create(
+    app_id: AppIDOption,
+    name: Annotated[
+        str | None,
+        typer.Option(
+            "--name",
+            "-n",
+            help="A name for the version. If a name is not provided, the version ID will be used as the name.",
+            metavar="NAME",
+        ),
+    ] = None,
+    description: Annotated[
+        str | None,
+        typer.Option(
+            "--description",
+            "-d",
+            help="An optional description for the version.",
+            metavar="DESCRIPTION",
+        ),
+    ] = None,
+    exist_ok: Annotated[
+        bool,
+        typer.Option(
+            "--exist-ok",
+            "-e",
+            help="If a version with the given ID already exists, do not raise an error, and simply return it.",
+        ),
+    ] = False,
+    version_id: Annotated[
+        str | None,
+        typer.Option(
+            "--version-id",
+            "-v",
+            help="The ID to assign to the new version. If not provided, a random ID will be generated.",
+            envvar="NEXTMV_VERSION_ID",
+            metavar="VERSION_ID",
+        ),
+    ] = None,
+    profile: ProfileOption = None,
+) -> None:
+    """
+    Create a new Nextmv Cloud application version.
+
+    Use the [code]--exist-ok[/code] flag to avoid errors when creating a
+    version with an ID that already exists. This is useful for scripts that
+    need to ensure a version exists without worrying about whether it was
+    created previously.
+
+    [bold][underline]Examples[/underline][/bold]
+
+    - Create a version for application [magenta]hare-app[/magenta]. A random ID will be generated.
+        $ [green]nextmv cloud version create --app-id hare-app[/green]
+
+    - Create a version with a specific name.
+        $ [green]nextmv cloud version create --app-id hare-app --name "v1.0.0"[/green]
+
+    - Create a version with a specific ID.
+        $ [green]nextmv cloud version create --app-id hare-app --version-id v1[/green]
+
+    - Create a version with a name and description.
+        $ [green]nextmv cloud version create --app-id hare-app --name "v1.0.0" \\
+            --description "Initial release with routing optimization"[/green]
+
+    - Create a version, or get it if it already exists.
+        $ [green]nextmv cloud version create --app-id hare-app --version-id v1 --exist-ok[/green]
+    """
+
+    cloud_app = build_app(app_id=app_id, profile=profile)
+    if exist_ok:
+        in_progress(msg="Creating or getting version...")
+    else:
+        in_progress(msg="Creating version...")
+
+    try:
+        version = cloud_app.new_version(
+            id=version_id,
+            name=name,
+            description=description,
+            exist_ok=exist_ok,
+        )
+    except Exception as e:
+        error(str(e))
+
+    print_json(version.to_dict())

--- a/nextmv/nextmv/cli/cloud/version/create.py
+++ b/nextmv/nextmv/cli/cloud/version/create.py
@@ -7,7 +7,7 @@ from typing import Annotated
 import typer
 
 from nextmv.cli.configuration.config import build_app
-from nextmv.cli.message import error, in_progress, print_json
+from nextmv.cli.message import in_progress, print_json
 from nextmv.cli.options import AppIDOption, ProfileOption
 
 # Set up subcommand application.
@@ -88,14 +88,10 @@ def create(
     else:
         in_progress(msg="Creating version...")
 
-    try:
-        version = cloud_app.new_version(
-            id=version_id,
-            name=name,
-            description=description,
-            exist_ok=exist_ok,
-        )
-    except Exception as e:
-        error(str(e))
-
+    version = cloud_app.new_version(
+        id=version_id,
+        name=name,
+        description=description,
+        exist_ok=exist_ok,
+    )
     print_json(version.to_dict())

--- a/nextmv/nextmv/cli/cloud/version/delete.py
+++ b/nextmv/nextmv/cli/cloud/version/delete.py
@@ -8,7 +8,7 @@ import typer
 from rich.prompt import Confirm
 
 from nextmv.cli.configuration.config import build_app
-from nextmv.cli.message import error, info, success
+from nextmv.cli.message import info, success
 from nextmv.cli.options import AppIDOption, ProfileOption, VersionIDOption
 
 # Set up subcommand application.
@@ -56,12 +56,7 @@ def delete(
             return
 
     cloud_app = build_app(app_id=app_id, profile=profile)
-
-    try:
-        cloud_app.delete_version(version_id=version_id)
-    except Exception as e:
-        error(str(e))
-
+    cloud_app.delete_version(version_id=version_id)
     success(
         f"Version [magenta]{version_id}[/magenta] deleted successfully from application [magenta]{app_id}[/magenta]."
     )

--- a/nextmv/nextmv/cli/cloud/version/delete.py
+++ b/nextmv/nextmv/cli/cloud/version/delete.py
@@ -1,0 +1,67 @@
+"""
+This module defines the cloud version delete command for the Nextmv CLI.
+"""
+
+from typing import Annotated
+
+import typer
+from rich.prompt import Confirm
+
+from nextmv.cli.configuration.config import build_app
+from nextmv.cli.message import error, info, success
+from nextmv.cli.options import AppIDOption, ProfileOption, VersionIDOption
+
+# Set up subcommand application.
+app = typer.Typer()
+
+
+@app.command()
+def delete(
+    app_id: AppIDOption,
+    version_id: VersionIDOption,
+    yes: Annotated[
+        bool,
+        typer.Option(
+            "--yes",
+            "-y",
+            help="Agree to deletion confirmation prompt. Useful for non-interactive sessions.",
+        ),
+    ] = False,
+    profile: ProfileOption = None,
+) -> None:
+    """
+    Deletes a Nextmv Cloud application version.
+
+    This action is permanent and cannot be undone. Use the [code]--yes[/code]
+    flag to skip the confirmation prompt.
+
+    [bold][underline]Examples[/underline][/bold]
+
+    - Delete the version with the ID [magenta]v1[/magenta] from application [magenta]hare-app[/magenta].
+        $ [green]nextmv cloud version delete --app-id hare-app --version-id v1[/green]
+
+    - Delete the version without confirmation prompt.
+        $ [green]nextmv cloud version delete --app-id hare-app --version-id v1 --yes[/green]
+    """
+
+    if not yes:
+        confirm = Confirm.ask(
+            f"Are you sure you want to delete version [magenta]{version_id}[/magenta] "
+            f"from application [magenta]{app_id}[/magenta]? This action cannot be undone",
+            default=False,
+        )
+
+        if not confirm:
+            info(msg=f"Version [magenta]{version_id}[/magenta] will not be deleted.", emoji=":bulb:")
+            return
+
+    cloud_app = build_app(app_id=app_id, profile=profile)
+
+    try:
+        cloud_app.delete_version(version_id=version_id)
+    except Exception as e:
+        error(str(e))
+
+    success(
+        f"Version [magenta]{version_id}[/magenta] deleted successfully from application [magenta]{app_id}[/magenta]."
+    )

--- a/nextmv/nextmv/cli/cloud/version/exists.py
+++ b/nextmv/nextmv/cli/cloud/version/exists.py
@@ -5,7 +5,7 @@ This module defines the cloud version exists command for the Nextmv CLI.
 import typer
 
 from nextmv.cli.configuration.config import build_app
-from nextmv.cli.message import error, in_progress, print_json
+from nextmv.cli.message import in_progress, print_json
 from nextmv.cli.options import AppIDOption, ProfileOption, VersionIDOption
 
 # Set up subcommand application.
@@ -35,10 +35,5 @@ def exists(
 
     cloud_app = build_app(app_id=app_id, profile=profile)
     in_progress(msg="Checking if version exists...")
-
-    try:
-        ok = cloud_app.version_exists(version_id=version_id)
-    except Exception as e:
-        error(str(e))
-
+    ok = cloud_app.version_exists(version_id=version_id)
     print_json({"exists": ok})

--- a/nextmv/nextmv/cli/cloud/version/exists.py
+++ b/nextmv/nextmv/cli/cloud/version/exists.py
@@ -1,0 +1,44 @@
+"""
+This module defines the cloud version exists command for the Nextmv CLI.
+"""
+
+import typer
+
+from nextmv.cli.configuration.config import build_app
+from nextmv.cli.message import error, in_progress, print_json
+from nextmv.cli.options import AppIDOption, ProfileOption, VersionIDOption
+
+# Set up subcommand application.
+app = typer.Typer()
+
+
+@app.command()
+def exists(
+    app_id: AppIDOption,
+    version_id: VersionIDOption,
+    profile: ProfileOption = None,
+) -> None:
+    """
+    Check if a Nextmv Cloud application version exists.
+
+    This command is useful in scripting applications to verify the existence of
+    a Nextmv Cloud application version by its ID.
+
+    [bold][underline]Examples[/underline][/bold]
+
+    - Check if the version with the ID [magenta]v1[/magenta] exists in application [magenta]hare-app[/magenta].
+        $ [green]nextmv cloud version exists --app-id hare-app --version-id v1[/green]
+
+    - Check if the version exists using the profile named [magenta]hare[/magenta].
+        $ [green]nextmv cloud version exists --app-id hare-app --version-id v1 --profile hare[/green]
+    """
+
+    cloud_app = build_app(app_id=app_id, profile=profile)
+    in_progress(msg="Checking if version exists...")
+
+    try:
+        ok = cloud_app.version_exists(version_id=version_id)
+    except Exception as e:
+        error(str(e))
+
+    print_json({"exists": ok})

--- a/nextmv/nextmv/cli/cloud/version/get.py
+++ b/nextmv/nextmv/cli/cloud/version/get.py
@@ -8,7 +8,7 @@ from typing import Annotated
 import typer
 
 from nextmv.cli.configuration.config import build_app
-from nextmv.cli.message import error, in_progress, print_json, success
+from nextmv.cli.message import in_progress, print_json, success
 from nextmv.cli.options import AppIDOption, ProfileOption, VersionIDOption
 
 # Set up subcommand application.
@@ -48,12 +48,7 @@ def get(
 
     cloud_app = build_app(app_id=app_id, profile=profile)
     in_progress(msg="Getting version...")
-
-    try:
-        version = cloud_app.version(version_id=version_id)
-    except Exception as e:
-        error(str(e))
-
+    version = cloud_app.version(version_id=version_id)
     version_dict = version.to_dict()
 
     if output is not None:

--- a/nextmv/nextmv/cli/cloud/version/get.py
+++ b/nextmv/nextmv/cli/cloud/version/get.py
@@ -1,0 +1,67 @@
+"""
+This module defines the cloud version get command for the Nextmv CLI.
+"""
+
+import json
+from typing import Annotated
+
+import typer
+
+from nextmv.cli.configuration.config import build_app
+from nextmv.cli.message import error, in_progress, print_json, success
+from nextmv.cli.options import AppIDOption, ProfileOption, VersionIDOption
+
+# Set up subcommand application.
+app = typer.Typer()
+
+
+@app.command()
+def get(
+    app_id: AppIDOption,
+    version_id: VersionIDOption,
+    output: Annotated[
+        str | None,
+        typer.Option(
+            "--output",
+            "-o",
+            help="Saves the version information to this location.",
+            metavar="OUTPUT_PATH",
+        ),
+    ] = None,
+    profile: ProfileOption = None,
+) -> None:
+    """
+    Get a Nextmv Cloud application version.
+
+    This command is useful to get the attributes of an existing Nextmv Cloud
+    application version by its ID.
+
+    [bold][underline]Examples[/underline][/bold]
+
+    - Get the version with the ID [magenta]v1[/magenta] from application [magenta]hare-app[/magenta].
+        $ [green]nextmv cloud version get --app-id hare-app --version-id v1[/green]
+
+    - Get the version with the ID [magenta]v1[/magenta] and save the information to a
+      [magenta]version.json[/magenta] file.
+        $ [green]nextmv cloud version get --app-id hare-app --version-id v1 --output version.json[/green]
+    """
+
+    cloud_app = build_app(app_id=app_id, profile=profile)
+    in_progress(msg="Getting version...")
+
+    try:
+        version = cloud_app.version(version_id=version_id)
+    except Exception as e:
+        error(str(e))
+
+    version_dict = version.to_dict()
+
+    if output is not None:
+        with open(output, "w") as f:
+            json.dump(version_dict, f, indent=2)
+
+        success(msg=f"Version information saved to [magenta]{output}[/magenta].")
+
+        return
+
+    print_json(version_dict)

--- a/nextmv/nextmv/cli/cloud/version/list.py
+++ b/nextmv/nextmv/cli/cloud/version/list.py
@@ -1,0 +1,64 @@
+"""
+This module defines the cloud version list command for the Nextmv CLI.
+"""
+
+import json
+from typing import Annotated
+
+import typer
+
+from nextmv.cli.configuration.config import build_app
+from nextmv.cli.message import error, in_progress, print_json, success
+from nextmv.cli.options import AppIDOption, ProfileOption
+
+# Set up subcommand application.
+app = typer.Typer()
+
+
+@app.command()
+def list(
+    app_id: AppIDOption,
+    output: Annotated[
+        str | None,
+        typer.Option(
+            "--output",
+            "-o",
+            help="Saves the version list information to this location.",
+            metavar="OUTPUT_PATH",
+        ),
+    ] = None,
+    profile: ProfileOption = None,
+) -> None:
+    """
+    List all versions of a Nextmv Cloud application.
+
+    [bold][underline]Examples[/underline][/bold]
+
+    - List all versions of application [magenta]hare-app[/magenta].
+        $ [green]nextmv cloud version list --app-id hare-app[/green]
+
+    - List all versions using the profile named [magenta]hare[/magenta].
+        $ [green]nextmv cloud version list --app-id hare-app --profile hare[/green]
+
+    - List all versions and save the information to a [magenta]versions.json[/magenta] file.
+        $ [green]nextmv cloud version list --app-id hare-app --output versions.json[/green]
+    """
+
+    cloud_app = build_app(app_id=app_id, profile=profile)
+    in_progress(msg="Listing versions...")
+    try:
+        versions = cloud_app.list_versions()
+    except Exception as e:
+        error(str(e))
+
+    versions_dicts = [version.to_dict() for version in versions]
+
+    if output is not None:
+        with open(output, "w") as f:
+            json.dump(versions_dicts, f, indent=2)
+
+        success(msg=f"Version list information saved to [magenta]{output}[/magenta].")
+
+        return
+
+    print_json(versions_dicts)

--- a/nextmv/nextmv/cli/cloud/version/list.py
+++ b/nextmv/nextmv/cli/cloud/version/list.py
@@ -8,7 +8,7 @@ from typing import Annotated
 import typer
 
 from nextmv.cli.configuration.config import build_app
-from nextmv.cli.message import error, in_progress, print_json, success
+from nextmv.cli.message import in_progress, print_json, success
 from nextmv.cli.options import AppIDOption, ProfileOption
 
 # Set up subcommand application.
@@ -46,11 +46,7 @@ def list(
 
     cloud_app = build_app(app_id=app_id, profile=profile)
     in_progress(msg="Listing versions...")
-    try:
-        versions = cloud_app.list_versions()
-    except Exception as e:
-        error(str(e))
-
+    versions = cloud_app.list_versions()
     versions_dicts = [version.to_dict() for version in versions]
 
     if output is not None:

--- a/nextmv/nextmv/cli/cloud/version/update.py
+++ b/nextmv/nextmv/cli/cloud/version/update.py
@@ -1,0 +1,97 @@
+"""
+This module defines the cloud version update command for the Nextmv CLI.
+"""
+
+import json
+from typing import Annotated
+
+import typer
+
+from nextmv.cli.configuration.config import build_app
+from nextmv.cli.message import error, print_json, success
+from nextmv.cli.options import AppIDOption, ProfileOption, VersionIDOption
+
+# Set up subcommand application.
+app = typer.Typer()
+
+
+@app.command()
+def update(
+    app_id: AppIDOption,
+    version_id: VersionIDOption,
+    name: Annotated[
+        str | None,
+        typer.Option(
+            "--name",
+            "-n",
+            help="A new name for the version.",
+            metavar="NAME",
+        ),
+    ] = None,
+    description: Annotated[
+        str | None,
+        typer.Option(
+            "--description",
+            "-d",
+            help="A new description for the version.",
+            metavar="DESCRIPTION",
+        ),
+    ] = None,
+    output: Annotated[
+        str | None,
+        typer.Option(
+            "--output",
+            "-o",
+            help="Saves the updated version information to this location.",
+            metavar="OUTPUT_PATH",
+        ),
+    ] = None,
+    profile: ProfileOption = None,
+) -> None:
+    """
+    Updates a Nextmv Cloud application version.
+
+    [bold][underline]Examples[/underline][/bold]
+
+    - Update a version's name.
+        $ [green]nextmv cloud version update --app-id hare-app --version-id v1 --name "Version 1.0"[/green]
+
+    - Update a version's description.
+        $ [green]nextmv cloud version update --app-id hare-app --version-id v1 \\
+            --description "Initial stable release"[/green]
+
+    - Update a version's name and description at once.
+        $ [green]nextmv cloud version update --app-id hare-app --version-id v1 \\
+            --name "Version 1.0" --description "Initial stable release"[/green]
+
+    - Update a version and save the updated information to a [magenta]updated_version.json[/magenta] file.
+        $ [green]nextmv cloud version update --app-id hare-app --version-id v1 \\
+            --name "Version 1.0" --output updated_version.json[/green]
+    """
+
+    if name is None and description is None:
+        error("Provide at least one option to update: [code]--name[/code] or [code]--description[/code].")
+
+    cloud_app = build_app(app_id=app_id, profile=profile)
+
+    try:
+        updated_version = cloud_app.update_version(
+            version_id=version_id,
+            name=name,
+            description=description,
+        )
+    except Exception as e:
+        error(str(e))
+
+    success(f"Version [magenta]{version_id}[/magenta] updated successfully in application [magenta]{app_id}[/magenta].")
+    updated_version_dict = updated_version.to_dict()
+
+    if output is not None:
+        with open(output, "w") as f:
+            json.dump(updated_version_dict, f, indent=2)
+
+        success(msg=f"Updated version information saved to [magenta]{output}[/magenta].")
+
+        return
+
+    print_json(updated_version_dict)

--- a/nextmv/nextmv/cli/cloud/version/update.py
+++ b/nextmv/nextmv/cli/cloud/version/update.py
@@ -73,16 +73,11 @@ def update(
         error("Provide at least one option to update: [code]--name[/code] or [code]--description[/code].")
 
     cloud_app = build_app(app_id=app_id, profile=profile)
-
-    try:
-        updated_version = cloud_app.update_version(
-            version_id=version_id,
-            name=name,
-            description=description,
-        )
-    except Exception as e:
-        error(str(e))
-
+    updated_version = cloud_app.update_version(
+        version_id=version_id,
+        name=name,
+        description=description,
+    )
     success(f"Version [magenta]{version_id}[/magenta] updated successfully in application [magenta]{app_id}[/magenta].")
     updated_version_dict = updated_version.to_dict()
 

--- a/nextmv/nextmv/cli/main.py
+++ b/nextmv/nextmv/cli/main.py
@@ -14,8 +14,10 @@ epilog of the Typer application defined below.
 """
 
 import os
+import sys
 from typing import Annotated
 
+import rich
 import typer
 from rich.prompt import Confirm
 
@@ -161,3 +163,26 @@ def check_config_in_path() -> None:
             f"[magenta]{CONFIG_DIR}[/magenta] was found in your [code]PATH[/code]. "
             f"You should remove any entries related to [magenta]{CONFIG_DIR}[/magenta] from your [code]PATH[/code]."
         )
+
+
+def main() -> None:
+    """
+    Entry point for the CLI with global exception handling.
+
+    Catches all exceptions except Typer/Click exceptions (which handle their
+    own exit codes) and displays a clean error message instead of a traceback.
+    """
+
+    try:
+        app()
+    except (typer.Exit, typer.Abort, SystemExit):
+        raise
+    except Exception as e:
+        # We do not use the messages.error function here because doing so would
+        # raise a Typer exception, which would print a traceback.
+        msg = str(e).rstrip("\n")
+        if not msg.endswith("."):
+            msg += "."
+
+        rich.print(f"[red]Error:[/red] {msg}", file=sys.stderr)
+        sys.exit(1)

--- a/nextmv/nextmv/cli/message.py
+++ b/nextmv/nextmv/cli/message.py
@@ -26,6 +26,7 @@ def error(msg: str) -> None:
         Exits the program with code 1.
     """
 
+    msg = msg.rstrip("\n")
     if not msg.endswith("."):
         msg += "."
 
@@ -44,6 +45,7 @@ def success(msg: str) -> None:
         The success message to display.
     """
 
+    msg = msg.rstrip("\n")
     if not msg.endswith("."):
         msg += "."
 
@@ -60,6 +62,7 @@ def warning(msg: str) -> None:
         The warning message to display.
     """
 
+    msg = msg.rstrip("\n")
     if not msg.endswith("."):
         msg += "."
 
@@ -84,6 +87,7 @@ def info(msg: str, emoji: str | None = None) -> None:
         `:hourglass_flowing_sand:`.
     """
 
+    msg = msg.rstrip("\n")
     if not msg.endswith("."):
         msg += "."
 

--- a/nextmv/nextmv/cli/options.py
+++ b/nextmv/nextmv/cli/options.py
@@ -50,3 +50,17 @@ RunIDOption = Annotated[
         metavar="RUN_ID",
     ),
 ]
+
+# version_id option - can be used in any command that requires a version ID.
+# Define it as follows in commands or callbacks, as necessary:
+# version_id: VersionIDOption
+VersionIDOption = Annotated[
+    str,
+    typer.Option(
+        "--version-id",
+        "-v",
+        help="The Nextmv Cloud version ID to use for this action.",
+        envvar="NEXTMV_VERSION_ID",
+        metavar="VERSION_ID",
+    ),
+]

--- a/nextmv/nextmv/cloud/application.py
+++ b/nextmv/nextmv/cloud/application.py
@@ -707,6 +707,32 @@ class Application(BaseModel):
             endpoint=f"{self.endpoint}/secrets/{secrets_collection_id}",
         )
 
+    def delete_version(self, version_id: str) -> None:
+        """
+        Delete a version.
+
+        Permanently removes the specified version from the application.
+
+        Parameters
+        ----------
+        version_id : str
+            ID of the version to delete.
+
+        Raises
+        ------
+        requests.HTTPError
+            If the response status code is not 2xx.
+
+        Examples
+        --------
+        >>> app.delete_version("v1.0.0")  # Permanently deletes the version
+        """
+
+        _ = self.client.request(
+            method="DELETE",
+            endpoint=f"{self.endpoint}/versions/{version_id}",
+        )
+
     def ensemble_definition(self, ensemble_definition_id: str) -> EnsembleDefinition:
         """
         Get an ensemble definition.
@@ -2432,7 +2458,7 @@ class Application(BaseModel):
         exist_ok: bool = False,
     ) -> Version:
         """
-        Create a new version using the current dev binary.
+        Create a new version using the latest pushed executable.
 
         This method creates a new version of the application using the current development
         binary. Application versions represent different iterations of your application's
@@ -3881,6 +3907,68 @@ class Application(BaseModel):
         )
 
         return SecretsCollectionSummary.from_dict(response.json())
+
+    def update_version(
+        self,
+        version_id: str,
+        name: str | None = None,
+        description: str | None = None,
+    ) -> Version:
+        """
+        Update a version.
+
+        This method updates a specific version of the application. It mimics a
+        PATCH operation by allowing you to update only the name and/or description
+        fields while preserving all other fields.
+
+        Parameters
+        ----------
+        version_id : str
+            ID of the version to update.
+        name : Optional[str], default=None
+            Optional new name for the version.
+        description : Optional[str], default=None
+            Optional new description for the version.
+
+        Returns
+        -------
+        Version
+            The updated version object.
+
+        Raises
+        ------
+        requests.HTTPError
+            If the response status code is not 2xx.
+
+        Examples
+        --------
+        >>> # Update a version's name
+        >>> updated = app.update_version("v1.0.0", name="Version 1.0")
+        >>> print(updated.name)
+        'Version 1.0'
+
+        >>> # Update a version's description
+        >>> updated = app.update_version("v1.0.0", description="Initial release")
+        >>> print(updated.description)
+        'Initial release'
+        """
+
+        version = self.version(version_id=version_id)
+        version_dict = version.to_dict()
+        payload = version_dict
+
+        if name is not None:
+            payload["name"] = name
+        if description is not None:
+            payload["description"] = description
+
+        response = self.client.request(
+            method="PUT",
+            endpoint=f"{self.endpoint}/versions/{version_id}",
+            payload=payload,
+        )
+
+        return Version.from_dict(response.json())
 
     def upload_large_input(
         self,

--- a/nextmv/pyproject.toml
+++ b/nextmv/pyproject.toml
@@ -51,8 +51,8 @@ Documentation = "https://nextmv-py.docs.nextmv.io/en/latest/nextmv/"
 Repository = "https://github.com/nextmv-io/nextmv-py"
 
 # TODO: Uncomment when CLI is ready for general rollout.
-# [project.scripts]
-# nextmv = "nextmv.cli.main:app"
+[project.scripts]
+nextmv = "nextmv.cli.main:main"
 
 [project.optional-dependencies]
 all = [

--- a/nextmv/pyproject.toml
+++ b/nextmv/pyproject.toml
@@ -51,8 +51,8 @@ Documentation = "https://nextmv-py.docs.nextmv.io/en/latest/nextmv/"
 Repository = "https://github.com/nextmv-io/nextmv-py"
 
 # TODO: Uncomment when CLI is ready for general rollout.
-[project.scripts]
-nextmv = "nextmv.cli.main:main"
+# [project.scripts]
+# nextmv = "nextmv.cli.main:main"
 
 [project.optional-dependencies]
 all = [


### PR DESCRIPTION
# Description

Adds all the necessary files for the `nextmv cloud version` command tree which includes the following commands:

- `create`
- `delete`
- `exists`
- `get`
- `list`
- `update`

Adds the following missing methods to the `cloud.Application` class: `delete_version` and `update_version`. 