### PR TITLE
Adds the `nextmv cloud instance` command tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,7 +62,6 @@ db.sqlite3
 db.sqlite3-journal
 
 # Flask stuff:
-instance/
 .webassets-cache
 
 # Scrapy stuff:

--- a/nextmv/nextmv/cli/CONTRIBUTING.md
+++ b/nextmv/nextmv/cli/CONTRIBUTING.md
@@ -496,6 +496,14 @@ Consider the following guideline when declaring command options:
   to allow the user to save the output to a file. Consider the `nextmv cloud
   app list` command again. It has an `output` option that allows the user to
   save the list of applications to a file.
+- Always order command options alphabetically. Required options (without
+  default values) should be listed first, in alphabetical order. Optional
+  options (with default values) should follow, also in alphabetical order. When
+  using `rich_help_panel` to group options, maintain alphabetical order within
+  each panel. This ensures consistency across the CLI and makes it easier to
+  locate options in the code. An exception for this is the `profile` option, which
+  should always be the last option in the command's signature, for consistency
+  across the CLI.
 
 [typer]: https://typer.tiangolo.com
 [typer-learn]: https://typer.tiangolo.com/tutorial/

--- a/nextmv/nextmv/cli/cloud/__init__.py
+++ b/nextmv/nextmv/cli/cloud/__init__.py
@@ -5,6 +5,7 @@ This module defines the cloud command tree for the Nextmv CLI.
 import typer
 
 from nextmv.cli.cloud.app import app as app_app
+from nextmv.cli.cloud.instance import app as instance_app
 from nextmv.cli.cloud.run import app as run_app
 from nextmv.cli.cloud.upload import app as upload_app
 from nextmv.cli.cloud.version import app as version_app
@@ -12,6 +13,7 @@ from nextmv.cli.cloud.version import app as version_app
 # Set up subcommand application.
 app = typer.Typer()
 app.add_typer(app_app, name="app")
+app.add_typer(instance_app, name="instance")
 app.add_typer(run_app, name="run")
 app.add_typer(upload_app, name="upload")
 app.add_typer(version_app, name="version")

--- a/nextmv/nextmv/cli/cloud/app/create.py
+++ b/nextmv/nextmv/cli/cloud/app/create.py
@@ -36,15 +36,6 @@ def create(
             metavar="APP_ID",
         ),
     ] = None,
