### PR TITLE
Adds versioning to push

### DIFF
--- a/nextmv/nextmv/cli/cloud/app/push.py
+++ b/nextmv/nextmv/cli/cloud/app/push.py
@@ -35,6 +35,46 @@ def push(
             metavar="MANIFEST_PATH",
         ),
     ] = None,
+    no_version: Annotated[
+        bool,
+        typer.Option(
+            "--no-version",
+            "-n",
+            help="The application will be pushed without creating a new version. "
+            "Default is to create a new version on each push.",
+            rich_help_panel="Versioning control",
+        ),
+    ] = False,
+    version_id: Annotated[
+        str | None,
+        typer.Option(
+            "--version-id",
+            "-v",
+            help="Custom version ID when pushing the application. Automatically generated if not provided.",
+            rich_help_panel="Versioning control",
+            metavar="VERSION_ID",
+        ),
+    ] = None,
+    version_name: Annotated[
+        str | None,
+        typer.Option(
+            "--version-name",
+            "-e",
+            help="Custom version name when pushing the application. Automatically generated if not provided.",
+            rich_help_panel="Versioning control",
+            metavar="VERSION_NAME",
+        ),
+    ] = None,
+    version_description: Annotated[
+        str | None,
+        typer.Option(
+            "--version-description",
+            "-r",
+            help="Custom version description when pushing the application. Automatically generated if not provided.",
+            rich_help_panel="Versioning control",
+            metavar="VERSION_DESCRIPTION",
+        ),
+    ] = None,
     profile: ProfileOption = None,
 ) -> None:
     """
@@ -47,6 +87,13 @@ def push(
     You can also provide a custom manifest file using the [code]--manifest[/code]
     option. If not provided, the CLI will look for a file named [magenta]app.yaml[/magenta]
     in the application's root.
+
+    The default behavior of this command is to create a new application version
+    [italic]after[/italic] the app has been pushed. You can use the
+    [code]--no-version[/code] option to skip this step. The
+    [code]--version-...[/code] options allow you to customize the attributes of
+    the version that is created. If any of these options are not provided,
+    automatically generated values will be used.
 
     [bold][underline]Examples[/underline][/bold]
 
@@ -63,6 +110,17 @@ def push(
       [magenta]./my-app[/magenta] directory with a custom manifest under [magenta]./custom-manifest.yaml[/magenta].
         $ [green]nextmv cloud app push --app-id hare-app --app-dir ./my-app \\
             --manifest ./custom-manifest.yaml[/green]
+
+    - Push an application without creating a new version.
+        $ [green]nextmv cloud app push --app-id hare-app --no-version[/green]
+
+    - Push an application with a custom version ID.
+        $ [green]nextmv cloud app push --app-id hare-app --version-id v1.0.0[/green]
+
+    - Push an application with custom version ID, name, and description.
+        $ [green]nextmv cloud app push --app-id hare-app --version-id v1.0.0 \\
+            --version-name "Release 1.0.0" \\
+            --version-description "First stable release"[/green]
     """
 
     cloud_app = build_app(app_id=app_id, profile=profile)
@@ -72,4 +130,8 @@ def push(
         app_dir=app_dir,
         verbose=True,
         rich_print=True,
+        no_version=no_version,
+        version_id=version_id,
+        version_name=version_name,
+        version_description=version_description,
     )

--- a/nextmv/nextmv/cloud/application.py
+++ b/nextmv/nextmv/cloud/application.py
@@ -2722,14 +2722,12 @@ class Application(BaseModel):
             return
 
         now = datetime.now(timezone.utc)
-        now_id = now.strftime("%Y%m%d-%H%M%S")
-        now_display = now.strftime("%Y-%m-%dT%H:%M:%SZ")
         if version_id is None:
-            version_id = safe_id(prefix="version") + f"-{now_id}"
+            version_id = safe_id(prefix="version") + f"-{now.strftime('%Y%m%d-%H%M%S')}"
         if version_name is None:
-            version_name = f"Version pushed at {now_display}"
+            version_name = f"Version {version_id}"
         if version_description is None:
