### PR TITLE
Adds the `nextmv cloud data` command tree, deprecates `upload_large_input`

### DIFF
--- a/docs/nextmv/cloud/large-payloads.md
+++ b/docs/nextmv/cloud/large-payloads.md
@@ -22,7 +22,7 @@ You can use the following methods to handle large payloads:
 
 * [`Application.upload_url`][application-upload-url]: This method returns a
       temporary, pre-signed URL to which you can upload a file.
-* [`Application.upload_large_input`][application-upload-large-input]: This
+* [`Application.upload_data`][application-upload-data]: This
       method takes the actual data and uploads it to the pre-signed URL.
 
 Here is an example of how to use these methods.
@@ -46,7 +46,7 @@ app = Application(client=client, id="<YOUR-APP-ID>")
 upload_url = app.upload_url()
 
 # Upload the input.
-app.upload_large_input(input=input, upload_url=upload_url)
+app.upload_data(data=input, upload_url=upload_url)
 
 # Make a run.
 run_id = app.new_run(
@@ -79,4 +79,4 @@ nextmv.write(download_response)
 
 [large-payloads-image]: ../../../images/large_file_run_overview.png
 [application-upload-url]: ./reference/application.md#nextmv.nextmv.cloud.application.Application.upload_url
-[application-upload-large-input]: ./reference/application.md#nextmv.nextmv.cloud.application.Application.upload_large_input
+[application-upload-data]: ./reference/application.md#nextmv.nextmv.cloud.application.Application.upload_data

--- a/docs/nextmv/cloud/manage.md
+++ b/docs/nextmv/cloud/manage.md
@@ -104,7 +104,7 @@ methods you can use that were not covered in this guide:
 * `run_result`: gets the result of a run.
 * `run_result_with_polling`: gets the result of a run with polling.
 * `update_instance`: updates an instance.
-* `upload_large_input`: uploads a large input.
+* `upload_data`: uploads data that is large or multiple files.
 * `upload_url`: gets the URL for uploading.
 * `version`: gets a version.
 

--- a/nextmv/nextmv/cli/CONTRIBUTING.md
+++ b/nextmv/nextmv/cli/CONTRIBUTING.md
@@ -434,7 +434,7 @@ Consider the following guideline when declaring command options:
       typer.Option(
           "--input",
           "-i",
-          help="The input path to use. File or directory depending on content type. "
+          help="The input path to use. File or directory depending on content format. "
           "Uses [magenta]stdin[/magenta] if not defined.",
           metavar="INPUT_PATH",
           rich_help_panel="Input control",

--- a/nextmv/nextmv/cli/cloud/__init__.py
+++ b/nextmv/nextmv/cli/cloud/__init__.py
@@ -5,6 +5,7 @@ This module defines the cloud command tree for the Nextmv CLI.
 import typer
 
 from nextmv.cli.cloud.app import app as app_app
+from nextmv.cli.cloud.data import app as data_app
 from nextmv.cli.cloud.instance import app as instance_app
 from nextmv.cli.cloud.run import app as run_app
 from nextmv.cli.cloud.secrets import app as secrets_app
@@ -14,6 +15,7 @@ from nextmv.cli.cloud.version import app as version_app
 # Set up subcommand application.
 app = typer.Typer()
 app.add_typer(app_app, name="app")
+app.add_typer(data_app, name="data")
 app.add_typer(instance_app, name="instance")
 app.add_typer(run_app, name="run")
 app.add_typer(secrets_app, name="secrets")

--- a/nextmv/nextmv/cli/cloud/data/__init__.py
+++ b/nextmv/nextmv/cli/cloud/data/__init__.py
@@ -1,0 +1,26 @@
+"""
+This module defines the cloud data command tree for the Nextmv CLI.
+"""
+
+import typer
+
+from nextmv.cli.cloud.data.upload import app as upload_app
+
+# Set up subcommand application.
+app = typer.Typer()
+app.add_typer(upload_app)
+
+
+@app.callback()
+def callback() -> None:
+    """
+    Upload data for Nextmv Cloud application runs.
+
+    When data is too large (exceeds [magenta]5 MiB[/magenta]), or you are
+    working with the [magenta]multi-file[/magenta] content format, you can use
+    this command to upload information to Nextmv Cloud. Requires a pre-signed
+    upload URL, which can be obtained using the [code]nextmv cloud upload
+    create[/code] command. Use the [magenta].upload_url[/magenta] field from the
+    command output.
+    """
+    pass

--- a/nextmv/nextmv/cli/cloud/data/upload.py
+++ b/nextmv/nextmv/cli/cloud/data/upload.py
@@ -1,0 +1,162 @@
+"""
+This module defines the cloud instance create command for the Nextmv CLI.
+"""
+
+import json
+import sys
+import tarfile
+from pathlib import Path
+from typing import Annotated, Any
+
+import typer
+
+from nextmv.cli.configuration.config import build_app
+from nextmv.cli.message import error, in_progress, success
+from nextmv.cli.options import AppIDOption, ProfileOption
+from nextmv.cloud.application import Application
+
+# Set up subcommand application.
+app = typer.Typer()
+
+
+@app.command()
+def upload(
+    app_id: AppIDOption,
+    upload_url: Annotated[
+        str,
+        typer.Option(
+            "--upload-url",
+            "-u",
+            help="Pre-signed URL for uploading the data.",
+            metavar="UPLOAD_URL",
+        ),
+    ],
+    input: Annotated[
+        str | None,
+        typer.Option(
+            "--input",
+            "-i",
+            help="The input path to use. File or directory depending on content format. "
+            "Uses [magenta]stdin[/magenta] if not defined. "
+            "Can be a [magenta].tar.gz[/magenta] file for multi-file content format.",
+            metavar="INPUT_PATH",
+        ),
+    ] = None,
+    profile: ProfileOption = None,
+) -> None:
+    """
+    Upload data for Nextmv Cloud application runs.
+
+    When data is too large, or is not in a text-based content format, you can
+    use this command to upload information for a Nextmv Cloud application. Data
+    is used for starting new runs, tracking runs, performing experiments, and
+    more.
+
+    The [code]--upload-url[/code] flag is required to specify the pre-signed
+    upload URL. It can be obtained using the [code]nextmv cloud upload
+    create[/code] command. Use the [magenta].upload_url[/magenta] field from
+    the command output.
+
+    The data input should be given through [magenta]stdin[/magenta] or the
+    [code]--input[/code] flag. When using the [code]--input[/code] flag, the
+    value can be one of the following:
+
+    - [green]<FILE_PATH>[/green]: path to a [magenta]file[/magenta] containing
+      the data. Use with the [magenta]json[/magenta], and
+      [magenta]text[/magenta] content formats.
+    - [green]<DIR_PATH>[/green]: path to a [magenta]directory[/magenta]
+      containing  data files. Use with the [magenta]multi-file[/magenta]
+      content format.
+    - [green]<.tar.gz_PATH>[/green]: path to a [magenta].tar.gz[/magenta] file
+      containing tarred data files. Use with the [magenta]multi-file[/magenta]
+      content format.
+
+    [bold][underline]Examples[/underline][/bold]
+
+    - Upload data from [magenta]stdin[/magenta] for application
+      [magenta]hare-app[/magenta].
+        $ [green]echo '{"key": "value"}' | nextmv cloud upload --app-id hare-app --upload-url <URL>[/green]
+
+    - Upload data from a [magenta]JSON[/magenta] file.
+        $ [green]nextmv cloud upload --app-id hare-app --upload-url <URL> --input data.json[/green]
+
+    - Upload data from a [magenta]text[/magenta] file.
+        $ [green]nextmv cloud upload --app-id hare-app --upload-url <URL> --input data.txt[/green]
+
+    - Upload [magenta]multi-file[/magenta] data from a directory.
+        $ [green]nextmv cloud upload --app-id hare-app --upload-url <URL> --input ./data_directory[/green]
+
+    - Upload [magenta]multi-file[/magenta] data from a
+      [magenta].tar.gz[/magenta] file.
+        $ [green]nextmv cloud upload --app-id hare-app --upload-url <URL> --input data.tar.gz[/green]
+
+    - Upload data using a specific profile.
+        $ [green]nextmv cloud upload --app-id hare-app --upload-url <URL> --input data.json --profile production[/green]
+    """
+
+    # Validate that input is provided.
+    stdin = sys.stdin.read().strip() if sys.stdin.isatty() is False else None
+    if stdin is None and (input is None or input == ""):
+        error("Input data must be provided via the [code]--input[/code] flag or [magenta]stdin[/magenta].")
+
+    cloud_app = build_app(app_id=app_id, profile=profile)
+    data_kwarg = resolve_data_kwarg(
+        stdin=stdin,
+        input=input,
+        cloud_app=cloud_app,
+    )
+
+    in_progress(msg="Uploading data...")
+    cloud_app.upload_data(upload_url=upload_url, **data_kwarg)
+    success(msg="Data uploaded successfully.")
+
+
+def resolve_data_kwarg(stdin: str | None, input: str | None, cloud_app: Application) -> dict[str, Any]:
+    """
+    Gets the keyword argument related to the data that is needed for the
+    upload. It handles stdin, file, and directory inputs.
+
+    Parameters
+    ----------
+    stdin : str | None
+        The stdin input data, if provided.
+    input : str | None
+        The input path, if provided.
+    cloud_app : Application
+        The Nextmv Cloud application instance.
+
+    Returns
+    -------
+    dict[str, Any]
+        The keyword argument with the resolved data.
+    """
+
+    if stdin is not None:
+        # Handle the case where stdin is provided as JSON for a JSON app.
+        try:
+            input_data = json.loads(stdin)
+        except json.JSONDecodeError:
+            input_data = stdin
+
+        return {"data": input_data}
+
+    input_path = Path(input)
+
+    # If the input is a file, we need to determine if it is a tar file or a
+    # regular file. If it is a regular file, we need to read its content.
+    if input_path.is_file():
+        if tarfile.is_tarfile(input_path):
+            return {"tar_file": str(input_path)}
+
+        with open(input_path) as f:
+            input_data = f.read()
+
+        return {"data": input_data}
+
+    # If the input is a directory, we need to tar the contents.
+    if input_path.is_dir():
+        tar_path = cloud_app._package_inputs(dir_path=str(input_path))
+
+        return {"tar_file": tar_path}
+
+    error(f"Input path [magenta]{input}[/magenta] does not exist.")

--- a/nextmv/nextmv/cli/cloud/data/upload.py
+++ b/nextmv/nextmv/cli/cloud/data/upload.py
@@ -65,7 +65,7 @@ def upload(
       the data. Use with the [magenta]json[/magenta], and
       [magenta]text[/magenta] content formats.
     - [green]<DIR_PATH>[/green]: path to a [magenta]directory[/magenta]
-      containing  data files. Use with the [magenta]multi-file[/magenta]
+      containing data files. Use with the [magenta]multi-file[/magenta]
       content format.
     - [green]<.tar.gz_PATH>[/green]: path to a [magenta].tar.gz[/magenta] file
       containing tarred data files. Use with the [magenta]multi-file[/magenta]

--- a/nextmv/nextmv/cli/cloud/data/upload.py
+++ b/nextmv/nextmv/cli/cloud/data/upload.py
@@ -149,8 +149,7 @@ def resolve_data_kwarg(stdin: str | None, input: str | None, cloud_app: Applicat
         if tarfile.is_tarfile(input_path):
             return {"tar_file": str(input_path)}
 
-        with open(input_path) as f:
-            input_data = f.read()
+        input_data = input_path.read_text()
 
         return {"data": input_data}
 

--- a/nextmv/nextmv/cli/cloud/data/upload.py
+++ b/nextmv/nextmv/cli/cloud/data/upload.py
@@ -1,5 +1,5 @@
 """
-This module defines the cloud instance create command for the Nextmv CLI.
+This module defines the cloud data upload command for the Nextmv CLI.
 """
 
 import json

--- a/nextmv/nextmv/cli/cloud/data/upload.py
+++ b/nextmv/nextmv/cli/cloud/data/upload.py
@@ -75,23 +75,24 @@ def upload(
 
     - Upload data from [magenta]stdin[/magenta] for application
       [magenta]hare-app[/magenta].
-        $ [green]echo '{"key": "value"}' | nextmv cloud upload --app-id hare-app --upload-url <URL>[/green]
+        $ [green]echo '{"key": "value"}' | nextmv cloud data upload --app-id hare-app --upload-url <URL>[/green]
 
     - Upload data from a [magenta]JSON[/magenta] file.
-        $ [green]nextmv cloud upload --app-id hare-app --upload-url <URL> --input data.json[/green]
+        $ [green]nextmv cloud data upload --app-id hare-app --upload-url <URL> --input data.json[/green]
 
     - Upload data from a [magenta]text[/magenta] file.
-        $ [green]nextmv cloud upload --app-id hare-app --upload-url <URL> --input data.txt[/green]
+        $ [green]nextmv cloud data upload --app-id hare-app --upload-url <URL> --input data.txt[/green]
 
     - Upload [magenta]multi-file[/magenta] data from a directory.
-        $ [green]nextmv cloud upload --app-id hare-app --upload-url <URL> --input ./data_directory[/green]
+        $ [green]nextmv cloud data upload --app-id hare-app --upload-url <URL> --input ./data_directory[/green]
 
     - Upload [magenta]multi-file[/magenta] data from a
       [magenta].tar.gz[/magenta] file.
-        $ [green]nextmv cloud upload --app-id hare-app --upload-url <URL> --input data.tar.gz[/green]
+        $ [green]nextmv cloud data upload --app-id hare-app --upload-url <URL> --input data.tar.gz[/green]
 
     - Upload data using a specific profile.
-        $ [green]nextmv cloud upload --app-id hare-app --upload-url <URL> --input data.json --profile production[/green]
+        $ [green]nextmv cloud data upload --app-id hare-app --upload-url <URL> --input data.json \\
+            --profile production[/green]
     """
 
     # Validate that input is provided.

--- a/nextmv/nextmv/cli/cloud/run/create.py
+++ b/nextmv/nextmv/cli/cloud/run/create.py
@@ -33,8 +33,9 @@ def create(
         typer.Option(
             "--input",
             "-i",
-            help="The input path to use. File or directory depending on content type. "
-            "Uses [magenta]stdin[/magenta] if not defined.",
+            help="The input path to use. File or directory depending on content format. "
+            "Uses [magenta]stdin[/magenta] if not defined. "
+            "Can be a [magenta].tar.gz[/magenta] file for multi-file content format.",
             metavar="INPUT_PATH",
             rich_help_panel="Input control",
         ),
@@ -56,7 +57,7 @@ def create(
             "--output",
             "-u",
             help="Waits for the run to complete and save the output to this location. "
-            "A file or directory will be created depending on content type. ",
+            "A file or directory will be created depending on content format. ",
             metavar="OUTPUT_PATH",
             rich_help_panel="Output control",
         ),
@@ -209,7 +210,21 @@ def create(
     Create a new Nextmv Cloud application run.
 
     Input for the run should be given through [magenta]stdin[/magenta] or the
-    [code]--input[/code] flag.
+    [code]--input[/code] flag. When using the [code]--input[/code] flag, the
+    value can be one of the following:
+
+    - [green]<FILE_PATH>[/green]: path to a [magenta]file[/magenta] containing
+      the input data. Use with the [magenta]json[/magenta], and
+      [magenta]text[/magenta] content formats.
+    - [green]<DIR_PATH>[/green]: path to a [magenta]directory[/magenta]
+      containing the input data files. Use with the
+      [magenta]multi-file[/magenta] content format.
+    - [green]<.tar.gz_PATH>[/green]: path to a [magenta].tar.gz[/magenta] file
+      containing tarred input data files. Use with the
+      [magenta]multi-file[/magenta] content format.
+
+    The CLI determines how to send the input to the application based on the
+    value.
 
     Use the [code]--wait[/code] flag to wait for the run to complete, polling
     for results. Using the [code]--output[/code] flag will also activate
@@ -500,10 +515,10 @@ def resolve_input_kwarg(
     if input_path.is_file():
         upload_url = cloud_app.upload_url()
         if tarfile.is_tarfile(input_path):
-            cloud_app.upload_large_input(input=None, upload_url=upload_url, tar_file=input_path)
+            cloud_app.upload_data(data=None, upload_url=upload_url, tar_file=input_path)
         else:
             input_data = input_path.read_text()
-            cloud_app.upload_large_input(input=input_data, upload_url=upload_url)
+            cloud_app.upload_data(data=input_data, upload_url=upload_url)
 
         return {"upload_id": upload_url.upload_id}
 

--- a/nextmv/nextmv/cli/cloud/run/get.py
+++ b/nextmv/nextmv/cli/cloud/run/get.py
@@ -28,7 +28,7 @@ def get(
             "--output",
             "-o",
             help="Waits for the run to complete and save the output to this location. "
-            "A file or directory will be created depending on content type.",
+            "A file or directory will be created depending on content format.",
             metavar="OUTPUT_PATH",
         ),
     ] = None,

--- a/nextmv/nextmv/cli/cloud/run/track.py
+++ b/nextmv/nextmv/cli/cloud/run/track.py
@@ -29,7 +29,7 @@ def track(
         typer.Option(
             "--output",
             "-o",
-            help="The output of the run being tracked. A file or directory depending on content type.",
+            help="The output of the run being tracked. A file or directory depending on content format.",
             metavar="OUTPUT_PATH",
             rich_help_panel="Tracked run configuration",
         ),
@@ -95,7 +95,7 @@ def track(
         typer.Option(
             "--input",
             "-i",
-            help="The input of the run being tracked. File or directory depending on content type. "
+            help="The input of the run being tracked. File or directory depending on content format. "
             "Uses [magenta]stdin[/magenta] if not defined.",
             metavar="INPUT_PATH",
             rich_help_panel="Tracked run configuration",

--- a/nextmv/nextmv/cloud/application/__init__.py
+++ b/nextmv/nextmv/cloud/application/__init__.py
@@ -29,6 +29,7 @@ import requests
 import rich
 from pydantic import AliasChoices, Field
 
+from nextmv import deprecated
 from nextmv._serialization import deflated_serialize_json
 from nextmv.base_model import BaseModel
 from nextmv.cloud import package
@@ -626,6 +627,69 @@ class Application(
 
         return Application.from_dict({"client": self.client} | response.json())
 
+    def upload_data(
+        self,
+        upload_url: UploadURL | str,
+        data: dict[str, Any] | str | None = None,
+        json_configurations: dict[str, Any] | None = None,
+        tar_file: str | None = None,
+    ) -> None:
+        """
+        Upload data to the provided upload URL.
+
+        This method allows uploading data (either a dictionary or string)
+        to a pre-signed URL. If the data is a dictionary, it will be converted to
+        a JSON string before upload.
+
+        Parameters
+        ----------
+        upload_url : UploadURL | str
+            Upload URL object containing the pre-signed URL to use for
+            uploading. If it is a string, it will be used directly as the
+            pre-signed URL.
+        data : Optional[Union[dict[str, Any], str]]
+            Data to upload. Can be either a dictionary that will be
+            converted to JSON, or a pre-formatted JSON string.
+        json_configurations : Optional[dict[str, Any]], default=None
+            Optional configurations for JSON serialization. If provided, these
+            configurations will be used when serializing the data via
+            `json.dumps`.
+        tar_file : Optional[str], default=None
+            If provided, this will be used to upload a tar file instead of
+            a JSON string or dictionary. This is useful for uploading large
+            files that are already packaged as a tarball.
+
+        Returns
+        -------
+        None
+            This method doesn't return anything.
+
+        Raises
+        ------
+        requests.HTTPError
+            If the response status code is not 2xx.
+
+        Examples
+        --------
+        >>> # Upload a dictionary as JSON
+        >>> data = {"locations": [...], "vehicles": [...]}
+        >>> url = app.upload_url()
+        >>> app.upload_data(data=data, upload_url=url)
+        >>>
+        >>> # Upload a pre-formatted JSON string
+        >>> json_str = '{"locations": [...], "vehicles": [...]}'
+        >>> app.upload_data(data=json_str, upload_url=url)
+        """
+
+        if data is not None and isinstance(data, dict):
+            data = deflated_serialize_json(data, json_configurations=json_configurations)
+
+        self.client.upload_to_presigned_url(
+            url=upload_url.upload_url if isinstance(upload_url, UploadURL) else upload_url,
+            data=data,
+            tar_file=tar_file,
+        )
+
     def upload_large_input(
         self,
         input: dict[str, Any] | str | None,
@@ -634,6 +698,9 @@ class Application(
         tar_file: str | None = None,
     ) -> None:
         """
+        !!! warning
+            `upload_large_input` is deprecated, use `upload_data` instead.
+
         Upload large input data to the provided upload URL.
 
         This method allows uploading large input data (either a dictionary or string)
@@ -678,12 +745,15 @@ class Application(
         >>> app.upload_large_input(input=json_str, upload_url=url)
         """
 
-        if input is not None and isinstance(input, dict):
-            input = deflated_serialize_json(input, json_configurations=json_configurations)
+        deprecated(
+            name="Application.upload_large_input",
+            reason="`upload_large_input` is deprecated, use `upload_data` instead",
+        )
 
-        self.client.upload_to_presigned_url(
-            url=upload_url.upload_url,
+        self.upload_data(
             data=input,
+            upload_url=upload_url,
+            json_configurations=json_configurations,
             tar_file=tar_file,
         )
 
@@ -711,7 +781,7 @@ class Application(
         >>> # Get an upload URL and upload large input data
         >>> upload_url = app.upload_url()
         >>> large_input = {"locations": [...], "vehicles": [...]}
-        >>> app.upload_large_input(input=large_input, upload_url=upload_url)
+        >>> app.upload_data(data=large_input, upload_url=upload_url)
         """
 
         response = self.client.request(

--- a/nextmv/nextmv/cloud/application/_batch_scenario.py
+++ b/nextmv/nextmv/cloud/application/_batch_scenario.py
@@ -820,7 +820,7 @@ class ApplicationBatchMixin:
             managed_inputs = []
             for data in scenario.scenario_input.scenario_input_data:
                 upload_url = self.upload_url()
-                self.upload_large_input(input=data, upload_url=upload_url)
+                self.upload_data(data=data, upload_url=upload_url)
                 name, id = safe_name_and_id(prefix="man-input", entity_id=scenario_id)
                 managed_input = self.new_managed_input(
                     id=id,

--- a/nextmv/nextmv/cloud/application/_managed_input.py
+++ b/nextmv/nextmv/cloud/application/_managed_input.py
@@ -81,7 +81,7 @@ class ApplicationManagedInputMixin:
         managed input:
 
         1. Specifying the `upload_id` parameter. You may use the `upload_url`
-           method to obtain the upload ID and the `upload_large_input` method
+           method to obtain the upload ID and the `upload_data` method
            to upload the data to it.
         2. Specifying the `run_id` parameter. The managed input will be
            created from the run specified by the `run_id` parameter.

--- a/nextmv/nextmv/cloud/application/_run.py
+++ b/nextmv/nextmv/cloud/application/_run.py
@@ -244,7 +244,7 @@ class ApplicationRunMixin:
             argument instead. This argument takes precedence over the `input`.
             If `input_dir_path` is specified, this function looks for files in that
             directory and tars them, to later be uploaded using the
-            `upload_large_input` method. If both the `input_dir_path` and `input`
+            `upload_data` method. If both the `input_dir_path` and `input`
             arguments are provided, the `input` is ignored.
 
             When `input_dir_path` is specified, the `configuration` argument must
@@ -261,7 +261,7 @@ class ApplicationRunMixin:
             directly.
 
             In general, if an input is too large, it will be uploaded with the
-            `upload_large_input` method.
+            `upload_data` method.
         instance_id: Optional[str]
             ID of the instance to use for the run. If not provided, the default
             instance ID associated to the Class (`default_instance_id`) is
@@ -329,7 +329,7 @@ class ApplicationRunMixin:
             if not os.path.isdir(input_dir_path):
                 raise ValueError(f"Path {input_dir_path} is not a directory.")
 
-            tar_file = self.__package_inputs(input_dir_path)
+            tar_file = self._package_inputs(input_dir_path)
 
         input_data = self.__extract_input_data(input)
 
@@ -340,7 +340,7 @@ class ApplicationRunMixin:
         upload_id_used = upload_id is not None
         if self.__upload_url_required(upload_id_used, input_size, tar_file, input):
             upload_url = self.upload_url()
-            self.upload_large_input(input=input_data, upload_url=upload_url, tar_file=tar_file)
+            self.upload_data(data=input_data, upload_url=upload_url, tar_file=tar_file)
             upload_id = upload_url.upload_id
             upload_id_used = True
 
@@ -426,7 +426,7 @@ class ApplicationRunMixin:
             argument instead. This argument takes precedence over the `input`.
             If `input_dir_path` is specified, this function looks for files in that
             directory and tars them, to later be uploaded using the
-            `upload_large_input` method. If both the `input_dir_path` and `input`
+            `upload_data` method. If both the `input_dir_path` and `input`
             arguments are provided, the `input` is ignored.
 
             When `input_dir_path` is specified, the `configuration` argument must
@@ -443,7 +443,7 @@ class ApplicationRunMixin:
             directly.
 
             In general, if an input is too large, it will be uploaded with the
-            `upload_large_input` method.
+            `upload_data` method.
         instance_id: Optional[str]
             ID of the instance to use for the run. If not provided, the default
             instance ID associated to the Class (`default_instance_id`) is
@@ -987,7 +987,7 @@ class ApplicationRunMixin:
             if not os.path.isdir(input_dir_path):
                 raise ValueError(f"Path {input_dir_path} is not a directory.")
 
-            input_tar_file = self.__package_inputs(input_dir_path)
+            input_tar_file = self._package_inputs(input_dir_path)
 
         # Handle the case where the input is uploaded as Input or a dict.
         upload_input = tracked_run.input
@@ -995,7 +995,7 @@ class ApplicationRunMixin:
             upload_input = tracked_run.input.data
 
         # Actually uploads de input.
-        self.upload_large_input(input=upload_input, upload_url=url_input, tar_file=input_tar_file)
+        self.upload_data(data=upload_input, upload_url=url_input, tar_file=input_tar_file)
 
         # Get the URL to upload the output to.
         url_output = self.upload_url()
@@ -1011,7 +1011,7 @@ class ApplicationRunMixin:
             if not os.path.isdir(output_dir_path):
                 raise ValueError(f"Path {output_dir_path} is not a directory.")
 
-            output_tar_file = self.__package_inputs(output_dir_path)
+            output_tar_file = self._package_inputs(output_dir_path)
 
         # Handle the case where the output is uploaded as Output or a dict.
         upload_output = tracked_run.output
@@ -1019,7 +1019,7 @@ class ApplicationRunMixin:
             upload_output = tracked_run.output.to_dict()
 
         # Actually uploads the output.
-        self.upload_large_input(input=upload_output, upload_url=url_output, tar_file=output_tar_file)
+        self.upload_data(data=upload_output, upload_url=url_output, tar_file=output_tar_file)
 
         # Create the external run result and appends logs if required.
         external_result = ExternalRunResult(
@@ -1031,7 +1031,7 @@ class ApplicationRunMixin:
         # Handle the stderr logs if provided.
         if tracked_run.logs is not None:
             url_stderr = self.upload_url()
-            self.upload_large_input(input=tracked_run.logs_text(), upload_url=url_stderr)
+            self.upload_data(data=tracked_run.logs_text(), upload_url=url_stderr)
             external_result.error_upload_id = url_stderr.upload_id
 
         if tracked_run.error is not None and tracked_run.error != "":
@@ -1051,7 +1051,7 @@ class ApplicationRunMixin:
                 raise ValueError("tracked_run.statistics must be either a `Statistics` or `dict` object")
 
             url_stats = self.upload_url()
-            self.upload_large_input(input=stats_dict, upload_url=url_stats)
+            self.upload_data(data=stats_dict, upload_url=url_stats)
             external_result.statistics_upload_id = url_stats.upload_id
 
         # Handle the assets upload if provided.
@@ -1075,7 +1075,7 @@ class ApplicationRunMixin:
                 raise ValueError("tracked_run.assets must be either a `list[Asset]`, `list[dict]`, or `dict` object")
 
             url_assets = self.upload_url()
-            self.upload_large_input(input=assets_dict, upload_url=url_assets)
+            self.upload_data(data=assets_dict, upload_url=url_assets)
             external_result.assets_upload_id = url_assets.upload_id
 
         return self.new_run(
@@ -1149,6 +1149,40 @@ class ApplicationRunMixin:
             polling_options=polling_options,
             output_dir_path=output_dir_path,
         )
+
+    def _package_inputs(self: "Application", dir_path: str) -> str:
+        """
+        This is an auxiliary function for packaging the inputs found in the
+        provided `dir_path`. All the files found in the directory are tarred and
+        g-zipped. This function returns the tar file path that contains the
+        packaged inputs.
+        """
+
+        # Create a temporary directory for the output
+        output_dir = tempfile.mkdtemp(prefix="nextmv-inputs-out-")
+
+        # Define the output tar file name and path
+        tar_filename = "inputs.tar.gz"
+        tar_file_path = os.path.join(output_dir, tar_filename)
+
+        # Create the tar.gz file
+        with tarfile.open(tar_file_path, "w:gz") as tar:
+            for root, _, files in os.walk(dir_path):
+                for file in files:
+                    if file == tar_filename:
+                        continue
+
+                    file_path = os.path.join(root, file)
+
+                    # Skip directories, only process files
+                    if os.path.isdir(file_path):
+                        continue
+
+                    # Create relative path for the archive
+                    arcname = os.path.relpath(file_path, start=dir_path)
+                    tar.add(file_path, arcname=arcname)
+
+        return tar_file_path
 
     def __run_result(
         self: "Application",
@@ -1245,40 +1279,6 @@ class ApplicationRunMixin:
         """Auxiliary method to get the console URL for a run."""
 
         return f"{self.client.console_url}/app/{self.id}/run/{run_id}?view=details"
-
-    def __package_inputs(self: "Application", dir_path: str) -> str:
-        """
-        This is an auxiliary function for packaging the inputs found in the
-        provided `dir_path`. All the files found in the directory are tarred and
-        g-zipped. This function returns the tar file path that contains the
-        packaged inputs.
-        """
-
-        # Create a temporary directory for the output
-        output_dir = tempfile.mkdtemp(prefix="nextmv-inputs-out-")
-
-        # Define the output tar file name and path
-        tar_filename = "inputs.tar.gz"
-        tar_file_path = os.path.join(output_dir, tar_filename)
-
-        # Create the tar.gz file
-        with tarfile.open(tar_file_path, "w:gz") as tar:
-            for root, _, files in os.walk(dir_path):
-                for file in files:
-                    if file == tar_filename:
-                        continue
-
-                    file_path = os.path.join(root, file)
-
-                    # Skip directories, only process files
-                    if os.path.isdir(file_path):
-                        continue
-
-                    # Create relative path for the archive
-                    arcname = os.path.relpath(file_path, start=dir_path)
-                    tar.add(file_path, arcname=arcname)
-
-        return tar_file_path
 
     def __upload_url_required(
         self: "Application",

--- a/nextmv/nextmv/local/application.py
+++ b/nextmv/nextmv/local/application.py
@@ -256,8 +256,7 @@ class Application:
             `nextmv.InputFormat.MULTI_FILE`, you should use the
             `input_dir_path` argument instead. This argument takes precedence
             over the `input`. If `input_dir_path` is specified, this function
-            looks for files in that directory and tars them, to later be
-            uploaded using the `upload_large_input` method. If both the
+            looks for files in that directory and tars them. If both the
             `input_dir_path` and `input` arguments are provided, the `input`
             is ignored.
 
@@ -273,9 +272,6 @@ class Application:
 
             When working with JSON or text data, use the `input` argument
             directly.
-
-            In general, if an input is too large, it will be uploaded with the
-            `upload_large_input` method.
         name: Optional[str]
             Name of the local run.
         description: Optional[str]
@@ -399,8 +395,7 @@ class Application:
             `nextmv.InputFormat.MULTI_FILE`, you should use the
             `input_dir_path` argument instead. This argument takes precedence
             over the `input`. If `input_dir_path` is specified, this function
-            looks for files in that directory and tars them, to later be
-            uploaded using the `upload_large_input` method. If both the
+            looks for files in that directory and tars them. If both the
             `input_dir_path` and `input` arguments are provided, the `input` is
             ignored.
 
@@ -416,9 +411,6 @@ class Application:
 
             When working with JSON or text data, use the `input` argument
             directly.
-
-            In general, if an input is too large, it will be uploaded with the
-            `upload_large_input` method.
         name: Optional[str]
             Name of the local run.
         description: Optional[str]


### PR DESCRIPTION
# Description

Adds the `nextmv cloud data upload` command for uploading to a pre-signed URL.

This warranted some changes:

- Deprecated the `cloud.Application.upload_large_input` method. We use pre-signed URL uploads for many things, not just for uploading inputs. Consequently, I renamed the method to `upload_data` which is more precise, and changed a couple of things. The deprecated method is still accessible, it will just emit a deprecation notice.
- Made the `_package_inputs` function of `cloud.Application` accessible from outside calls by replacing the double underscore with a single one. It is still ok for it to be a private method.