-    default_instance_id: Annotated[
-        str | None,
-        typer.Option(
-            "--default-instance-id",
-            "-i",
-            help="An optional default instance ID for the application.",
-            metavar="DEFAULT_INSTANCE_ID",
-        ),
-    ] = None,
     default_experiment_instance: Annotated[
         str | None,
         typer.Option(
@@ -52,6 +43,15 @@ def create(
             "-x",
             help="An optional default experiment instance ID for the application.",
             metavar="DEFAULT_EXPERIMENT_INSTANCE",
+        ),
+    ] = None,
+    default_instance_id: Annotated[
+        str | None,
+        typer.Option(
+            "--default-instance-id",
+            "-i",
+            help="An optional default instance ID for the application.",
+            metavar="DEFAULT_INSTANCE_ID",
         ),
     ] = None,
     description: Annotated[

--- a/nextmv/nextmv/cli/cloud/app/delete.py
+++ b/nextmv/nextmv/cli/cloud/app/delete.py
@@ -45,7 +45,7 @@ def delete(
 
     if not yes:
         confirm = Confirm.ask(
-            f"Are you sure you want to delete application [magenta]{app_id}[/magenta]? This action cannot be undone",
+            f"Are you sure you want to delete application [magenta]{app_id}[/magenta]? This action cannot be undone.",
             default=False,
         )
 

--- a/nextmv/nextmv/cli/cloud/app/update.py
+++ b/nextmv/nextmv/cli/cloud/app/update.py
@@ -18,13 +18,13 @@ app = typer.Typer()
 @app.command()
 def update(
     app_id: AppIDOption,
-    name: Annotated[
+    default_experiment_instance: Annotated[
         str | None,
         typer.Option(
-            "--name",
-            "-n",
-            help="A new name for the application.",
-            metavar="NAME",
+            "--default-experiment-instance",
+            "-x",
+            help="A new default experiment instance ID for the application.",
+            metavar="DEFAULT_EXPERIMENT_INSTANCE",
         ),
     ] = None,
     default_instance_id: Annotated[
@@ -36,15 +36,6 @@ def update(
             metavar="DEFAULT_INSTANCE_ID",
         ),
     ] = None,
-    default_experiment_instance: Annotated[
-        str | None,
-        typer.Option(
-            "--default-experiment-instance",
-            "-x",
-            help="A new default experiment instance ID for the application.",
-            metavar="DEFAULT_EXPERIMENT_INSTANCE",
-        ),
-    ] = None,
     description: Annotated[
         str | None,
         typer.Option(
@@ -52,6 +43,15 @@ def update(
             "-d",
             help="A new description for the application.",
             metavar="DESCRIPTION",
+        ),
+    ] = None,
+    name: Annotated[
+        str | None,
+        typer.Option(
+            "--name",
+            "-n",
+            help="A new name for the application.",
+            metavar="NAME",
         ),
     ] = None,
     output: Annotated[

--- a/nextmv/nextmv/cli/cloud/instance/__init__.py
+++ b/nextmv/nextmv/cli/cloud/instance/__init__.py
@@ -1,0 +1,35 @@
+"""
+This module defines the cloud instance command tree for the Nextmv CLI.
+"""
+
+import typer
+
+from nextmv.cli.cloud.instance.create import app as create_app
+from nextmv.cli.cloud.instance.delete import app as delete_app
+from nextmv.cli.cloud.instance.exists import app as exists_app
+from nextmv.cli.cloud.instance.get import app as get_app
+from nextmv.cli.cloud.instance.list import app as list_app
+from nextmv.cli.cloud.instance.update import app as update_app
+
+# Set up subcommand application.
+app = typer.Typer()
+app.add_typer(create_app)
+app.add_typer(delete_app)
+app.add_typer(exists_app)
+app.add_typer(get_app)
+app.add_typer(list_app)
+app.add_typer(update_app)
+
+
+@app.callback()
+def callback() -> None:
+    """
+    Create and manage Nextmv Cloud application instances.
+
+    An application instance is a representation of a version and optional
+    configuration (options/parameters). Instances are the mechanism by which a
+    run is made. When you make a new run, the app determines which instance to
+    use and then uses the executable code associated to the version for the
+    run.
+    """
+    pass

--- a/nextmv/nextmv/cli/cloud/instance/create.py
+++ b/nextmv/nextmv/cli/cloud/instance/create.py
@@ -11,7 +11,7 @@ from nextmv.cli.message import error, in_progress, print_json
 from nextmv.cli.options import AppIDOption, ProfileOption, VersionIDOption
 from nextmv.cloud.instance import InstanceConfiguration
 from nextmv.input import InputFormat
-from nextmv.run import Format, RunQueuing
+from nextmv.run import Format, FormatInput, RunQueuing
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -154,6 +154,14 @@ def create(
     - Create an instance, or get it if it already exists.
         $ [green]nextmv cloud instance create --app-id hare-app --version-id v1 \\
             --instance-id prod --exist-ok[/green]
+
+    - Create an instance with configuration options.
+        $ [green]nextmv cloud instance create --app-id hare-app --version-id v1 \\
+            --instance-id prod --execution-class 6c9500mb870s --priority 1[/green]
+
+    - Create an instance with runtime options.
+        $ [green]nextmv cloud instance create --app-id hare-app --version-id v1 \\
+            --instance-id prod --options max_duration=30 --options timeout=60[/green]
     """
 
     cloud_app = build_app(app_id=app_id, profile=profile)
@@ -275,7 +283,9 @@ def build_config(
         config.integration_id = integration_id
     if content_type is not None:
         config.format = Format(
-            format_input=InputFormat(content_type),
+            format_input=FormatInput(
+                input_type=InputFormat(content_type),
+            ),
         )
 
     return config

--- a/nextmv/nextmv/cli/cloud/instance/create.py
+++ b/nextmv/nextmv/cli/cloud/instance/create.py
@@ -59,14 +59,14 @@ def create(
         ),
     ] = None,
     # Options for configuring the instance.
-    content_type: Annotated[
+    content_format: Annotated[
         InputFormat | None,
         typer.Option(
-            "--content-type",
+            "--content-format",
             "-c",
-            help="The content type of the instance to create. Allowed values are: "
-            f"{[v.value for v in InputFormat.__members__.values()]}",
-            metavar="CONTENT_TYPE",
+            help="The content format of the instance to create. Allowed values are: "
+            f"[magenta]{[v.value for v in InputFormat.__members__.values()]}[/magenta].",
+            metavar="CONTENT_FORMAT",
             rich_help_panel="Instance configuration",
         ),
     ] = None,
@@ -177,7 +177,7 @@ def create(
     instance_config = build_config(
         priority=priority,
         no_queuing=no_queuing,
-        content_type=content_type,
+        content_format=content_format,
         execution_class=execution_class,
         integration_id=integration_id,
         options=instance_options,
@@ -235,7 +235,7 @@ def build_options(options: list[str] | None) -> dict[str, str] | None:
 def build_config(
     priority: int,
     no_queuing: bool,
-    content_type: InputFormat | None = None,
+    content_format: InputFormat | None = None,
     execution_class: str | None = None,
     integration_id: str | None = None,
     options: dict | None = None,
@@ -250,8 +250,8 @@ def build_config(
         The priority of the instance.
     no_queuing : bool
         Whether to disable queuing for the instance.
-    content_type : InputFormat | None
-        The content type for the instance, if applicable.
+    content_format : InputFormat | None
+        The content format for the instance, if applicable.
     execution_class : str | None
         The execution class to use for the instance, if applicable.
     integration_id : str | None
@@ -281,10 +281,10 @@ def build_config(
         config.secrets_collection_id = secret_collection_id
     if integration_id is not None:
         config.integration_id = integration_id
-    if content_type is not None:
+    if content_format is not None:
         config.format = Format(
             format_input=FormatInput(
-                input_type=InputFormat(content_type),
+                input_type=InputFormat(content_format),
             ),
         )
 

--- a/nextmv/nextmv/cli/cloud/instance/create.py
+++ b/nextmv/nextmv/cli/cloud/instance/create.py
@@ -1,0 +1,99 @@
+"""
+This module defines the cloud instance create command for the Nextmv CLI.
+"""
+
+from typing import Annotated
+
+import typer
+
+from nextmv.cli.configuration.config import build_app
+from nextmv.cli.message import in_progress, print_json
+from nextmv.cli.options import AppIDOption, ProfileOption, VersionIDOption
+
+# Set up subcommand application.
+app = typer.Typer()
+
+
+@app.command()
+def create(
+    app_id: AppIDOption,
+    version_id: VersionIDOption,
+    description: Annotated[
+        str | None,
+        typer.Option(
+            "--description",
+            "-d",
+            help="An optional description for the instance.",
+            metavar="DESCRIPTION",
+        ),
+    ] = None,
+    exist_ok: Annotated[
+        bool,
+        typer.Option(
+            "--exist-ok",
+            "-e",
+            help="If an instance with the given ID already exists, do not raise an error, and simply return it.",
+        ),
+    ] = False,
+    instance_id: Annotated[
+        str | None,
+        typer.Option(
+            "--instance-id",
+            "-i",
+            help="The ID to assign to the new instance. If not provided, a random ID will be generated.",
+            envvar="NEXTMV_INSTANCE_ID",
+            metavar="INSTANCE_ID",
+        ),
+    ] = None,
+    name: Annotated[
+        str | None,
+        typer.Option(
+            "--name",
+            "-n",
+            help="A name for the instance. If a name is not provided, the instance ID will be used as the name.",
+            metavar="NAME",
+        ),
+    ] = None,
+    profile: ProfileOption = None,
+) -> None:
+    """
+    Create a new Nextmv Cloud application instance.
+
+    Use the [code]--exist-ok[/code] flag to avoid errors when creating an
+    instance with an ID that already exists. This is useful for scripts that
+    need to ensure an instance exists without worrying about whether it was
+    created previously.
+
+    [bold][underline]Examples[/underline][/bold]
+
+    - Create an instance for application [magenta]hare-app[/magenta] version [magenta]v1[/magenta].
+        $ [green]nextmv cloud instance create --app-id hare-app --version-id v1 --instance-id prod[/green]
+
+    - Create an instance with a specific name.
+        $ [green]nextmv cloud instance create --app-id hare-app --version-id v1 \\
+            --instance-id prod --name "Production Instance"[/green]
+
+    - Create an instance with a name and description.
+        $ [green]nextmv cloud instance create --app-id hare-app --version-id v1 \\
+            --instance-id prod --name "Production Instance" \\
+            --description "Instance for production routing jobs"[/green]
+
+    - Create an instance, or get it if it already exists.
+        $ [green]nextmv cloud instance create --app-id hare-app --version-id v1 \\
+            --instance-id prod --exist-ok[/green]
+    """
+
+    cloud_app = build_app(app_id=app_id, profile=profile)
+    if exist_ok:
+        in_progress(msg="Creating or getting instance...")
+    else:
+        in_progress(msg="Creating instance...")
+
+    instance = cloud_app.new_instance(
+        version_id=version_id,
+        id=instance_id,
+        name=name,
+        description=description,
+        exist_ok=exist_ok,
+    )
+    print_json(instance.to_dict())

--- a/nextmv/nextmv/cli/cloud/instance/create.py
+++ b/nextmv/nextmv/cli/cloud/instance/create.py
@@ -216,7 +216,7 @@ def build_options(options: list[str] | None) -> dict[str, str] | None:
         return None
 
     instance_options = {}
-    for opt in options or []:
+    for opt in options:
         # It is possible to pass multiple options separated by commas. The
         # default way though is to use the flag multiple times to specify
         # different options.

--- a/nextmv/nextmv/cli/cloud/instance/create.py
+++ b/nextmv/nextmv/cli/cloud/instance/create.py
@@ -7,8 +7,11 @@ from typing import Annotated
 import typer
 
 from nextmv.cli.configuration.config import build_app
-from nextmv.cli.message import in_progress, print_json
+from nextmv.cli.message import error, in_progress, print_json
 from nextmv.cli.options import AppIDOption, ProfileOption, VersionIDOption
+from nextmv.cloud.instance import InstanceConfiguration
+from nextmv.input import InputFormat
+from nextmv.run import Format, RunQueuing
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -16,6 +19,7 @@ app = typer.Typer()
 
 @app.command()
 def create(
+    # Options for creating the instance.
     app_id: AppIDOption,
     version_id: VersionIDOption,
     description: Annotated[
@@ -54,6 +58,75 @@ def create(
             metavar="NAME",
         ),
     ] = None,
+    # Options for configuring the instance.
+    content_type: Annotated[
+        InputFormat | None,
+        typer.Option(
+            "--content-type",
+            "-c",
+            help="The content type of the instance to create. Allowed values are: "
+            f"{[v.value for v in InputFormat.__members__.values()]}",
+            metavar="CONTENT_TYPE",
+            rich_help_panel="Instance configuration",
+        ),
+    ] = None,
+    execution_class: Annotated[
+        str | None,
+        typer.Option(
+            "--execution-class",
+            "-x",
+            help="The execution class to use for the instance.",
+            metavar="EXECUTION_CLASS",
+            rich_help_panel="Instance configuration",
+        ),
+    ] = None,
+    integration_id: Annotated[
+        str | None,
+        typer.Option(
+            help="The integration ID to use for the runs of the instance, if applicable.",
+            metavar="INTEGRATION_ID",
+            rich_help_panel="Instance configuration",
+        ),
+    ] = None,
+    no_queuing: Annotated[
+        bool,
+        typer.Option(
+            "--no-queuing",
+            help="Do not queue when running the instance. Default is [magenta]False[/magenta], "
+            "meaning the instance's run [italic]will[/italic] be queued.",
+            rich_help_panel="Instance configuration",
+        ),
+    ] = False,
+    options: Annotated[
+        list[str],
+        typer.Option(
+            "--options",
+            "-o",
+            help="Options to always use when running the instance. Format: [magenta]key=value[/magenta]. "
+            "Pass multiple options by repeating the flag, or separating with commas.",
+            metavar="KEY=VALUE",
+            rich_help_panel="Instance configuration",
+        ),
+    ] = None,
+    priority: Annotated[
+        int,
+        typer.Option(
+            help="The priority of the runs in the instance. "
+            "Priority is between 1 and 10, with 1 being the highest priority.",
+            metavar="PRIORITY",
+            rich_help_panel="Instance configuration",
+        ),
+    ] = 6,
+    secret_collection_id: Annotated[
+        str | None,
+        typer.Option(
+            "--secret-collection-id",
+            "-s",
+            help="The secret collection ID to use for the instance, if applicable.",
+            metavar="SECRET_COLLECTION_ID",
+            rich_help_panel="Instance configuration",
+        ),
+    ] = None,
     profile: ProfileOption = None,
 ) -> None:
     """
@@ -89,11 +162,120 @@ def create(
     else:
         in_progress(msg="Creating instance...")
 
+    # Build the instance options from the CLI options
+    instance_options = build_options(options)
+
+    # Build the instance configuration
+    instance_config = build_config(
+        priority=priority,
+        no_queuing=no_queuing,
+        content_type=content_type,
+        execution_class=execution_class,
+        integration_id=integration_id,
+        options=instance_options,
+        secret_collection_id=secret_collection_id,
+    )
+
     instance = cloud_app.new_instance(
         version_id=version_id,
         id=instance_id,
         name=name,
         description=description,
+        configuration=instance_config,
         exist_ok=exist_ok,
     )
     print_json(instance.to_dict())
+
+
+def build_options(options: list[str] | None) -> dict[str, str] | None:
+    """
+    Builds the instance options. One can pass options by either using the flag
+    multiple times or by separating with commas in the same flag. A
+    combination of both is also possible.
+
+    Parameters
+    ----------
+    options : list[str] | None
+        The list of instance options as strings.
+
+    Returns
+    -------
+    dict[str, str]
+        The built instance options.
+    """
+
+    if options is None:
+        return None
+
+    instance_options = {}
+    for opt in options or []:
+        # It is possible to pass multiple options separated by commas. The
+        # default way though is to use the flag multiple times to specify
+        # different options.
+        sub_opts = opt.split(",")
+        for sub_opt in sub_opts:
+            key_value = sub_opt.split("=", 1)
+            if len(key_value) != 2:
+                error(f"Invalid option format: {sub_opt}. Expected format is [magenta]key=value[/magenta].")
+
+            key, value = key_value
+            instance_options[key] = value
+
+    return instance_options
+
+
+def build_config(
+    priority: int,
+    no_queuing: bool,
+    content_type: InputFormat | None = None,
+    execution_class: str | None = None,
+    integration_id: str | None = None,
+    options: dict | None = None,
+    secret_collection_id: str | None = None,
+) -> InstanceConfiguration:
+    """
+    Builds the instance configuration for the new instance.
+
+    Parameters
+    ----------
+    priority : int
+        The priority of the instance.
+    no_queuing : bool
+        Whether to disable queuing for the instance.
+    content_type : InputFormat | None
+        The content type for the instance, if applicable.
+    execution_class : str | None
+        The execution class to use for the instance, if applicable.
+    integration_id : str | None
+        The integration ID to use for the instance, if applicable.
+    options : dict | None
+        The runtime options for the instance, if applicable.
+    secret_collection_id : str | None
+        The secret collection ID to use for the instance, if applicable.
+
+    Returns
+    -------
+    InstanceConfiguration
+        The built instance configuration.
+    """
+
+    config = InstanceConfiguration(
+        queuing=RunQueuing(
+            priority=priority,
+            disabled=no_queuing,
+        ),
+    )
+    if execution_class is not None:
+        config.execution_class = execution_class
+    if options is not None:
+        config.options = options
+    if secret_collection_id is not None:
+        config.secrets_collection_id = secret_collection_id
+    if integration_id is not None:
+        config.integration_id = integration_id
+    if content_type is not None:
+        config.format = Format(
+            format_input=InputFormat(content_type),
+        )
+
+    return config

--- a/nextmv/nextmv/cli/cloud/instance/delete.py
+++ b/nextmv/nextmv/cli/cloud/instance/delete.py
@@ -1,5 +1,5 @@
 """
-This module defines the cloud version delete command for the Nextmv CLI.
+This module defines the cloud instance delete command for the Nextmv CLI.
 """
 
 from typing import Annotated
@@ -9,7 +9,7 @@ from rich.prompt import Confirm
 
 from nextmv.cli.configuration.config import build_app
 from nextmv.cli.message import info, success
-from nextmv.cli.options import AppIDOption, ProfileOption, VersionIDOption
+from nextmv.cli.options import AppIDOption, InstanceIDOption, ProfileOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -18,7 +18,7 @@ app = typer.Typer()
 @app.command()
 def delete(
     app_id: AppIDOption,
-    version_id: VersionIDOption,
+    instance_id: InstanceIDOption,
     yes: Annotated[
         bool,
         typer.Option(
@@ -30,33 +30,33 @@ def delete(
     profile: ProfileOption = None,
 ) -> None:
     """
-    Deletes a Nextmv Cloud application version.
+    Deletes a Nextmv Cloud application instance.
 
     This action is permanent and cannot be undone. Use the [code]--yes[/code]
     flag to skip the confirmation prompt.
 
     [bold][underline]Examples[/underline][/bold]
 
-    - Delete the version with the ID [magenta]v1[/magenta] from application [magenta]hare-app[/magenta].
-        $ [green]nextmv cloud version delete --app-id hare-app --version-id v1[/green]
+    - Delete the instance with the ID [magenta]prod[/magenta] from application [magenta]hare-app[/magenta].
+        $ [green]nextmv cloud instance delete --app-id hare-app --instance-id prod[/green]
 
-    - Delete the version without confirmation prompt.
-        $ [green]nextmv cloud version delete --app-id hare-app --version-id v1 --yes[/green]
+    - Delete the instance without confirmation prompt.
+        $ [green]nextmv cloud instance delete --app-id hare-app --instance-id prod --yes[/green]
     """
 
     if not yes:
         confirm = Confirm.ask(
-            f"Are you sure you want to delete version [magenta]{version_id}[/magenta] "
+            f"Are you sure you want to delete instance [magenta]{instance_id}[/magenta] "
             f"from application [magenta]{app_id}[/magenta]? This action cannot be undone.",
             default=False,
         )
 
         if not confirm:
-            info(msg=f"Version [magenta]{version_id}[/magenta] will not be deleted.", emoji=":bulb:")
+            info(msg=f"Instance [magenta]{instance_id}[/magenta] will not be deleted.", emoji=":bulb:")
             return
 
     cloud_app = build_app(app_id=app_id, profile=profile)
-    cloud_app.delete_version(version_id=version_id)
+    cloud_app.delete_instance(instance_id=instance_id)
     success(
-        f"Version [magenta]{version_id}[/magenta] deleted successfully from application [magenta]{app_id}[/magenta]."
+        f"Instance [magenta]{instance_id}[/magenta] deleted successfully from application [magenta]{app_id}[/magenta]."
     )

--- a/nextmv/nextmv/cli/cloud/instance/exists.py
+++ b/nextmv/nextmv/cli/cloud/instance/exists.py
@@ -1,0 +1,39 @@
+"""
+This module defines the cloud instance exists command for the Nextmv CLI.
+"""
+
+import typer
+
+from nextmv.cli.configuration.config import build_app
+from nextmv.cli.message import in_progress, print_json
+from nextmv.cli.options import AppIDOption, InstanceIDOption, ProfileOption
+
+# Set up subcommand application.
+app = typer.Typer()
+
+
+@app.command()
+def exists(
+    app_id: AppIDOption,
+    instance_id: InstanceIDOption,
+    profile: ProfileOption = None,
+) -> None:
+    """
+    Check if a Nextmv Cloud application instance exists.
+
+    This command is useful in scripting applications to verify the existence of
+    a Nextmv Cloud application instance by its ID.
+
+    [bold][underline]Examples[/underline][/bold]
+
+    - Check if the instance with the ID [magenta]prod[/magenta] exists in application [magenta]hare-app[/magenta].
+        $ [green]nextmv cloud instance exists --app-id hare-app --instance-id prod[/green]
+
+    - Check if the instance exists using the profile named [magenta]hare[/magenta].
+        $ [green]nextmv cloud instance exists --app-id hare-app --instance-id prod --profile hare[/green]
+    """
+
+    cloud_app = build_app(app_id=app_id, profile=profile)
+    in_progress(msg="Checking if instance exists...")
+    ok = cloud_app.instance_exists(instance_id=instance_id)
+    print_json({"exists": ok})

--- a/nextmv/nextmv/cli/cloud/instance/get.py
+++ b/nextmv/nextmv/cli/cloud/instance/get.py
@@ -1,0 +1,62 @@
+"""
+This module defines the cloud instance get command for the Nextmv CLI.
+"""
+
+import json
+from typing import Annotated
+
+import typer
+
+from nextmv.cli.configuration.config import build_app
+from nextmv.cli.message import in_progress, print_json, success
+from nextmv.cli.options import AppIDOption, InstanceIDOption, ProfileOption
+
+# Set up subcommand application.
+app = typer.Typer()
+
+
+@app.command()
+def get(
+    app_id: AppIDOption,
+    instance_id: InstanceIDOption,
+    output: Annotated[
+        str | None,
+        typer.Option(
+            "--output",
+            "-o",
+            help="Saves the instance information to this location.",
+            metavar="OUTPUT_PATH",
+        ),
+    ] = None,
+    profile: ProfileOption = None,
+) -> None:
+    """
+    Get a Nextmv Cloud application instance.
+
+    This command is useful to get the attributes of an existing Nextmv Cloud
+    application instance by its ID.
+
+    [bold][underline]Examples[/underline][/bold]
+
+    - Get the instance with the ID [magenta]prod[/magenta] from application [magenta]hare-app[/magenta].
+        $ [green]nextmv cloud instance get --app-id hare-app --instance-id prod[/green]
+
+    - Get the instance with the ID [magenta]prod[/magenta] and save the information to a
+      [magenta]instance.json[/magenta] file.
+        $ [green]nextmv cloud instance get --app-id hare-app --instance-id prod --output instance.json[/green]
+    """
+
+    cloud_app = build_app(app_id=app_id, profile=profile)
+    in_progress(msg="Getting instance...")
+    instance = cloud_app.instance(instance_id=instance_id)
+    instance_dict = instance.to_dict()
+
+    if output is not None:
+        with open(output, "w") as f:
+            json.dump(instance_dict, f, indent=2)
+
+        success(msg=f"Instance information saved to [magenta]{output}[/magenta].")
+
+        return
+
+    print_json(instance_dict)

--- a/nextmv/nextmv/cli/cloud/instance/list.py
+++ b/nextmv/nextmv/cli/cloud/instance/list.py
@@ -1,0 +1,60 @@
+"""
+This module defines the cloud instance list command for the Nextmv CLI.
+"""
+
+import json
+from typing import Annotated
+
+import typer
+
+from nextmv.cli.configuration.config import build_app
+from nextmv.cli.message import in_progress, print_json, success
+from nextmv.cli.options import AppIDOption, ProfileOption
+
+# Set up subcommand application.
+app = typer.Typer()
+
+
+@app.command()
+def list(
+    app_id: AppIDOption,
+    output: Annotated[
+        str | None,
+        typer.Option(
+            "--output",
+            "-o",
+            help="Saves the instance list information to this location.",
+            metavar="OUTPUT_PATH",
+        ),
+    ] = None,
+    profile: ProfileOption = None,
+) -> None:
+    """
+    List all instances of a Nextmv Cloud application.
+
+    [bold][underline]Examples[/underline][/bold]
+
+    - List all instances of application [magenta]hare-app[/magenta].
+        $ [green]nextmv cloud instance list --app-id hare-app[/green]
+
+    - List all instances using the profile named [magenta]hare[/magenta].
+        $ [green]nextmv cloud instance list --app-id hare-app --profile hare[/green]
+
+    - List all instances and save the information to a [magenta]instances.json[/magenta] file.
+        $ [green]nextmv cloud instance list --app-id hare-app --output instances.json[/green]
+    """
+
+    cloud_app = build_app(app_id=app_id, profile=profile)
+    in_progress(msg="Listing instances...")
+    instances = cloud_app.list_instances()
+    instances_dicts = [instance.to_dict() for instance in instances]
+
+    if output is not None:
+        with open(output, "w") as f:
+            json.dump(instances_dicts, f, indent=2)
+
+        success(msg=f"Instance list information saved to [magenta]{output}[/magenta].")
+
+        return
+
+    print_json(instances_dicts)

--- a/nextmv/nextmv/cli/cloud/instance/update.py
+++ b/nextmv/nextmv/cli/cloud/instance/update.py
@@ -58,14 +58,14 @@ def update(
         ),
     ] = None,
     # Options for updating the instance configuration.
-    content_type: Annotated[
+    content_format: Annotated[
         InputFormat | None,
         typer.Option(
-            "--content-type",
+            "--content-format",
             "-c",
-            help="The content type for the instance. Allowed values are: "
-            f"{[v.value for v in InputFormat.__members__.values()]}",
-            metavar="CONTENT_TYPE",
+            help="The content format for the instance. Allowed values are: "
+            f"[magenta]{[v.value for v in InputFormat.__members__.values()]}[/magenta].",
+            metavar="CONTENT_FORMAT",
             rich_help_panel="Instance configuration",
         ),
     ] = None,
@@ -162,7 +162,7 @@ def update(
     # Check if any configuration options are provided
     has_config_options = any(
         [
-            content_type is not None,
+            content_format is not None,
             execution_class is not None,
             integration_id is not None,
             no_queuing is not None,
@@ -187,7 +187,7 @@ def update(
         configuration = build_config(
             priority=priority,
             no_queuing=no_queuing,
-            content_type=content_type,
+            content_format=content_format,
             execution_class=execution_class,
             integration_id=integration_id,
             options=instance_options,

--- a/nextmv/nextmv/cli/cloud/instance/update.py
+++ b/nextmv/nextmv/cli/cloud/instance/update.py
@@ -1,0 +1,110 @@
+"""
+This module defines the cloud instance update command for the Nextmv CLI.
+"""
+
+import json
+from typing import Annotated
+
+import typer
+
+from nextmv.cli.configuration.config import build_app
+from nextmv.cli.message import error, print_json, success
+from nextmv.cli.options import AppIDOption, InstanceIDOption, ProfileOption
+
+# Set up subcommand application.
+app = typer.Typer()
+
+
+@app.command()
+def update(
+    app_id: AppIDOption,
+    instance_id: InstanceIDOption,
+    name: Annotated[
+        str | None,
+        typer.Option(
+            "--name",
+            "-n",
+            help="A new name for the instance.",
+            metavar="NAME",
+        ),
+    ] = None,
+    description: Annotated[
+        str | None,
+        typer.Option(
+            "--description",
+            "-d",
+            help="A new description for the instance.",
+            metavar="DESCRIPTION",
+        ),
+    ] = None,
+    version_id: Annotated[
+        str | None,
+        typer.Option(
+            "--version-id",
+            "-v",
+            help="Update the instance to use a different version.",
+            metavar="VERSION_ID",
+        ),
+    ] = None,
+    output: Annotated[
+        str | None,
+        typer.Option(
+            "--output",
+            "-o",
+            help="Saves the updated instance information to this location.",
+            metavar="OUTPUT_PATH",
+        ),
+    ] = None,
+    profile: ProfileOption = None,
+) -> None:
+    """
+    Updates a Nextmv Cloud application instance.
+
+    [bold][underline]Examples[/underline][/bold]
+
+    - Update an instance's name.
+        $ [green]nextmv cloud instance update --app-id hare-app --instance-id prod --name "Production Instance"[/green]
+
+    - Update an instance's description.
+        $ [green]nextmv cloud instance update --app-id hare-app --instance-id prod \\
+            --description "Instance for production routing jobs"[/green]
+
+    - Update an instance to use a different version.
+        $ [green]nextmv cloud instance update --app-id hare-app --instance-id prod --version-id v2[/green]
+
+    - Update an instance's name and description at once.
+        $ [green]nextmv cloud instance update --app-id hare-app --instance-id prod \\
+            --name "Production Instance" --description "Instance for production routing jobs"[/green]
+
+    - Update an instance and save the updated information to a [magenta]updated_instance.json[/magenta] file.
+        $ [green]nextmv cloud instance update --app-id hare-app --instance-id prod \\
+            --name "Production Instance" --output updated_instance.json[/green]
+    """
+
+    if name is None and description is None and version_id is None:
+        error(
+            "Provide at least one option to update: [code]--name[/code], [code]--description[/code], "
+            "or [code]--version-id[/code]."
+        )
+
+    cloud_app = build_app(app_id=app_id, profile=profile)
+    updated_instance = cloud_app.update_instance(
+        id=instance_id,
+        name=name,
+        description=description,
+        version_id=version_id,
+    )
+    success(
+        f"Instance [magenta]{instance_id}[/magenta] updated successfully in application [magenta]{app_id}[/magenta]."
+    )
+    updated_instance_dict = updated_instance.to_dict()
+
+    if output is not None:
+        with open(output, "w") as f:
+            json.dump(updated_instance_dict, f, indent=2)
+
+        success(msg=f"Updated instance information saved to [magenta]{output}[/magenta].")
+
+        return
+
+    print_json(updated_instance_dict)

--- a/nextmv/nextmv/cli/cloud/instance/update.py
+++ b/nextmv/nextmv/cli/cloud/instance/update.py
@@ -149,6 +149,14 @@ def update(
     - Update an instance and save the updated information to a [magenta]updated_instance.json[/magenta] file.
         $ [green]nextmv cloud instance update --app-id hare-app --instance-id prod \\
             --name "Production Instance" --output updated_instance.json[/green]
+
+    - Update an instance's execution class and priority.
+        $ [green]nextmv cloud instance update --app-id hare-app --instance-id prod \\
+            --execution-class 6c9500mb870s --priority 1[/green]
+
+    - Update an instance's runtime options.
+        $ [green]nextmv cloud instance update --app-id hare-app --instance-id prod \\
+            --options max_duration=30 --options timeout=60[/green]
     """
 
     # Check if any configuration options are provided

--- a/nextmv/nextmv/cli/cloud/instance/update.py
+++ b/nextmv/nextmv/cli/cloud/instance/update.py
@@ -7,9 +7,11 @@ from typing import Annotated
 
 import typer
 
+from nextmv.cli.cloud.instance.create import build_config, build_options
 from nextmv.cli.configuration.config import build_app
 from nextmv.cli.message import error, print_json, success
 from nextmv.cli.options import AppIDOption, InstanceIDOption, ProfileOption
+from nextmv.input import InputFormat
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -41,7 +43,7 @@ def update(
         str | None,
         typer.Option(
             "--output",
-            "-o",
+            "-u",
             help="Saves the updated instance information to this location.",
             metavar="OUTPUT_PATH",
         ),
@@ -53,6 +55,74 @@ def update(
             "-v",
             help="Update the instance to use a different version.",
             metavar="VERSION_ID",
+        ),
+    ] = None,
+    # Options for updating the instance configuration.
+    content_type: Annotated[
+        InputFormat | None,
+        typer.Option(
+            "--content-type",
+            "-c",
+            help="The content type for the instance. Allowed values are: "
+            f"{[v.value for v in InputFormat.__members__.values()]}",
+            metavar="CONTENT_TYPE",
+            rich_help_panel="Instance configuration",
+        ),
+    ] = None,
+    execution_class: Annotated[
+        str | None,
+        typer.Option(
+            "--execution-class",
+            "-x",
+            help="The execution class to use for the instance.",
+            metavar="EXECUTION_CLASS",
+            rich_help_panel="Instance configuration",
+        ),
+    ] = None,
+    integration_id: Annotated[
+        str | None,
+        typer.Option(
+            help="The integration ID to use for the runs of the instance, if applicable.",
+            metavar="INTEGRATION_ID",
+            rich_help_panel="Instance configuration",
+        ),
+    ] = None,
+    no_queuing: Annotated[
+        bool | None,
+        typer.Option(
+            "--no-queuing",
+            help="Do not queue when running the instance.",
+            rich_help_panel="Instance configuration",
+        ),
+    ] = None,
+    options: Annotated[
+        list[str] | None,
+        typer.Option(
+            "--options",
+            "-o",
+            help="Options to always use when running the instance. Format: [magenta]key=value[/magenta]. "
+            "Pass multiple options by repeating the flag, or separating with commas.",
+            metavar="KEY=VALUE",
+            rich_help_panel="Instance configuration",
+        ),
+    ] = None,
+    priority: Annotated[
+        int | None,
+        typer.Option(
+            help="The priority of the runs in the instance. "
+            "Priority is between 1 and 10, with 1 being the highest priority.",
+            metavar="PRIORITY",
+            rich_help_panel="Instance configuration",
+        ),
+    ] = None,
+    secret_collection_id: Annotated[
+        str | None,
+        typer.Option(
+            "--secret-collection-id",
+            "-s",
+            help="The secret collection ID to use for the instance, if applicable.",
+            metavar="SECRET_COLLECTION_ID",
+            rich_help_panel="Instance configuration",
         ),
     ] = None,
     profile: ProfileOption = None,
@@ -81,18 +151,47 @@ def update(
             --name "Production Instance" --output updated_instance.json[/green]
     """
 
-    if name is None and description is None and version_id is None:
+    # Check if any configuration options are provided
+    has_config_options = any(
+        [
+            content_type is not None,
+            execution_class is not None,
+            integration_id is not None,
+            no_queuing is not None,
+            options is not None,
+            priority is not None,
+            secret_collection_id is not None,
+        ]
+    )
+
+    if name is None and description is None and version_id is None and not has_config_options:
         error(
             "Provide at least one option to update: [code]--name[/code], [code]--description[/code], "
-            "or [code]--version-id[/code]."
+            "[code]--version-id[/code], or any [magenta]Instance configuration[/magenta] option."
         )
 
     cloud_app = build_app(app_id=app_id, profile=profile)
+
+    # Build configuration if any configuration options were provided.
+    configuration = None
+    if has_config_options:
+        instance_options = build_options(options)
+        configuration = build_config(
+            priority=priority,
+            no_queuing=no_queuing,
+            content_type=content_type,
+            execution_class=execution_class,
+            integration_id=integration_id,
+            options=instance_options,
+            secret_collection_id=secret_collection_id,
+        )
+
     updated_instance = cloud_app.update_instance(
         id=instance_id,
         name=name,
         description=description,
         version_id=version_id,
+        configuration=configuration,
     )
     success(
         f"Instance [magenta]{instance_id}[/magenta] updated successfully in application [magenta]{app_id}[/magenta]."

--- a/nextmv/nextmv/cli/cloud/instance/update.py
+++ b/nextmv/nextmv/cli/cloud/instance/update.py
@@ -19,15 +19,6 @@ app = typer.Typer()
 def update(
     app_id: AppIDOption,
     instance_id: InstanceIDOption,
-    name: Annotated[
-        str | None,
-        typer.Option(
-            "--name",
-            "-n",
-            help="A new name for the instance.",
-            metavar="NAME",
-        ),
-    ] = None,
     description: Annotated[
         str | None,
         typer.Option(
@@ -37,13 +28,13 @@ def update(
             metavar="DESCRIPTION",
         ),
     ] = None,
-    version_id: Annotated[
+    name: Annotated[
         str | None,
         typer.Option(
-            "--version-id",
-            "-v",
-            help="Update the instance to use a different version.",
-            metavar="VERSION_ID",
+            "--name",
+            "-n",
+            help="A new name for the instance.",
+            metavar="NAME",
         ),
     ] = None,
     output: Annotated[
@@ -53,6 +44,15 @@ def update(
             "-o",
             help="Saves the updated instance information to this location.",
             metavar="OUTPUT_PATH",
+        ),
+    ] = None,
+    version_id: Annotated[
+        str | None,
+        typer.Option(
+            "--version-id",
+            "-v",
+            help="Update the instance to use a different version.",
+            metavar="VERSION_ID",
         ),
     ] = None,
     profile: ProfileOption = None,

--- a/nextmv/nextmv/cli/cloud/run/create.py
+++ b/nextmv/nextmv/cli/cloud/run/create.py
@@ -443,7 +443,7 @@ def build_run_options(options: list[str] | None) -> dict[str, str]:
         return None
 
     run_options = {}
-    for opt in options or []:
+    for opt in options:
         # It is possible to pass multiple options separated by commas. The
         # default way though is to use the flag multiple times to specify
         # different options.

--- a/nextmv/nextmv/cli/cloud/run/create.py
+++ b/nextmv/nextmv/cli/cloud/run/create.py
@@ -83,14 +83,14 @@ def create(
         ),
     ] = False,
     # Options for run configuration.
-    content_type: Annotated[
+    content_format: Annotated[
         InputFormat | None,
         typer.Option(
-            "--content-type",
+            "--content-format",
             "-c",
-            help="The content type of the run to create. Allowed values are: "
-            f"{[v.value for v in InputFormat.__members__.values()]}",
-            metavar="CONTENT_TYPE",
+            help="The content format of the run to create. Allowed values are: "
+            f"[magenta]{[v.value for v in InputFormat.__members__.values()]}[/magenta].",
+            metavar="CONTENT_FORMAT",
             rich_help_panel="Run configuration",
         ),
     ] = None,
@@ -299,7 +299,7 @@ def create(
         priority=priority,
         no_queuing=no_queuing,
         execution_class=execution_class,
-        content_type=content_type,
+        content_format=content_format,
         secret_collection_id=secret_collection_id,
         integration_id=integration_id,
         definition_id=definition_id,
@@ -362,7 +362,7 @@ def build_run_config(
     priority: int,
     no_queuing: bool,
     execution_class: str | None = None,
-    content_type: InputFormat | None = None,
+    content_format: InputFormat | None = None,
     secret_collection_id: str | None = None,
     integration_id: str | None = None,
     definition_id: str | None = None,
@@ -380,8 +380,8 @@ def build_run_config(
         Whether to disable queuing for the run.
     execution_class : str | None
         The execution class to use for the run, if applicable.
-    content_type : InputFormat | None
-        The content type of the run to create, if applicable.
+    content_format : InputFormat | None
+        The content format of the run to create, if applicable.
     secret_collection_id : str | None
         The secret collection ID to use for the run, if applicable.
     integration_id : str | None
@@ -406,10 +406,10 @@ def build_run_config(
     )
     if execution_class is not None:
         config.execution_class = execution_class
-    if content_type is not None:
+    if content_format is not None:
         config.format = Format(
             format_input=FormatInput(
-                input_type=InputFormat(content_type),
+                input_type=InputFormat(content_format),
             ),
         )
     if secret_collection_id is not None:

--- a/nextmv/nextmv/cli/cloud/run/create.py
+++ b/nextmv/nextmv/cli/cloud/run/create.py
@@ -439,6 +439,9 @@ def build_run_options(options: list[str] | None) -> dict[str, str]:
         The built run options.
     """
 
+    if options is None:
+        return None
+
     run_options = {}
     for opt in options or []:
         # It is possible to pass multiple options separated by commas. The

--- a/nextmv/nextmv/cli/cloud/run/get.py
+++ b/nextmv/nextmv/cli/cloud/run/get.py
@@ -153,13 +153,13 @@ def handle_outputs(
 
     # Get the run metadata to determine how to operate with the output.
     run_info = cloud_app.run_metadata(run_id=run_id)
-    content_type = run_info.metadata.format.format_output.output_type
+    content_format = run_info.metadata.format.format_output.output_type
 
     # Build kwargs for the result retrieval.
     kwargs = {"run_id": run_id}
 
     # For MULTI_FILE and CSV_ARCHIVE, we need output_dir_path.
-    if content_type not in {OutputFormat.JSON, OutputFormat.TEXT}:
+    if content_format not in {OutputFormat.JSON, OutputFormat.TEXT}:
         output_dir = f"{run_id}-output" if output is None or output == "" else output
         kwargs["output_dir_path"] = output_dir
 
@@ -174,7 +174,7 @@ def handle_outputs(
         run_result = cloud_app.run_result(**kwargs)
 
     # Handle the case where output is embedded directly in the result: json and text.
-    if content_type in {OutputFormat.JSON, OutputFormat.TEXT}:
+    if content_format in {OutputFormat.JSON, OutputFormat.TEXT}:
         if output is None or output == "":
             print_json(run_result.to_dict())
         else:

--- a/nextmv/nextmv/cli/cloud/run/track.py
+++ b/nextmv/nextmv/cli/cloud/run/track.py
@@ -31,7 +31,7 @@ def track(
             "-o",
             help="The output of the run being tracked. A file or directory depending on content type.",
             metavar="OUTPUT_PATH",
-            rich_help_panel="Tracked run control",
+            rich_help_panel="Tracked run configuration",
         ),
     ],
     status: Annotated[
@@ -42,7 +42,7 @@ def track(
             help="Status of the tracked run. Allowed values are: "
             f"{[v.value for v in TrackedRunStatus.__members__.values()]}",
             metavar="STATUS",
-            rich_help_panel="Tracked run control",
+            rich_help_panel="Tracked run configuration",
         ),
     ],
     assets: Annotated[
@@ -50,7 +50,7 @@ def track(
         typer.Option(
             help="The assets of the run being tracked. A [magenta]json[/magenta] file to read the assets from.",
             metavar="ASSETS_PATH",
-            rich_help_panel="Tracked run control",
+            rich_help_panel="Tracked run configuration",
         ),
     ] = None,
     content_type: Annotated[
@@ -61,7 +61,7 @@ def track(
             help="The content type of the run to track. Allowed values are: "
             f"{[v.value for v in InputFormat.__members__.values()]}",
             metavar="CONTENT_TYPE",
-            rich_help_panel="Tracked run control",
+            rich_help_panel="Tracked run configuration",
         ),
     ] = InputFormat.JSON,
     description: Annotated[
@@ -69,7 +69,7 @@ def track(
         typer.Option(
             help="An optional description for the tracked run.",
             metavar="DESCRIPTION",
-            rich_help_panel="Tracked run control",
+            rich_help_panel="Tracked run configuration",
         ),
     ] = None,
     duration: Annotated[
@@ -79,7 +79,7 @@ def track(
             "-d",
             help="The duration of the run being tracked, in milliseconds.",
             metavar="DURATION_MS",
-            rich_help_panel="Tracked run control",
+            rich_help_panel="Tracked run configuration",
         ),
     ] = 0,
     error_msg: Annotated[
@@ -89,7 +89,7 @@ def track(
             "-e",
             help="An error message if the run being tracked failed.",
             metavar="ERROR_MESSAGE",
-            rich_help_panel="Tracked run control",
+            rich_help_panel="Tracked run configuration",
         ),
     ] = None,
     input: Annotated[
@@ -100,7 +100,7 @@ def track(
             help="The input of the run being tracked. File or directory depending on content type. "
             "Uses [magenta]stdin[/magenta] if not defined.",
             metavar="INPUT_PATH",
-            rich_help_panel="Tracked run control",
+            rich_help_panel="Tracked run configuration",
         ),
     ] = None,
     logs: Annotated[
@@ -110,7 +110,7 @@ def track(
             "-l",
             help="The logs of the run being tracked. A utf-8 encoded text file to read the logs from.",
             metavar="LOGS_PATH",
-            rich_help_panel="Tracked run control",
+            rich_help_panel="Tracked run configuration",
         ),
     ] = None,
     name: Annotated[
@@ -120,7 +120,7 @@ def track(
             "-n",
             help="An optional name for the tracked run.",
             metavar="NAME",
-            rich_help_panel="Tracked run control",
+            rich_help_panel="Tracked run configuration",
         ),
     ] = None,
     statistics: Annotated[
@@ -128,7 +128,7 @@ def track(
         typer.Option(
             help="The statistics of the run being tracked. A [magenta]json[/magenta] file to read the statistics from.",
             metavar="STATISTICS_PATH",
-            rich_help_panel="Tracked run control",
+            rich_help_panel="Tracked run configuration",
         ),
     ] = None,
     # Options for run configuration.

--- a/nextmv/nextmv/cli/cloud/run/track.py
+++ b/nextmv/nextmv/cli/cloud/run/track.py
@@ -53,14 +53,14 @@ def track(
             rich_help_panel="Tracked run configuration",
         ),
     ] = None,
-    content_type: Annotated[
+    content_format: Annotated[
         InputFormat | None,
         typer.Option(
-            "--content-type",
+            "--content-format",
             "-c",
-            help="The content type of the run to track. Allowed values are: "
-            f"{[v.value for v in InputFormat.__members__.values()]}",
-            metavar="CONTENT_TYPE",
+            help="The content format of the run to track. Allowed values are: "
+            f"[magenta]{[v.value for v in InputFormat.__members__.values()]}[/magenta].",
+            metavar="CONTENT_FORMAT",
             rich_help_panel="Tracked run configuration",
         ),
     ] = InputFormat.JSON,
@@ -233,7 +233,7 @@ def track(
         run_type=RunType.EXTERNAL,
         priority=6,
         no_queuing=False,
-        content_type=content_type,
+        content_format=content_format,
     )
 
     # Handles the default instance.
@@ -249,7 +249,7 @@ def track(
         description=description,
         stdin=stdin,
         input=input,
-        content_type=content_type,
+        content_format=content_format,
         output=output,
         assets=assets,
         logs=logs,
@@ -275,7 +275,7 @@ def build_tracked_run_input(
     description: str | None,
     stdin: str | None,
     input: str | None,
-    content_type: InputFormat,
+    content_format: InputFormat,
     output: str,
     assets: str | None = None,
     logs: str | None = None,
@@ -304,8 +304,8 @@ def build_tracked_run_input(
         The input provided via stdin, if any.
     input : str | None
         The input file or directory path, if any.
-    content_type : InputFormat
-        The content type of the input (json or text).
+    content_format : InputFormat
+        The content format of the input (json or text).
     output : str
         The output file or directory path.
     assets : str | None
@@ -326,12 +326,12 @@ def build_tracked_run_input(
         tracked_run=tracked_run,
         stdin=stdin,
         input=input,
-        content_type=content_type,
+        content_format=content_format,
     )
     tracked_run = resolve_output(
         tracked_run=tracked_run,
         output=output,
-        content_type=content_type,
+        content_format=content_format,
     )
 
     # Handle the assets, which should be a JSON file.
@@ -365,7 +365,7 @@ def resolve_input(
     tracked_run: TrackedRun,
     stdin: str | None,
     input: str | None,
-    content_type: InputFormat,
+    content_format: InputFormat,
 ) -> TrackedRun:
     """
     Resolves the input for the tracked run, either from stdin or from a
@@ -379,8 +379,8 @@ def resolve_input(
         The input provided via stdin, if any.
     input : str | None
         The input file or directory path, if any.
-    content_type : InputFormat
-        The content type of the input (json or text).
+    content_format : InputFormat
+        The content format of the input (json or text).
 
     Returns
     -------
@@ -391,20 +391,20 @@ def resolve_input(
         # Handle the case where stdin is provided as JSON for a JSON app.
         try:
             input_data = json.loads(stdin)
-            if content_type != InputFormat.JSON:
+            if content_format != InputFormat.JSON:
                 error(
                     "Input provided via [magenta]stdin[/magenta] is [magenta]json[/magenta], "
-                    f"but the specified content type is {content_type.value}. "
-                    "[code]--content-type[/code] should be set to [magenta]json[/magenta]."
+                    f"but the specified content format is {content_format.value}. "
+                    "[code]--content-format[/code] should be set to [magenta]json[/magenta]."
                 )
 
         except json.JSONDecodeError:
             input_data = stdin
-            if content_type != InputFormat.TEXT:
+            if content_format != InputFormat.TEXT:
                 error(
                     "Input provided via [magenta]stdin[/magenta] is [magenta]text[/magenta], "
-                    f"but the specified content type is {content_type.value}. "
-                    "[code]--content-type[/code] should be set to [magenta]text[/magenta]."
+                    f"but the specified content format is {content_format.value}. "
+                    "[code]--content-format[/code] should be set to [magenta]text[/magenta]."
                 )
 
         tracked_run.input = input_data
@@ -416,7 +416,7 @@ def resolve_input(
     input_path = Path(input)
 
     if input_path.is_file():
-        if content_type == InputFormat.JSON:
+        if content_format == InputFormat.JSON:
             try:
                 with input_path.open("r") as f:
                     input_data = json.load(f)
@@ -428,14 +428,14 @@ def resolve_input(
             except json.JSONDecodeError as e:
                 error(f"Failed to parse input file [magenta]{input}[/magenta] as [magenta]json[/magenta]: {e}.")
 
-        elif content_type == InputFormat.TEXT:
+        elif content_format == InputFormat.TEXT:
             input_data = input_path.read_text()
             tracked_run.input = input_data
 
             return tracked_run
 
         else:
-            error(f"Unsupported content type [magenta]{content_type.value}[/magenta] for file input.")
+            error(f"Unsupported content format [magenta]{content_format.value}[/magenta] for file input.")
 
     # If the input is a directory, we give the path directly to the run method.
     # Internally, the files will be tarred and uploaded.
@@ -450,7 +450,7 @@ def resolve_input(
 def resolve_output(
     tracked_run: TrackedRun,
     output: str,
-    content_type: InputFormat,
+    content_format: InputFormat,
 ) -> TrackedRun:
     """
     Resolves the output for the tracked run.
@@ -461,8 +461,8 @@ def resolve_output(
         The tracked run to set the output for.
     output : str
         The output file or directory path.
-    content_type : InputFormat
-        The content type of the output (json or text).
+    content_format : InputFormat
+        The content format of the output (json or text).
 
     Returns
     -------
@@ -472,7 +472,7 @@ def resolve_output(
 
     output_path = Path(output)
     if output_path.is_file():
-        if content_type == InputFormat.JSON:
+        if content_format == InputFormat.JSON:
             try:
                 with output_path.open("r") as f:
                     output_data = json.load(f)
@@ -484,14 +484,14 @@ def resolve_output(
             except json.JSONDecodeError as e:
                 error(f"Failed to parse output file [magenta]{output}[/magenta] as [magenta]json[/magenta]: {e}.")
 
-        elif content_type == InputFormat.TEXT:
+        elif content_format == InputFormat.TEXT:
             output_data = output_path.read_text()
             tracked_run.output = output_data
 
             return tracked_run
 
         else:
-            error(f"Unsupported content type [magenta]{content_type.value}[/magenta] for file output.")
+            error(f"Unsupported content type [magenta]{content_format.value}[/magenta] for file output.")
 
     # If the output is a directory, we give the path directly to the run method.
     # Internally, the files will be downloaded and extracted.

--- a/nextmv/nextmv/cli/cloud/version/create.py
+++ b/nextmv/nextmv/cli/cloud/version/create.py
@@ -17,15 +17,6 @@ app = typer.Typer()
 @app.command()
 def create(
     app_id: AppIDOption,
-    name: Annotated[
-        str | None,
-        typer.Option(
-            "--name",
-            "-n",
-            help="A name for the version. If a name is not provided, the version ID will be used as the name.",
-            metavar="NAME",
-        ),
-    ] = None,
     description: Annotated[
         str | None,
         typer.Option(
@@ -43,6 +34,15 @@ def create(
             help="If a version with the given ID already exists, do not raise an error, and simply return it.",
         ),
     ] = False,
+    name: Annotated[
+        str | None,
+        typer.Option(
+            "--name",
+            "-n",
+            help="A name for the version. If a name is not provided, the version ID will be used as the name.",
+            metavar="NAME",
+        ),
+    ] = None,
     version_id: Annotated[
         str | None,
         typer.Option(

--- a/nextmv/nextmv/cli/cloud/version/update.py
+++ b/nextmv/nextmv/cli/cloud/version/update.py
@@ -19,15 +19,6 @@ app = typer.Typer()
 def update(
     app_id: AppIDOption,
     version_id: VersionIDOption,
-    name: Annotated[
-        str | None,
-        typer.Option(
-            "--name",
-            "-n",
-            help="A new name for the version.",
-            metavar="NAME",
-        ),
-    ] = None,
     description: Annotated[
         str | None,
         typer.Option(
@@ -35,6 +26,15 @@ def update(
             "-d",
             help="A new description for the version.",
             metavar="DESCRIPTION",
+        ),
+    ] = None,
+    name: Annotated[
+        str | None,
+        typer.Option(
+            "--name",
+            "-n",
+            help="A new name for the version.",
+            metavar="NAME",
         ),
     ] = None,
     output: Annotated[

--- a/nextmv/nextmv/cli/configuration/create.py
+++ b/nextmv/nextmv/cli/configuration/create.py
@@ -33,6 +33,14 @@ def create(
             metavar="NEXTMV_API_KEY",
         ),
     ],
+    endpoint: Annotated[  # Hidden because it is meant for internal use.
+        str | None,
+        typer.Option(
+            "--endpoint",
+            "-e",
+            hidden=True,
+        ),
+    ] = DEFAULT_ENDPOINT,
     profile: Annotated[  # Similar to nextmv.cli.options.ProfileOption but with different help text.
         str | None,
         typer.Option(
@@ -43,14 +51,6 @@ def create(
             metavar="PROFILE_NAME",
         ),
     ] = None,
-    endpoint: Annotated[  # Hidden because it is meant for internal use.
-        str | None,
-        typer.Option(
-            "--endpoint",
-            "-e",
-            hidden=True,
-        ),
-    ] = DEFAULT_ENDPOINT,
 ) -> None:
     """
     Create a new configuration or update an existing one.

--- a/nextmv/nextmv/cli/configuration/delete.py
+++ b/nextmv/nextmv/cli/configuration/delete.py
@@ -53,7 +53,7 @@ def delete(
 
     if not yes:
         confirm = Confirm.ask(
-            f"Are you sure you want to delete profile [magenta]{profile}[/magenta]? This action cannot be undone",
+            f"Are you sure you want to delete profile [magenta]{profile}[/magenta]? This action cannot be undone.",
             default=False,
         )
 

--- a/nextmv/nextmv/cli/options.py
+++ b/nextmv/nextmv/cli/options.py
@@ -64,3 +64,17 @@ VersionIDOption = Annotated[
         metavar="VERSION_ID",
     ),
 ]
+
+# instance_id option - can be used in any command that requires an instance ID.
+# Define it as follows in commands or callbacks, as necessary:
+# instance_id: InstanceIDOption
+InstanceIDOption = Annotated[
+    str,
+    typer.Option(
+        "--instance-id",
+        "-i",
+        help="The Nextmv Cloud instance ID to use for this action.",
+        envvar="NEXTMV_INSTANCE_ID",
+        metavar="INSTANCE_ID",
+    ),
+]

--- a/nextmv/nextmv/cloud/application.py
+++ b/nextmv/nextmv/cloud/application.py
@@ -659,6 +659,32 @@ class Application(BaseModel):
             endpoint=f"{self.ensembles_endpoint}/{ensemble_definition_id}",
         )
 
+    def delete_instance(self, instance_id: str) -> None:
+        """
+        Delete an instance.
+
+        Permanently removes the specified instance from the application.
+
+        Parameters
+        ----------
+        instance_id : str
+            ID of the instance to delete.
+
+        Raises
+        ------
+        requests.HTTPError
+            If the response status code is not 2xx.
+
+        Examples
+        --------
+        >>> app.delete_instance("prod-instance")  # Permanently deletes the instance
+        """
+
+        _ = self.client.request(
+            method="DELETE",
+            endpoint=f"{self.endpoint}/instances/{instance_id}",
+        )
+
     def delete_scenario_test(self, scenario_test_id: str) -> None:
         """
         Delete a scenario test.
@@ -1690,8 +1716,8 @@ class Application(BaseModel):
     def new_instance(
         self,
         version_id: str,
-        id: str,
-        name: str,
+        id: str | None = None,
+        name: str | None = None,
         description: str | None = None,
         configuration: InstanceConfiguration | None = None,
         exist_ok: bool = False,
@@ -1699,16 +1725,17 @@ class Application(BaseModel):
         """
         Create a new instance and associate it with a version.
 
-        This method creates a new instance associated with a specific version of the application.
-        Instances are configurations of an application version that can be executed.
+        This method creates a new instance associated with a specific version
+        of the application. Instances are configurations of an application
+        version that can be executed.
 
         Parameters
         ----------
         version_id : str
             ID of the version to associate the instance with.
-        id : str
+        id : str | None, default=None
             ID of the instance. Will be generated if not provided.
-        name : str
+        name : str | None, default=None
             Name of the instance. Will be generated if not provided.
         description : Optional[str], default=None
             Description of the instance.
@@ -1750,14 +1777,17 @@ class Application(BaseModel):
         if exist_ok and self.instance_exists(instance_id=id):
             return self.instance(instance_id=id)
 
+        if id is None:
+            id = safe_id(prefix="instance")
+        if name is None:
+            name = id
+
         payload = {
+            "id": id,
+            "name": name,
             "version_id": version_id,
         }
 
-        if id is not None:
-            payload["id"] = id
-        if name is not None:
-            payload["name"] = name
         if description is not None:
             payload["description"] = description
         if configuration is not None:

--- a/nextmv/nextmv/cloud/instance.py
+++ b/nextmv/nextmv/cloud/instance.py
@@ -86,7 +86,10 @@ class InstanceConfiguration(BaseModel):
         self.execution_class = integration_val
 
         # Processes the format to ensure only format_input is set.
-        final_format = Format(format_input=self.format.format_input) if self.format else None
+        if self.format is not None and self.format.format_input is not None:
+            final_format = Format(format_input=self.format.format_input)
+        else:
+            final_format = None
         self.format = final_format
 
 

--- a/nextmv/nextmv/cloud/instance.py
+++ b/nextmv/nextmv/cloud/instance.py
@@ -15,7 +15,7 @@ Instance
 from datetime import datetime
 
 from nextmv.base_model import BaseModel
-from nextmv.run import RunQueuing
+from nextmv.run import Format, RunQueuing
 
 
 class InstanceConfiguration(BaseModel):
@@ -54,6 +54,9 @@ class InstanceConfiguration(BaseModel):
 
     execution_class: str | None = None
     """Execution class for the instance."""
+    format: Format | None = None
+    """Input format for the instance, if applicable. When configuring an
+    instance, only the `format.format_input` attribute is used."""
     options: dict | None = None
     """Options of the app that the instance uses."""
     secrets_collection_id: str | None = None
@@ -81,6 +84,10 @@ class InstanceConfiguration(BaseModel):
             raise ValueError(f"When integration_id is set, execution_class must be `{integration_val}` or None.")
 
         self.execution_class = integration_val
+
+        # Processes the format to ensure only format_input is set.
+        final_format = Format(format_input=self.format.format_input) if self.format else None
+        self.format = final_format
 
 
 class Instance(BaseModel):

--- a/nextmv/nextmv/input.py
+++ b/nextmv/nextmv/input.py
@@ -77,8 +77,6 @@ class InputFormat(str, Enum):
     """JSON format, utf-8 encoded."""
     TEXT = "text"
     """Text format, utf-8 encoded."""
-    CSV = "csv"
-    """CSV format, utf-8 encoded."""
     CSV_ARCHIVE = "csv-archive"
     """CSV archive format: multiple CSV files."""
     MULTI_FILE = "multi-file"
@@ -376,8 +374,6 @@ class Input:
        means that the data must be JSON-deserializable, which includes dicts and
        lists.
     - `InputFormat.TEXT`: the data is `str`, and it must be utf-8 encoded.
-    - `InputFormat.CSV`: the data is `list[dict[str, Any]]`, where each dict
-       represents a row in the CSV.
     - `InputFormat.CSV_ARCHIVE`: the data is `dict[str, list[dict[str, Any]]]`,
        where each key is the name of a CSV file and the value is a list of dicts
        representing the rows in that CSV file.
@@ -464,12 +460,6 @@ class Input:
             raise ValueError(
                 f"unsupported Input.data type: {type(self.data)} with "
                 "input_format InputFormat.TEXT, supported type is `str`"
-            )
-
-        elif self.input_format == InputFormat.CSV and not isinstance(self.data, list):
-            raise ValueError(
-                f"unsupported Input.data type: {type(self.data)} with "
-                "input_format InputFormat.CSV, supported type is `list`"
             )
 
         elif self.input_format == InputFormat.CSV_ARCHIVE and not isinstance(self.data, dict):
@@ -607,8 +597,6 @@ class LocalInputLoader(InputLoader):
     >>> loader = LocalInputLoader()
     >>> # Load JSON from stdin or file
     >>> input_obj = loader.load(input_format=InputFormat.JSON, path="data.json")
-    >>> # Load CSV from a file
-    >>> input_obj = loader.load(input_format=InputFormat.CSV, path="data.csv")
     """
 
     def _read_text(path: str, _) -> str:
@@ -672,7 +660,6 @@ class LocalInputLoader(InputLoader):
     STDIN_READERS = {
         InputFormat.JSON: lambda _: json.load(sys.stdin),
         InputFormat.TEXT: lambda _: sys.stdin.read().rstrip("\n"),
-        InputFormat.CSV: lambda csv_configurations: list(csv.DictReader(sys.stdin, **csv_configurations)),
     }
     """
     Dictionary of functions to read from standard input.
@@ -687,7 +674,7 @@ class LocalInputLoader(InputLoader):
     FILE_READERS = {
         InputFormat.JSON: _read_json,
         InputFormat.TEXT: _read_text,
-        InputFormat.CSV: _read_csv,
+        "CSV": _read_csv,
     }
     """
     Dictionary of functions to read from files.
@@ -706,23 +693,23 @@ class LocalInputLoader(InputLoader):
     ) -> Input:
         """
         Load the input data. The input data can be in various formats. For
-        `InputFormat.JSON`, `InputFormat.TEXT`, and `InputFormat.CSV`, the data
-        can be streamed from stdin or read from a file. When the `path`
-        argument is provided (and valid), the input data is read from the file
-        specified by `path`, otherwise, it is streamed from stdin. For
-        `InputFormat.CSV_ARCHIVE`, the input data is read from the directory
-        specified by `path`. If the `path` is not provided, the default
-        location `input` is used. The directory should contain one or more
-        files, where each file in the directory is a CSV file.
+        `InputFormat.JSON` and `InputFormat.TEXT`, the data can be streamed
+        from stdin or read from a file. When the `path` argument is provided
+        (and valid), the input data is read from the file specified by `path`,
+        otherwise, it is streamed from stdin. For `InputFormat.CSV_ARCHIVE`,
+        the input data is read from the directory specified by `path`. If the
+        `path` is not provided, the default location `input` is used. The
+        directory should contain one or more files, where each file in the
+        directory is a CSV file.
 
         The `Input` that is returned contains the `data` attribute. This data
         can be of different types, depending on the provided `input_format`:
 
         - `InputFormat.JSON`: the data is a `dict[str, Any]`.
         - `InputFormat.TEXT`: the data is a `str`.
-        - `InputFormat.CSV`: the data is a `list[dict[str, Any]]`.
-        - `InputFormat.CSV_ARCHIVE`: the data is a `dict[str, list[dict[str, Any]]]`.
-          Each key is the name of the CSV file, minus the `.csv` extension.
+        - `InputFormat.CSV_ARCHIVE`: the data is a `dict[str, list[dict[str,
+          Any]]]`. Each key is the name of the CSV file, minus the `.csv`
+          extension.
         - `InputFormat.MULTI_FILE`: the data is a `dict[str, Any]`, where each
           key is the file name (with extension) and the value is the data read
           from the file. The data can be of any type, depending on the file
@@ -745,11 +732,11 @@ class LocalInputLoader(InputLoader):
             `input_format` is set to `InputFormat.MULTI_FILE`. Each `DataFile`
             instance should have a `name` (the file name with extension) and a
             `loader` function that reads the data from the file. The `loader`
-            function should accept the file path as its first argument and return
-            the data read from the file. The `loader` can also accept additional
-            positional and keyword arguments, which can be provided through the
-            `loader_args` and `loader_kwargs` attributes of the `DataFile`
-            instance.
+            function should accept the file path as its first argument and
+            return the data read from the file. The `loader` can also accept
+            additional positional and keyword arguments, which can be provided
+            through the `loader_args` and `loader_kwargs` attributes of the
+            `DataFile` instance.
 
         Returns
         -------
@@ -766,7 +753,7 @@ class LocalInputLoader(InputLoader):
         if csv_configurations is None:
             csv_configurations = {}
 
-        if input_format in [InputFormat.JSON, InputFormat.TEXT, InputFormat.CSV]:
+        if input_format in [InputFormat.JSON, InputFormat.TEXT]:
             data = self._load_utf8_encoded(path=path, input_format=input_format, csv_configurations=csv_configurations)
         elif input_format == InputFormat.CSV_ARCHIVE:
             data = self._load_archive(path=path, csv_configurations=csv_configurations)
@@ -785,7 +772,7 @@ class LocalInputLoader(InputLoader):
         self,
         csv_configurations: dict[str, Any] | None,
         path: str | None = None,
-        input_format: InputFormat | None = InputFormat.JSON,
+        input_format: InputFormat | str | None = InputFormat.JSON,
         use_file_reader: bool = False,
     ) -> dict[str, Any] | str | list[dict[str, Any]]:
         """
@@ -871,7 +858,7 @@ class LocalInputLoader(InputLoader):
                 stripped = file.removesuffix(csv_ext)
                 data[stripped] = self._load_utf8_encoded(
                     path=os.path.join(dir_path, file),
-                    input_format=InputFormat.CSV,
+                    input_format="CSV",
                     use_file_reader=True,
                     csv_configurations=csv_configurations,
                 )
@@ -1034,7 +1021,6 @@ def load(
 
     - `InputFormat.JSON`: the data is a `dict[str, Any]`
     - `InputFormat.TEXT`: the data is a `str`
-    - `InputFormat.CSV`: the data is a `list[dict[str, Any]]`
     - `InputFormat.CSV_ARCHIVE`: the data is a `dict[str, list[dict[str, Any]]]`
         Each key is the name of the CSV file, minus the `.csv` extension.
     - `InputFormat.MULTI_FILE`: the data is a `dict[str, Any]`
@@ -1119,8 +1105,6 @@ def load(
     >>> from nextmv.input import load, InputFormat
     >>> # Load JSON from stdin
     >>> input_obj = load(input_format=InputFormat.JSON)
-    >>> # Load CSV from a file
-    >>> input_obj = load(input_format=InputFormat.CSV, path="data.csv")
     >>> # Load CSV archive from a directory
     >>> input_obj = load(input_format=InputFormat.CSV_ARCHIVE, path="input_dir")
     """

--- a/nextmv/tests/test_input.py
+++ b/nextmv/tests/test_input.py
@@ -82,29 +82,6 @@ class TestInput(unittest.TestCase):
         self.assertEqual(input_data.data, "empanadas are life")
         self.assertIsNone(input_data.options)
 
-    def test_local_loader_csv_stdin(self):
-        sample_input = '"empanadas","are","life"\n1,2,3\n4,5,6'
-        input_loader = nextmv.LocalInputLoader()
-
-        with patch("sys.stdin", new=StringIO(sample_input)):
-            input_data = input_loader.load(
-                input_format=nextmv.InputFormat.CSV,
-                csv_configurations={
-                    "quoting": csv.QUOTE_NONNUMERIC,
-                },
-            )
-
-        self.assertIsInstance(input_data, nextmv.Input)
-        self.assertEqual(input_data.input_format, nextmv.InputFormat.CSV)
-        self.assertEqual(
-            list(input_data.data),
-            [
-                {"empanadas": 1.0, "are": 2.0, "life": 3.0},
-                {"empanadas": 4.0, "are": 5.0, "life": 6.0},
-            ],
-        )
-        self.assertIsNone(input_data.options)
-
     def test_local_loader_with_options(self):
         sample_input = '{"empanadas": "are_life"}\n'
         options = nextmv.Options(nextmv.Option("foo", str, default="bar", required=False))
@@ -141,30 +118,6 @@ class TestInput(unittest.TestCase):
         self.assertIsInstance(input_data, nextmv.Input)
         self.assertEqual(input_data.input_format, nextmv.InputFormat.TEXT)
         self.assertEqual(input_data.data, "empanadas are life")
-        self.assertIsNone(input_data.options)
-
-    def test_local_loader_csv_file(self):
-        sample_input = '"empanadas","are","life"\n1,2,3\n4,5,6'
-        input_loader = nextmv.LocalInputLoader()
-
-        with patch("builtins.open", return_value=StringIO(sample_input)):
-            input_data = input_loader.load(
-                input_format=nextmv.InputFormat.CSV,
-                path="input.csv",
-                csv_configurations={
-                    "quoting": csv.QUOTE_NONNUMERIC,
-                },
-            )
-
-        self.assertIsInstance(input_data, nextmv.Input)
-        self.assertEqual(input_data.input_format, nextmv.InputFormat.CSV)
-        self.assertEqual(
-            list(input_data.data),
-            [
-                {"empanadas": 1.0, "are": 2.0, "life": 3.0},
-                {"empanadas": 4.0, "are": 5.0, "life": 6.0},
-            ],
-        )
         self.assertIsNone(input_data.options)
 
     def test_local_loader_csv_archive_default_dir(self):


### PR DESCRIPTION
# Description

Adds the `nextmv cloud instance` command tree with the following subcommands:

- `create`
- `delete`
- `exists`
- `get`
- `list`
- `update`

Additionally, the following mandatory changes were introduced:

- Deletes `InputFormat.CSV` as it was showing in `cloud` commands and it is not a thing, at all, in our Platform
- Adds a missing attribute to the configuration of an instance: `format`.
- Adds missing CRUD operation to instances in the `cloud.Application` class: `delete_instance`.
- Refactors some CLI commands so that the options are in alphabetical order.
- Corrects the behavior of  `cloud.Application.update_instance` to automatically generate an ID and name and make them truly optional. In summary, we turn the `PUT` operation in to a `PATCH` operation.