### PR TITLE
Adds the `nextmv cloud secrets` command tree

### DIFF
--- a/nextmv/nextmv/cli/cloud/__init__.py
+++ b/nextmv/nextmv/cli/cloud/__init__.py
@@ -7,6 +7,7 @@ import typer
 from nextmv.cli.cloud.app import app as app_app
 from nextmv.cli.cloud.instance import app as instance_app
 from nextmv.cli.cloud.run import app as run_app
+from nextmv.cli.cloud.secrets import app as secrets_app
 from nextmv.cli.cloud.upload import app as upload_app
 from nextmv.cli.cloud.version import app as version_app
 
@@ -15,6 +16,7 @@ app = typer.Typer()
 app.add_typer(app_app, name="app")
 app.add_typer(instance_app, name="instance")
 app.add_typer(run_app, name="run")
+app.add_typer(secrets_app, name="secrets")
 app.add_typer(upload_app, name="upload")
 app.add_typer(version_app, name="version")
 

--- a/nextmv/nextmv/cli/cloud/instance/create.py
+++ b/nextmv/nextmv/cli/cloud/instance/create.py
@@ -7,7 +7,7 @@ from typing import Annotated
 import typer
 
 from nextmv.cli.configuration.config import build_app
-from nextmv.cli.message import error, in_progress, print_json
+from nextmv.cli.message import enum_values, error, in_progress, print_json
 from nextmv.cli.options import AppIDOption, ProfileOption, VersionIDOption
 from nextmv.cloud.instance import InstanceConfiguration
 from nextmv.input import InputFormat