-            version_description = f"Version created automatically from push at {now_display}"
+            version_description = f"Version created automatically from push at {now.strftime('%Y-%m-%dT%H:%M:%SZ')}"
 
         version = self.new_version(
             id=version_id,

--- a/nextmv/nextmv/cloud/application.py
+++ b/nextmv/nextmv/cloud/application.py
@@ -26,7 +26,7 @@ import shutil
 import sys
 import tarfile
 import tempfile
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 from typing import Any
 
@@ -2534,7 +2534,7 @@ class Application(BaseModel):
 
         return Version.from_dict(response.json())
 
-    def push(
+    def push(  # noqa: C901
         self,
         manifest: Manifest | None = None,
         app_dir: str | None = None,
@@ -2542,6 +2542,10 @@ class Application(BaseModel):
         model: Model | None = None,
         model_configuration: ModelConfiguration | None = None,
         rich_print: bool = False,
+        no_version: bool = False,
+        version_id: str | None = None,
+        version_name: str | None = None,
+        version_description: str | None = None,
     ) -> None:
         """
         Push an app to Nextmv Cloud.
@@ -2558,6 +2562,15 @@ class Application(BaseModel):
         internal (or Python-native) strategy, where the app is actually a
         `nextmv.Model`. The model is encoded, some dependencies and
         accompanying files are packaged, and the app is pushed to Nextmv Cloud.
+
+        The default behavior of this function is to create a new application
+        version _after_ the app has been pushed. You can set the `no_version`
+        argument to `True` to skip this step. The `version_id`, `version_name`,
+        and `version_description` arguments can be used to customize the version
+        that is created. If the `version_id` is not specified, a randomly
+        generated ID will be used. If the `version_name` is not specified, a
+        generic name with a timestamp will be used. Lastly, if no description is
+        specified, then a generic description will also be used.
 
         Parameters
         ----------
@@ -2683,6 +2696,47 @@ class Application(BaseModel):
             shutil.rmtree(output_dir)
         except OSError as e:
             raise Exception(f"error deleting output directory: {e}") from e
+
+        if no_version:
+            if verbose:
+                if rich_print:
+                    rich.print(
+                        f":white_check_mark: Push completed for Nextmv application [magenta]{self.id}[/magenta] "
+                        "without creating a new version.",
+                        file=sys.stderr,
+                    )
+                else:
+                    log("✅ Push completed without creating a new version for Nextmv application.")
+
+            return
+
+        now = datetime.now(timezone.utc)
+        now_id = now.strftime("%Y%m%d-%H%M%S")
+        now_display = now.strftime("%Y-%m-%dT%H:%M:%SZ")
+        if version_id is None:
+            version_id = safe_id(prefix="version") + f"-{now_id}"
+        if version_name is None:
+            version_name = f"Version pushed at {now_display}"
+        if version_description is None:
+            version_description = f"Version created automatically from push at {now_display}"
+
+        version = self.new_version(
+            id=version_id,
+            name=version_name,
+            description=version_description,
+        )
+        version_dict = version.to_dict()
+
+        if verbose:
+            if rich_print:
+                rich.print(
+                    f":white_check_mark: Automatically created new version [magenta]{version.id}[/magenta].",
+                    file=sys.stderr,
+                )
+                rich.print_json(data=version_dict)
+            else:
+                log(f'✅ Automatically created new version "{version.id}".')
+                log(json.dumps(version_dict, indent=2))
 
     def list_assets(self, run_id: str) -> list[RunAsset]:
         """

--- a/nextmv/nextmv/cloud/application.py
+++ b/nextmv/nextmv/cloud/application.py
@@ -2590,6 +2590,17 @@ class Application(BaseModel):
             with `model`.
         rich_print : bool, default=False
             Whether to use rich printing when verbose output is enabled.
+        no_version : bool, default=False
+            If True, do not create a new version after pushing the app.
+        version_id : Optional[str], default=None
+            ID of the version to create after pushing the app. If None, a unique
+            ID will be generated.
+        version_name : Optional[str], default=None
+            Name of the version to create after pushing the app. If None, a name
+            with a timestamp will be generated.
+        version_description : Optional[str], default=None
+            Description of the version to create after pushing the app. If None, a
+            generic description with a timestamp will be generated.
 
         Returns
         -------


### PR DESCRIPTION
# Description

Changes the default behavior when pushing an app. Whenever you push an app, a new version is created. Added options to skip this behavior and to customize the version attributes if it is created.