@@ -64,8 +64,7 @@ def create(
         typer.Option(
             "--content-format",
             "-c",
-            help="The content format of the instance to create. Allowed values are: "
-            f"[magenta]{[v.value for v in InputFormat.__members__.values()]}[/magenta].",
+            help=f"The content format of the instance to create. Allowed values are: {enum_values(InputFormat)}.",
             metavar="CONTENT_FORMAT",
             rich_help_panel="Instance configuration",
         ),

--- a/nextmv/nextmv/cli/cloud/instance/update.py
+++ b/nextmv/nextmv/cli/cloud/instance/update.py
@@ -9,7 +9,7 @@ import typer
 
 from nextmv.cli.cloud.instance.create import build_config, build_options
 from nextmv.cli.configuration.config import build_app
-from nextmv.cli.message import error, print_json, success
+from nextmv.cli.message import enum_values, error, print_json, success
 from nextmv.cli.options import AppIDOption, InstanceIDOption, ProfileOption
 from nextmv.input import InputFormat
 
@@ -63,8 +63,7 @@ def update(
         typer.Option(
             "--content-format",
             "-c",
-            help="The content format for the instance. Allowed values are: "
-            f"[magenta]{[v.value for v in InputFormat.__members__.values()]}[/magenta].",
+            help=f"The content format for the instance. Allowed values are: {enum_values(InputFormat)}.",
             metavar="CONTENT_FORMAT",
             rich_help_panel="Instance configuration",
         ),

--- a/nextmv/nextmv/cli/cloud/run/create.py
+++ b/nextmv/nextmv/cli/cloud/run/create.py
@@ -13,7 +13,7 @@ import typer
 from nextmv.cli.cloud.run.get import handle_outputs
 from nextmv.cli.cloud.run.logs import handle_logs
 from nextmv.cli.configuration.config import build_app
-from nextmv.cli.message import error, print_json, success
+from nextmv.cli.message import enum_values, error, print_json, success
 from nextmv.cli.options import AppIDOption, ProfileOption
 from nextmv.cloud.application import Application
 from nextmv.input import InputFormat
@@ -88,8 +88,7 @@ def create(
         typer.Option(
             "--content-format",
             "-c",
-            help="The content format of the run to create. Allowed values are: "
-            f"[magenta]{[v.value for v in InputFormat.__members__.values()]}[/magenta].",
+            help=f"The content format of the run to create. Allowed values are: {enum_values(InputFormat)}.",
             metavar="CONTENT_FORMAT",
             rich_help_panel="Run configuration",
         ),
@@ -181,8 +180,7 @@ def create(
         typer.Option(
             "--run-type",
             "-r",
-            help=f"The type of run to create. Allowed values are: "
-            f"[magenta]{[v.value for v in RunType.__members__.values()]}[/magenta].",
+            help=f"The type of run to create. Allowed values are: {enum_values(RunType)}.",
             metavar="RUN_TYPE",
             rich_help_panel="Run configuration",
         ),

--- a/nextmv/nextmv/cli/cloud/run/create.py
+++ b/nextmv/nextmv/cli/cloud/run/create.py
@@ -181,7 +181,8 @@ def create(
         typer.Option(
             "--run-type",
             "-r",
-            help=f"The type of run to create. Allowed values are: {[v.value for v in RunType.__members__.values()]}",
+            help=f"The type of run to create. Allowed values are: "
+            f"[magenta]{[v.value for v in RunType.__members__.values()]}[/magenta].",
             metavar="RUN_TYPE",
             rich_help_panel="Run configuration",
         ),

--- a/nextmv/nextmv/cli/cloud/run/track.py
+++ b/nextmv/nextmv/cli/cloud/run/track.py
@@ -40,7 +40,7 @@ def track(
             "--status",
             "-s",
             help="Status of the tracked run. Allowed values are: "
-            f"{[v.value for v in TrackedRunStatus.__members__.values()]}",
+            f"[magenta]{[v.value for v in TrackedRunStatus.__members__.values()]}[/magenta].",
             metavar="STATUS",
             rich_help_panel="Tracked run configuration",
         ),

--- a/nextmv/nextmv/cli/cloud/run/track.py
+++ b/nextmv/nextmv/cli/cloud/run/track.py
@@ -11,7 +11,7 @@ import typer
 
 from nextmv.cli.cloud.run.create import build_run_config
 from nextmv.cli.configuration.config import build_app
-from nextmv.cli.message import error, in_progress, print_json
+from nextmv.cli.message import enum_values, error, in_progress, print_json
 from nextmv.cli.options import AppIDOption, ProfileOption
 from nextmv.input import InputFormat
 from nextmv.run import RunType, TrackedRun, TrackedRunStatus
@@ -39,8 +39,7 @@ def track(
         typer.Option(
             "--status",
             "-s",
-            help="Status of the tracked run. Allowed values are: "
-            f"[magenta]{[v.value for v in TrackedRunStatus.__members__.values()]}[/magenta].",
+            help=f"Status of the tracked run. Allowed values are: {enum_values(TrackedRunStatus)}.",
             metavar="STATUS",
             rich_help_panel="Tracked run configuration",
         ),
@@ -58,8 +57,7 @@ def track(
         typer.Option(
             "--content-format",
             "-c",
-            help="The content format of the run to track. Allowed values are: "
-            f"[magenta]{[v.value for v in InputFormat.__members__.values()]}[/magenta].",
+            help=f"The content format of the run to track. Allowed values are: {enum_values(InputFormat)}.",
             metavar="CONTENT_FORMAT",
             rich_help_panel="Tracked run configuration",
         ),

--- a/nextmv/nextmv/cli/cloud/secrets/__init__.py
+++ b/nextmv/nextmv/cli/cloud/secrets/__init__.py
@@ -1,0 +1,33 @@
+"""
+This module defines the cloud secrets command tree for the Nextmv CLI.
+"""
+
+import typer
+
+from nextmv.cli.cloud.secrets.create import app as create_app
+from nextmv.cli.cloud.secrets.delete import app as delete_app
+from nextmv.cli.cloud.secrets.get import app as get_app
+from nextmv.cli.cloud.secrets.list import app as list_app
+from nextmv.cli.cloud.secrets.update import app as update_app
+
+# Set up subcommand application.
+app = typer.Typer()
+app.add_typer(create_app)
+app.add_typer(delete_app)
+app.add_typer(get_app)
+app.add_typer(list_app)
+app.add_typer(update_app)
+
+
+@app.callback()
+def callback() -> None:
+    """
+    Create and manage Nextmv Cloud secrets collections.
+
+    A secret collection defines one or more secrets used by your optimization
+    model during execution. You can reference a secret collection either in an
+    application instance configuration, or directly when starting a run. The
+    platform then injects the secrets into the container during the
+    optimization run as environment variables and files.
+    """
+    pass

--- a/nextmv/nextmv/cli/cloud/secrets/create.py
+++ b/nextmv/nextmv/cli/cloud/secrets/create.py
@@ -1,0 +1,206 @@
+"""
+This module defines the cloud secrets create command for the Nextmv CLI.
+"""
+
+from typing import Annotated
+
+import typer
+
+from nextmv.cli.configuration.config import build_app
+from nextmv.cli.message import error, in_progress, print_json
+from nextmv.cli.options import AppIDOption, ProfileOption
+from nextmv.cloud.secrets import Secret, SecretType
+
+# Set up subcommand application.
+app = typer.Typer()
+
+
+@app.command()
+def create(
+    app_id: AppIDOption,
+    secrets: Annotated[
+        list[str],
+        typer.Option(
+            "--secrets",
+            "-e",
+            help="Secrets to configure in the app. Data should be valid [magenta]json[/magenta]. "
+            "Pass multiple secrets by repeating the flag, or providing a list of objects. "
+            "Allowed values for [magenta]type[/magenta] are: "
+            f"[magenta]{[v.value for v in SecretType.__members__.values()]}[/magenta]. "
+            "Object format: [magenta]{'type': type, 'location': location, 'value': value}[/magenta].",
+            metavar="SECRETS",
+        ),
+    ],
+    description: Annotated[
+        str | None,
+        typer.Option(
+            "--description",
+            "-d",
+            help="An optional description for the secrets collection.",
+            metavar="DESCRIPTION",
+        ),
+    ] = None,
+    name: Annotated[
+        str | None,
+        typer.Option(
+            "--name",
+            "-n",
+            help="A name for the secrets collection.",
+            metavar="NAME",
+        ),
+    ] = None,
+    secrets_collection_id: Annotated[
+        str | None,
+        typer.Option(
+            "--secrets-collection-id",
+            "-s",
+            help="The ID to assign to the new secrets collection. If not provided, a random ID will be generated.",
+            envvar="NEXTMV_SECRETS_COLLECTION_ID",
+            metavar="SECRETS_COLLECTION_ID",
+        ),
+    ] = None,
+    profile: ProfileOption = None,
+) -> None:
+    """
+    Create a new Nextmv Cloud secrets collection.
+
+    A secrets collection is a group of key-value pairs that can be used by
+    your application instances during execution. Each collection can contain
+    up to 20 secrets. Secrets are provided as JSON objects using the
+    [code]--secrets[/code] flag.
+
+    Each secret must include three fields:
+    - [magenta]type[/magenta]: Either [magenta]env[/magenta] or [magenta]file[/magenta],
+      which determines how the secret is injected into the runtime.
+    - [magenta]location[/magenta]: Where to place the secret.
+      - [magenta]env[/magenta]: the environment variable name. E.g.: [magenta]BURROW_ENTRANCE[/magenta].
+      - [magenta]file[/magenta]: the relative path from the execution
+        directory. E.g.: [magenta]licenses/burrow.entr[/magenta].
+    - [magenta]value[/magenta]: The secret value as text (limited to 1 KB).
+
+    You can provide secrets in three ways:
+    - A single secret as a [magenta]json[/magenta] object.
+    - Multiple secrets by repeating the [code]--secrets[/code] flag.
+    - Multiple secrets as a [magenta]json[/magenta] array in a single [code]--secrets[/code] flag.
+
+    The [code]--secrets-collection-id[/code] and [code]--name[/code] are optional.
+    If not provided, they will be automatically generated.
+
+    [bold][underline]Examples[/underline][/bold]
+
+    - Create a secrets collection with a single environment variable secret.
+        $ [green]nextmv cloud secrets create --app-id hare-app \\
+            --secrets '{"type": "env", "location": "API_KEY", "value": "secret-value"}'[/green]
+
+    - Create a secrets collection with multiple secrets by repeating the flag.
+        $ [green]nextmv cloud secrets create --app-id hare-app \\
+            --secrets '{"type": "env", "location": "API_KEY", "value": "secret-value"}' \\
+            --secrets '{"type": "env", "location": "DATABASE_URL", "value": "postgres://localhost"}'[/green]
+
+    - Create a secrets collection with multiple secrets in a single JSON array.
+        $ [green]nextmv cloud secrets create --app-id hare-app \\
+            --secrets '[{"type": "env", "location": "DB_USER", "value": "admin"}, {...}]'[/green]
+
+    - Create a secrets collection with custom ID, name, and description.
+        $ [green]nextmv cloud secrets create --app-id hare-app \\
+            --secrets-collection-id db-creds --name "Database Credentials" \\
+            --description "Production database credentials" \\
+            --secrets '{"type": "env", "location": "DB_USER", "value": "admin"}' \\
+            --secrets '{"type": "env", "location": "DB_PASS", "value": "secure123"}'[/green]
+
+    - Create a secrets collection with file-based secrets.
+        $ [green]nextmv cloud secrets create --app-id hare-app \\
+            --secrets-collection-id certs --name "Certificates" \\
+            --secrets '{"type": "file", "location": "licenses/acme.lic", "value": "LICENSE_CONTENT_HERE"}'[/green]
+
+    - Mix environment and file-based secrets.
+        $ [green]nextmv cloud secrets create --app-id hare-app \\
+            --secrets '{"type": "env", "location": "ACME_LICENSE_KEY", "value": "abc123"}' \\
+            --secrets '{"type": "file", "location": "config/app.conf", "value": "server=prod\\nport=8080"}'[/green]
+    """
+
+    if len(secrets) == 0:
+        error("No secrets provided. Use [code]--secret[/code] to provide secrets in [magenta]json[/magenta] format.")
+
+    cloud_app = build_app(app_id=app_id, profile=profile)
+    in_progress(msg="Creating secrets collection...")
+
+    # Build the secrets list from the CLI options
+    secrets_list = build_secrets(secrets)
+
+    collection = cloud_app.new_secrets_collection(
+        secrets=secrets_list,
+        id=secrets_collection_id,
+        name=name,
+        description=description,
+    )
+    print_json(collection.to_dict())
+
+
+def build_secrets(secrets: list[str]) -> list[Secret]:
+    """
+    Builds the secrets list from the CLI option(s).
+
+    Parameters
+    ----------
+    secrets : list[str]
+        List of secrets provided via the CLI.
+
+    Returns
+    -------
+    list[Secret]
+        The built secrets list.
+    """
+    import json
+
+    secrets_list = []
+
+    for secret_str in secrets:
+        try:
+            secret_data = json.loads(secret_str)
+
+            # Handle the case where the value is a list of secrets.
+            if isinstance(secret_data, list):
+                for ix, item in enumerate(secret_data):
+                    if item.get("type") is None or item.get("location") is None or item.get("value") is None:
+                        error(
+                            f"Invalid secret format at index [magenta]{ix}[/magenta] in "
+                            f"[magenta]{secret_str}[/magenta]. Each secret must have "
+                            "[magenta]type[/magenta], [magenta]location[/magenta], "
+                            "and [magenta]value[/magenta] fields."
+                        )
+
+                    secret = Secret(
+                        type=SecretType(item["type"]),
+                        location=item["location"],
+                        value=item["value"],
+                    )
+                    secrets_list.append(secret)
+
+            # Handle the case where the value is a single secret.
+            elif isinstance(secret_data, dict):
+                if (
+                    secret_data.get("type") is None
+                    or secret_data.get("location") is None
+                    or secret_data.get("value") is None
+                ):
+                    error(
+                        f"Invalid secret format in [magenta]{secret_str}[/magenta]. "
+                        "Each secret must have [magenta]type[/magenta], [magenta]location[/magenta], "
+                        "and [magenta]value[/magenta] fields."
+                    )
+
+                secret = Secret(
+                    type=SecretType(secret_data["type"]),
+                    location=secret_data["location"],
+                    value=secret_data["value"],
+                )
+                secrets_list.append(secret)
+
+            else:
+                error(f"Invalid secret format: [magenta]{secret_str}[/magenta]. Expected JSON object or array.")
+
+        except (json.JSONDecodeError, KeyError, ValueError) as e:
+            error(f"Invalid secret format: [magenta]{secret_str}[/magenta]. Error: {e}")
+
+    return secrets_list

--- a/nextmv/nextmv/cli/cloud/secrets/create.py
+++ b/nextmv/nextmv/cli/cloud/secrets/create.py
@@ -7,7 +7,7 @@ from typing import Annotated
 import typer
 
 from nextmv.cli.configuration.config import build_app
-from nextmv.cli.message import error, in_progress, print_json
+from nextmv.cli.message import enum_values, error, in_progress, print_json
 from nextmv.cli.options import AppIDOption, ProfileOption
 from nextmv.cloud.secrets import Secret, SecretType
 
@@ -26,7 +26,7 @@ def create(
             help="Secrets to configure in the app. Data should be valid [magenta]json[/magenta]. "
             "Pass multiple secrets by repeating the flag, or providing a list of objects. "
             "Allowed values for [magenta]type[/magenta] are: "
-            f"[magenta]{[v.value for v in SecretType.__members__.values()]}[/magenta]. "
+            f"{enum_values(SecretType)}. "
             "Object format: [magenta]{'type': type, 'location': location, 'value': value}[/magenta].",
             metavar="SECRETS",
         ),

--- a/nextmv/nextmv/cli/cloud/secrets/create.py
+++ b/nextmv/nextmv/cli/cloud/secrets/create.py
@@ -120,7 +120,7 @@ def create(
     """
 
     if len(secrets) == 0:
-        error("No secrets provided. Use [code]--secret[/code] to provide secrets in [magenta]json[/magenta] format.")
+        error("No secrets provided. Use [code]--secrets[/code] to provide secrets in [magenta]json[/magenta] format.")
 
     cloud_app = build_app(app_id=app_id, profile=profile)
     in_progress(msg="Creating secrets collection...")

--- a/nextmv/nextmv/cli/cloud/secrets/delete.py
+++ b/nextmv/nextmv/cli/cloud/secrets/delete.py
@@ -1,0 +1,67 @@
+"""
+This module defines the cloud secrets delete command for the Nextmv CLI.
+"""
+
+from typing import Annotated
+
+import typer
+from rich.prompt import Confirm
+
+from nextmv.cli.configuration.config import build_app
+from nextmv.cli.message import info, success
+from nextmv.cli.options import AppIDOption, ProfileOption, SecretsCollectionIDOption
+
+# Set up subcommand application.
+app = typer.Typer()
+
+
+@app.command()
+def delete(
+    app_id: AppIDOption,
+    secrets_collection_id: SecretsCollectionIDOption,
+    yes: Annotated[
+        bool,
+        typer.Option(
+            "--yes",
+            "-y",
+            help="Agree to deletion confirmation prompt. Useful for non-interactive sessions.",
+        ),
+    ] = False,
+    profile: ProfileOption = None,
+) -> None:
+    """
+    Deletes a Nextmv Cloud secrets collection.
+
+    This action is permanent and cannot be undone. Use the [code]--yes[/code]
+    flag to skip the confirmation prompt.
+
+    [bold][underline]Examples[/underline][/bold]
+
+    - Delete the secrets collection with the ID [magenta]api-keys[/magenta] from application
+      [magenta]hare-app[/magenta].
+        $ [green]nextmv cloud secrets delete --app-id hare-app --secrets-collection-id api-keys[/green]
+
+    - Delete the secrets collection without confirmation prompt.
+        $ [green]nextmv cloud secrets delete --app-id hare-app --secrets-collection-id api-keys --yes[/green]
+    """
+
+    if not yes:
+        confirm = Confirm.ask(
+            f"Are you sure you want to delete secrets collection [magenta]{secrets_collection_id}[/magenta] "
+            f"from application [magenta]{app_id}[/magenta]? This action cannot be undone.",
+            default=False,
+        )
+
+        if not confirm:
+            info(
+                msg=f"Secrets collection [magenta]{secrets_collection_id}[/magenta] will not be deleted.",
+                emoji=":bulb:",
+            )
+            return
+
+    cloud_app = build_app(app_id=app_id, profile=profile)
+    cloud_app.delete_secrets_collection(secrets_collection_id=secrets_collection_id)
+    success(
+        f"Secrets collection [magenta]{secrets_collection_id}[/magenta] deleted successfully "
+        f"from application [magenta]{app_id}[/magenta]."
+    )

--- a/nextmv/nextmv/cli/cloud/secrets/get.py
+++ b/nextmv/nextmv/cli/cloud/secrets/get.py
@@ -1,0 +1,66 @@
+"""
+This module defines the cloud secrets get command for the Nextmv CLI.
+"""
+
+import json
+from typing import Annotated
+
+import typer
+
+from nextmv.cli.configuration.config import build_app
+from nextmv.cli.message import in_progress, print_json, success
+from nextmv.cli.options import AppIDOption, ProfileOption, SecretsCollectionIDOption
+
+# Set up subcommand application.
+app = typer.Typer()
+
+
+@app.command()
+def get(
+    app_id: AppIDOption,
+    secrets_collection_id: SecretsCollectionIDOption,
+    output: Annotated[
+        str | None,
+        typer.Option(
+            "--output",
+            "-o",
+            help="Saves the secrets collection information to this location.",
+            metavar="OUTPUT_PATH",
+        ),
+    ] = None,
+    profile: ProfileOption = None,
+) -> None:
+    """
+    Get a Nextmv Cloud secrets collection.
+
+    This command is useful to get the attributes of an existing Nextmv Cloud
+    secrets collection by its ID. :construction: [yellow bold]Warning:
+    secret values will be included in the output.[/yellow bold]
+
+    [bold][underline]Examples[/underline][/bold]
+
+    - Get the secrets collection with the ID [magenta]api-keys[/magenta] from
+      application [magenta]hare-app[/magenta].
+        $ [green]nextmv cloud secrets get --app-id hare-app \\
+        --secrets-collection-id api-keys[/green]
+
+    - Get the secrets collection with the ID [magenta]api-keys[/magenta] and
+      save the information to a [magenta]secrets.json[/magenta] file.
+        $ [green]nextmv cloud secrets get --app-id hare-app \\
+            --secrets-collection-id api-keys --output secrets.json[/green]
+    """
+
+    cloud_app = build_app(app_id=app_id, profile=profile)
+    in_progress(msg="Getting secrets collection...")
+    collection = cloud_app.secrets_collection(secrets_collection_id=secrets_collection_id)
+    collection_dict = collection.to_dict()
+
+    if output is not None:
+        with open(output, "w") as f:
+            json.dump(collection_dict, f, indent=2)
+
+        success(msg=f"Secrets collection information saved to [magenta]{output}[/magenta].")
+
+        return
+
+    print_json(collection_dict)

--- a/nextmv/nextmv/cli/cloud/secrets/list.py
+++ b/nextmv/nextmv/cli/cloud/secrets/list.py
@@ -1,0 +1,60 @@
+"""
+This module defines the cloud secrets list command for the Nextmv CLI.
+"""
+
+import json
+from typing import Annotated
+
+import typer
+
+from nextmv.cli.configuration.config import build_app
+from nextmv.cli.message import in_progress, print_json, success
+from nextmv.cli.options import AppIDOption, ProfileOption
+
+# Set up subcommand application.
+app = typer.Typer()
+
+
+@app.command()
+def list(
+    app_id: AppIDOption,
+    output: Annotated[
+        str | None,
+        typer.Option(
+            "--output",
+            "-o",
+            help="Saves the secrets collections list information to this location.",
+            metavar="OUTPUT_PATH",
+        ),
+    ] = None,
+    profile: ProfileOption = None,
+) -> None:
+    """
+    List all secrets collections of a Nextmv Cloud application.
+
+    [bold][underline]Examples[/underline][/bold]
+
+    - List all secrets collections of application [magenta]hare-app[/magenta].
+        $ [green]nextmv cloud secrets list --app-id hare-app[/green]
+
+    - List all secrets collections using the profile named [magenta]hare[/magenta].
+        $ [green]nextmv cloud secrets list --app-id hare-app --profile hare[/green]
+
+    - List all secrets collections and save the information to a [magenta]secrets.json[/magenta] file.
+        $ [green]nextmv cloud secrets list --app-id hare-app --output secrets.json[/green]
+    """
+
+    cloud_app = build_app(app_id=app_id, profile=profile)
+    in_progress(msg="Listing secrets collections...")
+    collections = cloud_app.list_secrets_collections()
+    collections_dicts = [collection.to_dict() for collection in collections]
+
+    if output is not None:
+        with open(output, "w") as f:
+            json.dump(collections_dicts, f, indent=2)
+
+        success(msg=f"Secrets collections list information saved to [magenta]{output}[/magenta].")
+
+        return
+
+    print_json(collections_dicts)

--- a/nextmv/nextmv/cli/cloud/secrets/update.py
+++ b/nextmv/nextmv/cli/cloud/secrets/update.py
@@ -9,7 +9,7 @@ import typer
 
 from nextmv.cli.cloud.secrets.create import build_secrets
 from nextmv.cli.configuration.config import build_app
-from nextmv.cli.message import error, print_json, success
+from nextmv.cli.message import enum_values, error, print_json, success
 from nextmv.cli.options import AppIDOption, ProfileOption, SecretsCollectionIDOption
 from nextmv.cloud.secrets import SecretType
 
@@ -56,7 +56,7 @@ def update(
             help="Secrets to configure in the app. Data should be valid [magenta]json[/magenta]. "
             "Pass multiple secrets by repeating the flag, or providing a list of objects. "
             "Allowed values for [magenta]type[/magenta] are: "
-            f"[magenta]{[v.value for v in SecretType.__members__.values()]}[/magenta]. "
+            f"{enum_values(SecretType)}. "
             "Object format: [magenta]{'type': type, 'location': location, 'value': value}[/magenta]. "
             "This will replace all existing secrets in the collection.",
             metavar="SECRETS",

--- a/nextmv/nextmv/cli/cloud/secrets/update.py
+++ b/nextmv/nextmv/cli/cloud/secrets/update.py
@@ -1,0 +1,143 @@
+"""
+This module defines the cloud secrets update command for the Nextmv CLI.
+"""
+
+import json
+from typing import Annotated
+
+import typer
+
+from nextmv.cli.cloud.secrets.create import build_secrets
+from nextmv.cli.configuration.config import build_app
+from nextmv.cli.message import error, print_json, success
+from nextmv.cli.options import AppIDOption, ProfileOption, SecretsCollectionIDOption
+from nextmv.cloud.secrets import SecretType
+
+# Set up subcommand application.
+app = typer.Typer()
+
+
+@app.command()
+def update(
+    app_id: AppIDOption,
+    secrets_collection_id: SecretsCollectionIDOption,
+    description: Annotated[
+        str | None,
+        typer.Option(
+            "--description",
+            "-d",
+            help="A new description for the secrets collection.",
+            metavar="DESCRIPTION",
+        ),
+    ] = None,
+    name: Annotated[
+        str | None,
+        typer.Option(
+            "--name",
+            "-n",
+            help="A new name for the secrets collection.",
+            metavar="NAME",
+        ),
+    ] = None,
+    output: Annotated[
+        str | None,
+        typer.Option(
+            "--output",
+            "-u",
+            help="Saves the updated secrets collection information to this location.",
+            metavar="OUTPUT_PATH",
+        ),
+    ] = None,
+    secrets: Annotated[
+        list[str] | None,
+        typer.Option(
+            "--secrets",
+            "-e",
+            help="Secrets to configure in the app. Data should be valid [magenta]json[/magenta]. "
+            "Pass multiple secrets by repeating the flag, or providing a list of objects. "
+            "Allowed values for [magenta]type[/magenta] are: "
+            f"[magenta]{[v.value for v in SecretType.__members__.values()]}[/magenta]. "
+            "Object format: [magenta]{'type': type, 'location': location, 'value': value}[/magenta]. "
+            "This will replace all existing secrets in the collection.",
+            metavar="SECRETS",
+        ),
+    ] = None,
+    profile: ProfileOption = None,
+) -> None:
+    """
+    Update a Nextmv Cloud secrets collection.
+
+    You can update the name, description, and/or secrets of an existing
+    secrets collection. When updating secrets, all existing secrets will be
+    replaced with the new ones provided.
+
+    Secrets are provided as JSON objects using the [code]--secrets[/code] flag,
+    following the same format as the create command. You can provide secrets as:
+    - A single secret as a JSON object
+    - Multiple secrets by repeating the [code]--secrets[/code] flag
+    - Multiple secrets as a JSON array in a single [code]--secrets[/code] flag
+
+    [bold][underline]Examples[/underline][/bold]
+
+    - Update the name of a secrets collection.
+        $ [green]nextmv cloud secrets update --app-id hare-app \\
+            --secrets-collection-id api-keys --name "Updated API Keys"[/green]
+
+    - Update the description of a secrets collection.
+        $ [green]nextmv cloud secrets update --app-id hare-app \\
+            --secrets-collection-id api-keys \\
+            --description "Updated collection of API keys"[/green]
+
+    - Update both name and description.
+        $ [green]nextmv cloud secrets update --app-id hare-app \\
+            --secrets-collection-id api-keys --name "Production API Keys" \\
+            --description "API keys for production environment"[/green]
+
+    - Replace all secrets in a collection with new secrets.
+        $ [green]nextmv cloud secrets update --app-id hare-app \\
+            --secrets-collection-id api-keys \\
+            --secrets '{"type": "env", "location": "API_KEY", "value": "new-value"}' \\
+            --secrets '{"type": "env", "location": "DATABASE_URL", "value": "postgres://newhost"}'[/green]
+
+    - Replace all secrets with a JSON array.
+        $ [green]nextmv cloud secrets update --app-id hare-app \\
+            --secrets-collection-id api-keys \\
+            --secrets '[{"type": "env", "location": "API_KEY", "value": "new-value"}, {...}]'[/green]
+
+    - Update multiple attributes at once and save the result.
+        $ [green]nextmv cloud secrets update --app-id hare-app \\
+            --secrets-collection-id api-keys --name "New Name" \\
+            --description "New Description" \\
+            --secrets '{"type": "env", "location": "NEW_KEY", "value": "new-value"}' \\
+            --output updated.json[/green]
+    """
+
+    if name is None and description is None and secrets is None:
+        error(
+            "Provide at least one option to update: "
+            "[code]--name[/code], [code]--description[/code], or [code]--secrets[/code]."
+        )
+
+    cloud_app = build_app(app_id=app_id, profile=profile)
+
+    # Build the secrets list if provided
+    secrets_list = None
+    if secrets is not None:
+        secrets_list = build_secrets(secrets)
+
+    collection = cloud_app.update_secrets_collection(
+        secrets_collection_id=secrets_collection_id,
+        name=name,
+        description=description,
+        secrets=secrets_list,
+    )
+
+    if output is not None:
+        with open(output, "w") as f:
+            json.dump(collection.to_dict(), f, indent=2)
+
+        success(msg=f"Updated secrets collection information saved to [magenta]{output}[/magenta].")
+
+        return
+
+    print_json(collection.to_dict())

--- a/nextmv/nextmv/cli/message.py
+++ b/nextmv/nextmv/cli/message.py
@@ -4,6 +4,7 @@ formatting. Logging, in general, is always printed to stderr.
 """
 
 import sys
+from enum import Enum
 from typing import Any
 
 import rich
@@ -123,3 +124,30 @@ def print_json(data: dict[str, Any] | list[dict[str, Any]]) -> None:
     """
 
     rich.print_json(data=data)
+
+
+def enum_values(enum_class: Enum) -> str:
+    """
+    Get a nicely formatted string of the values of an Enum class, using commas
+    and an oxford comma.
+
+    Parameters
+    ----------
+    enum_class : Enum
+        The Enum class to get the values from.
+
+    Returns
+    -------
+    str
+        A nicely formatted string of the values of the Enum class.
+    """
+
+    values = [f"[magenta]{member.value}[/magenta]" for member in enum_class]
+    if len(values) == 0:
+        return ""
+    if len(values) == 1:
+        return values[0]
+    if len(values) == 2:
+        return " and ".join(values)
+
+    return ", ".join(values[:-1]) + ", and " + values[-1]

--- a/nextmv/nextmv/cli/options.py
+++ b/nextmv/nextmv/cli/options.py
@@ -78,3 +78,17 @@ InstanceIDOption = Annotated[
         metavar="INSTANCE_ID",
     ),
 ]
+
+# secrets_collection_id option - can be used in any command that requires a secrets collection ID.
+# Define it as follows in commands or callbacks, as necessary:
+# secrets_collection_id: SecretsCollectionIDOption
+SecretsCollectionIDOption = Annotated[
+    str,
+    typer.Option(
+        "--secrets-collection-id",
+        "-s",
+        help="The Nextmv Cloud secrets collection ID to use for this action.",
+        envvar="NEXTMV_SECRETS_COLLECTION_ID",
+        metavar="SECRETS_COLLECTION_ID",
+    ),
+]

--- a/nextmv/nextmv/cloud/application.py
+++ b/nextmv/nextmv/cloud/application.py
@@ -2396,8 +2396,8 @@ class Application(BaseModel):
     def new_secrets_collection(
         self,
         secrets: list[Secret],
-        id: str,
-        name: str,
+        id: str | None = None,
+        name: str | None = None,
         description: str | None = None,
     ) -> SecretsCollectionSummary:
         """
@@ -2405,18 +2405,22 @@ class Application(BaseModel):
 
         This method creates a new secrets collection with the provided secrets.
         A secrets collection is a group of key-value pairs that can be used by
-        your application instances during execution. If no secrets are provided,
-        a ValueError is raised.
+        your application instances during execution. If no secrets are
+        provided, a ValueError is raised. If the `id` or `name` parameters are
+        not provided, they will be generated based on a unique ID.
 
         Parameters
         ----------
         secrets : list[Secret]
             List of secrets to use for the secrets collection. Each secret
-            should be an instance of the Secret class containing a key and value.
-        id : str
-            ID of the secrets collection.
-        name : str
-            Name of the secrets collection.
+            should be an instance of the Secret class containing a key and
+            value.
+        id : str | None, default=None
+            ID of the secrets collection. If not provided, a unique ID will be
+            generated.
+        name : str | None, default=None
+            Name of the secrets collection. If not provided, the ID will be
+            used.
         description : Optional[str], default=None
             Description of the secrets collection.
 
@@ -2461,14 +2465,17 @@ class Application(BaseModel):
         if len(secrets) == 0:
             raise ValueError("secrets must be provided")
 
+        if id is None or id == "":
+            id = safe_id(prefix="secrets")
+        if name is None or name == "":
+            name = id
+
         payload = {
+            "id": id,
+            "name": name,
             "secrets": [secret.to_dict() for secret in secrets],
         }
 
-        if id is not None:
-            payload["id"] = id
-        if name is not None:
-            payload["name"] = name
         if description is not None:
             payload["description"] = description
 


### PR DESCRIPTION
# Description

Adds the `nextmv cloud secrets` command tree with the following subcommands:

- `create`
- `delete`
- `get`
- `list`
- `update`

Fixes some logic when creating a secrets collection and not giving it an ID and/or name. Fixes some formatting issues where the enumerations of some classes where not being enclosed in `magenta` for some option help messages.