### PR TITLE
Adds the `nextmv cloud managed-input` command tree

### DIFF
--- a/nextmv/nextmv/cli/cloud/__init__.py
+++ b/nextmv/nextmv/cli/cloud/__init__.py
@@ -7,6 +7,7 @@ import typer
 from nextmv.cli.cloud.app import app as app_app
 from nextmv.cli.cloud.data import app as data_app
 from nextmv.cli.cloud.instance import app as instance_app
+from nextmv.cli.cloud.managed_input import app as managed_input_app
 from nextmv.cli.cloud.run import app as run_app
 from nextmv.cli.cloud.secrets import app as secrets_app
 from nextmv.cli.cloud.upload import app as upload_app
@@ -17,6 +18,7 @@ app = typer.Typer()
 app.add_typer(app_app, name="app")
 app.add_typer(data_app, name="data")
 app.add_typer(instance_app, name="instance")
+app.add_typer(managed_input_app, name="managed-input")
 app.add_typer(run_app, name="run")
 app.add_typer(secrets_app, name="secrets")
 app.add_typer(upload_app, name="upload")

--- a/nextmv/nextmv/cli/cloud/managed_input/__init__.py
+++ b/nextmv/nextmv/cli/cloud/managed_input/__init__.py
@@ -1,0 +1,31 @@
+"""
+This module defines the cloud managed-input command tree for the Nextmv CLI.
+"""
+
+import typer
+
+from nextmv.cli.cloud.managed_input.create import app as create_app
+from nextmv.cli.cloud.managed_input.delete import app as delete_app
+from nextmv.cli.cloud.managed_input.get import app as get_app
+from nextmv.cli.cloud.managed_input.list import app as list_app
+from nextmv.cli.cloud.managed_input.update import app as update_app
+
+# Set up subcommand application.
+app = typer.Typer()
+app.add_typer(create_app)
+app.add_typer(delete_app)
+app.add_typer(get_app)
+app.add_typer(list_app)
+app.add_typer(update_app)
+
+
+@app.callback()
+def callback() -> None:
+    """
+    Create and handle managed inputs for Nextmv Cloud applications.
+
+    A managed input is a stored input that can be referenced and used across
+    runs and experiments. Managed inputs help organize and reuse test cases
+    and datasets within your application.
+    """
+    pass

--- a/nextmv/nextmv/cli/cloud/managed_input/create.py
+++ b/nextmv/nextmv/cli/cloud/managed_input/create.py
@@ -1,0 +1,146 @@
+"""
+This module defines the cloud managed-input create command for the Nextmv CLI.
+"""
+
+from typing import Annotated
+
+import typer
+
+from nextmv.cli.configuration.config import build_app
+from nextmv.cli.message import enum_values, error, in_progress, print_json
+from nextmv.cli.options import AppIDOption, ProfileOption
+from nextmv.input import InputFormat
+from nextmv.run import Format, FormatInput
+
+# Set up subcommand application.
+app = typer.Typer()
+
+
+@app.command()
+def create(
+    app_id: AppIDOption,
+    content_format: Annotated[
+        InputFormat | None,
+        typer.Option(
+            "--content-format",
+            "-c",
+            help=f"The content format for the managed input. "
+            f"Allowed values are: {enum_values(InputFormat)}. Default is JSON.",
+            metavar="CONTENT_FORMAT",
+        ),
+    ] = None,
+    description: Annotated[
+        str | None,
+        typer.Option(
+            "--description",
+            "-d",
+            help="An optional description for the managed input.",
+            metavar="DESCRIPTION",
+        ),
+    ] = None,
+    managed_input_id: Annotated[
+        str | None,
+        typer.Option(
+            "--managed-input-id",
+            "-m",
+            help="The ID to assign to the new managed input. If not provided, a random ID will be generated.",
+            envvar="NEXTMV_MANAGED_INPUT_ID",
+            metavar="MANAGED_INPUT_ID",
+        ),
+    ] = None,
+    name: Annotated[
+        str | None,
+        typer.Option(
+            "--name",
+            "-n",
+            help="A name for the managed input. If not provided, the ID will be used as the name.",
+            metavar="NAME",
+        ),
+    ] = None,
+    run_id: Annotated[
+        str | None,
+        typer.Option(
+            "--run-id",
+            "-r",
+            help="ID of the run to use for the managed input. "
+            "Either [code]--upload-id[/code] or [code]--run-id[/code] must be specified.",
+            envvar="NEXTMV_RUN_ID",
+            metavar="RUN_ID",
+        ),
+    ] = None,
+    upload_id: Annotated[
+        str | None,
+        typer.Option(
+            "--upload-id",
+            "-u",
+            help="ID of the upload to use for the managed input. "
+            "Either [code]--upload-id[/code] or [code]--run-id[/code] must be specified.",
+            metavar="UPLOAD_ID",
+        ),
+    ] = None,
+    profile: ProfileOption = None,
+) -> None:
+    """
+    Create a new Nextmv Cloud application managed input.
+
+    A managed input can be created from either an upload or a run. Use the
+    [code]--upload-id[/code] flag to create from an upload, or the
+    [code]--run-id[/code] flag to create from a run output.
+
+    You can get an upload ID by using the [code]nextmv cloud upload
+    create[/code] command. The [magenta].upload_id[/magenta] field in the
+    command output contains the upload ID, and the
+    [magenta].upload_url[/magenta] field contains a pre-signed URL to upload
+    the data to. You may use the [code]nextmv cloud data upload[/code] command
+    to upload the data to the upload URL.
+
+    If no ID is provided, a unique ID will be automatically generated. If no
+    name is provided, the ID will be used as the name.
+
+    [bold][underline]Examples[/underline][/bold]
+
+    - Create a managed input from an upload.
+        $ [green]nextmv cloud managed-input create --app-id hare-app --name "Test Input 1" \
+            --upload-id upl_123456789[/green]
+
+    - Create a managed input from a run.
+        $ [green]nextmv cloud managed-input create --app-id hare-app --name "Baseline Run" \
+            --run-id run_123456789[/green]
+
+    - Create a managed input with a specific ID and description.
+        $ [green]nextmv cloud managed-input create --app-id hare-app --name "Test Input" \\
+            --managed-input-id inp_custom --description "Test case for validation" --upload-id upl_123456789[/green]
+
+    - Create a managed input with custom format.
+        $ [green]nextmv cloud managed-input create --app-id hare-app --name "CSV Input" \\
+            --upload-id upl_123456789 --content-format csv[/green]
+    """
+
+    if upload_id is None and run_id is None:
+        error(
+            "Either [code]--upload-id[/code] or [code]--run-id[/code] must be specified. "
+            "Use [code]nextmv cloud upload create[/code] to create an upload first, "
+            "or specify an existing run ID."
+        )
+
+    cloud_app = build_app(app_id=app_id, profile=profile)
+
+    # Build format if content_format is provided
+    format_obj = None
+    if content_format is not None:
+        format_obj = Format(
+            format_input=FormatInput(
+                input_type=InputFormat(content_format),
+            ),
+        )
+
+    in_progress(msg="Creating managed input...")
+    managed_input = cloud_app.new_managed_input(
+        id=managed_input_id,
+        name=name,
+        description=description,
+        upload_id=upload_id,
+        run_id=run_id,
+        format=format_obj,
+    )
+    print_json(managed_input.to_dict())

--- a/nextmv/nextmv/cli/cloud/managed_input/delete.py
+++ b/nextmv/nextmv/cli/cloud/managed_input/delete.py
@@ -1,0 +1,65 @@
+"""
+This module defines the cloud managed-input delete command for the Nextmv CLI.
+"""
+
+from typing import Annotated
+
+import typer
+from rich.prompt import Confirm
+
+from nextmv.cli.configuration.config import build_app
+from nextmv.cli.message import info, success
+from nextmv.cli.options import AppIDOption, ManagedInputIDOption, ProfileOption
+
+# Set up subcommand application.
+app = typer.Typer()
+
+
+@app.command()
+def delete(
+    app_id: AppIDOption,
+    managed_input_id: ManagedInputIDOption,
+    yes: Annotated[
+        bool,
+        typer.Option(
+            "--yes",
+            "-y",
+            help="Agree to deletion confirmation prompt. Useful for non-interactive sessions.",
+        ),
+    ] = False,
+    profile: ProfileOption = None,
+) -> None:
+    """
+    Deletes a Nextmv Cloud application managed input.
+
+    This action is permanent and cannot be undone. Use the [code]--yes[/code]
+    flag to skip the confirmation prompt.
+
+    [bold][underline]Examples[/underline][/bold]
+
+    - Delete the managed input with the ID [magenta]inp_123456789[/magenta] from application
+      [magenta]hare-app[/magenta].
+        $ [green]nextmv cloud managed-input delete --app-id hare-app \
+            --managed-input-id inp_123456789[/green]
+
+    - Delete the managed input without confirmation prompt.
+        $ [green]nextmv cloud managed-input delete --app-id hare-app --managed-input-id inp_123456789 --yes[/green]
+    """
+
+    if not yes:
+        confirm = Confirm.ask(
+            f"Are you sure you want to delete managed input [magenta]{managed_input_id}[/magenta] "
+            f"from application [magenta]{app_id}[/magenta]? This action cannot be undone.",
+            default=False,
+        )
+
+        if not confirm:
+            info(msg=f"Managed input [magenta]{managed_input_id}[/magenta] will not be deleted.", emoji=":bulb:")
+            return
+
+    cloud_app = build_app(app_id=app_id, profile=profile)
+    cloud_app.delete_managed_input(managed_input_id=managed_input_id)
+    success(
+        f"Managed input [magenta]{managed_input_id}[/magenta] deleted successfully "
+        f"from application [magenta]{app_id}[/magenta]."
+    )

--- a/nextmv/nextmv/cli/cloud/managed_input/get.py
+++ b/nextmv/nextmv/cli/cloud/managed_input/get.py
@@ -1,0 +1,63 @@
+"""
+This module defines the cloud managed-input get command for the Nextmv CLI.
+"""
+
+import json
+from typing import Annotated
+
+import typer
+
+from nextmv.cli.configuration.config import build_app
+from nextmv.cli.message import in_progress, print_json, success
+from nextmv.cli.options import AppIDOption, ManagedInputIDOption, ProfileOption
+
+# Set up subcommand application.
+app = typer.Typer()
+
+
+@app.command()
+def get(
+    app_id: AppIDOption,
+    managed_input_id: ManagedInputIDOption,
+    output: Annotated[
+        str | None,
+        typer.Option(
+            "--output",
+            "-o",
+            help="Saves the managed input information to this location.",
+            metavar="OUTPUT_PATH",
+        ),
+    ] = None,
+    profile: ProfileOption = None,
+) -> None:
+    """
+    Get a Nextmv Cloud application managed input.
+
+    This command is useful to get the attributes of an existing Nextmv Cloud
+    application managed input by its ID.
+
+    [bold][underline]Examples[/underline][/bold]
+
+    - Get the managed input with the ID [magenta]inp_123456789[/magenta] from application [magenta]hare-app[/magenta].
+        $ [green]nextmv cloud managed-input get --app-id hare-app --managed-input-id inp_123456789[/green]
+
+    - Get the managed input with the ID [magenta]inp_123456789[/magenta] and save the information to a
+      [magenta]managed_input.json[/magenta] file.
+        $ [green]nextmv cloud managed-input get --app-id hare-app --managed-input-id inp_123456789 \
+            --output managed_input.json[/green]
+    """
+
+    cloud_app = build_app(app_id=app_id, profile=profile)
+    in_progress(msg="Getting managed input...")
+    managed_input = cloud_app.managed_input(managed_input_id=managed_input_id)
+    managed_input_dict = managed_input.to_dict()
+
+    if output is not None:
+        with open(output, "w") as f:
+            json.dump(managed_input_dict, f, indent=2)
+
+        success(msg=f"Managed input information saved to [magenta]{output}[/magenta].")
+
+        return
+
+    print_json(managed_input_dict)

--- a/nextmv/nextmv/cli/cloud/managed_input/list.py
+++ b/nextmv/nextmv/cli/cloud/managed_input/list.py
@@ -1,0 +1,60 @@
+"""
+This module defines the cloud managed-input list command for the Nextmv CLI.
+"""
+
+import json
+from typing import Annotated
+
+import typer
+
+from nextmv.cli.configuration.config import build_app
+from nextmv.cli.message import in_progress, print_json, success
+from nextmv.cli.options import AppIDOption, ProfileOption
+
+# Set up subcommand application.
+app = typer.Typer()
+
+
+@app.command()
+def list(
+    app_id: AppIDOption,
+    output: Annotated[
+        str | None,
+        typer.Option(
+            "--output",
+            "-o",
+            help="Saves the managed input list information to this location.",
+            metavar="OUTPUT_PATH",
+        ),
+    ] = None,
+    profile: ProfileOption = None,
+) -> None:
+    """
+    List all managed inputs of a Nextmv Cloud application.
+
+    [bold][underline]Examples[/underline][/bold]
+
+    - List all managed inputs of application [magenta]hare-app[/magenta].
+        $ [green]nextmv cloud managed-input list --app-id hare-app[/green]
+
+    - List all managed inputs using the profile named [magenta]hare[/magenta].
+        $ [green]nextmv cloud managed-input list --app-id hare-app --profile hare[/green]
+
+    - List all managed inputs and save the information to a [magenta]managed_inputs.json[/magenta] file.
+        $ [green]nextmv cloud managed-input list --app-id hare-app --output managed_inputs.json[/green]
+    """
+
+    cloud_app = build_app(app_id=app_id, profile=profile)
+    in_progress(msg="Listing managed inputs...")
+    managed_inputs = cloud_app.list_managed_inputs()
+    managed_inputs_dicts = [managed_input.to_dict() for managed_input in managed_inputs]
+
+    if output is not None:
+        with open(output, "w") as f:
+            json.dump(managed_inputs_dicts, f, indent=2)
+
+        success(msg=f"Managed input list information saved to [magenta]{output}[/magenta].")
+
+        return
+
+    print_json(managed_inputs_dicts)

--- a/nextmv/nextmv/cli/cloud/managed_input/update.py
+++ b/nextmv/nextmv/cli/cloud/managed_input/update.py
@@ -1,0 +1,97 @@
+"""
+This module defines the cloud managed-input update command for the Nextmv CLI.
+"""
+
+import json
+from typing import Annotated
+
+import typer
+
+from nextmv.cli.configuration.config import build_app
+from nextmv.cli.message import error, print_json, success
+from nextmv.cli.options import AppIDOption, ManagedInputIDOption, ProfileOption
+
+# Set up subcommand application.
+app = typer.Typer()
+
+
+@app.command()
+def update(
+    app_id: AppIDOption,
+    managed_input_id: ManagedInputIDOption,
+    description: Annotated[
+        str | None,
+        typer.Option(
+            "--description",
+            "-d",
+            help="A new description for the managed input.",
+            metavar="DESCRIPTION",
+        ),
+    ] = None,
+    name: Annotated[
+        str | None,
+        typer.Option(
+            "--name",
+            "-n",
+            help="A new name for the managed input.",
+            metavar="NAME",
+        ),
+    ] = None,
+    output: Annotated[
+        str | None,
+        typer.Option(
+            "--output",
+            "-o",
+            help="Saves the updated managed input information to this location.",
+            metavar="OUTPUT_PATH",
+        ),
+    ] = None,
+    profile: ProfileOption = None,
+) -> None:
+    """
+    Updates a Nextmv Cloud application managed input.
+
+    [bold][underline]Examples[/underline][/bold]
+
+    - Update a managed input's name.
+        $ [green]nextmv cloud managed-input update --app-id hare-app \
+            --managed-input-id inp_123456789 --name "Updated Test Input"[/green]
+
+    - Update a managed input's description.
+        $ [green]nextmv cloud managed-input update --app-id hare-app --managed-input-id inp_123456789 \\
+            --description "Updated test case for validation"[/green]
+
+    - Update a managed input's name and description at once.
+        $ [green]nextmv cloud managed-input update --app-id hare-app --managed-input-id inp_123456789 \\
+            --name "Updated Test Input" --description "Updated test case for validation"[/green]
+
+    - Update a managed input and save the updated information to a [magenta]updated_managed_input.json[/magenta] file.
+        $ [green]nextmv cloud managed-input update --app-id hare-app --managed-input-id inp_123456789 \\
+            --name "Updated Test Input" --output updated_managed_input.json[/green]
+    """
+
+    if name is None and description is None:
+        error("Provide at least one option to update: [code]--name[/code] or [code]--description[/code].")
+
+    cloud_app = build_app(app_id=app_id, profile=profile)
+
+    updated_managed_input = cloud_app.update_managed_input(
+        managed_input_id=managed_input_id,
+        name=name,
+        description=description,
+    )
+    success(
+        f"Managed input [magenta]{managed_input_id}[/magenta] updated successfully "
+        f"in application [magenta]{app_id}[/magenta]."
+    )
+    updated_managed_input_dict = updated_managed_input.to_dict()
+
+    if output is not None:
+        with open(output, "w") as f:
+            json.dump(updated_managed_input_dict, f, indent=2)
+
+        success(msg=f"Updated managed input information saved to [magenta]{output}[/magenta].")
+
+        return
+
+    print_json(updated_managed_input_dict)

--- a/nextmv/nextmv/cli/options.py
+++ b/nextmv/nextmv/cli/options.py
@@ -92,3 +92,17 @@ SecretsCollectionIDOption = Annotated[
         metavar="SECRETS_COLLECTION_ID",
     ),
 ]
+
+# managed_input_id option - can be used in any command that requires a managed input ID.
+# Define it as follows in commands or callbacks, as necessary:
+# managed_input_id: ManagedInputIDOption
+ManagedInputIDOption = Annotated[
+    str,
+    typer.Option(
+        "--managed-input-id",
+        "-m",
+        help="The Nextmv Cloud managed input ID to use for this action.",
+        envvar="NEXTMV_MANAGED_INPUT_ID",
+        metavar="MANAGED_INPUT_ID",
+    ),
+]

--- a/nextmv/nextmv/cloud/application/_managed_input.py
+++ b/nextmv/nextmv/cloud/application/_managed_input.py
@@ -8,6 +8,7 @@ from nextmv.cloud.input_set import ManagedInput
 from nextmv.input import InputFormat
 from nextmv.output import OutputFormat
 from nextmv.run import Format, FormatInput, FormatOutput
+from nextmv.safe import safe_id
 
 if TYPE_CHECKING:
     from . import Application
@@ -17,6 +18,32 @@ class ApplicationManagedInputMixin:
     """
     Mixin class for handling app managed inputs within an application.
     """
+
+    def delete_managed_input(self: "Application", managed_input_id: str) -> None:
+        """
+        Delete a managed input.
+
+        Permanently removes the specified managed input from the application.
+
+        Parameters
+        ----------
+        managed_input_id : str
+            ID of the managed input to delete.
+
+        Raises
+        ------
+        requests.HTTPError
+            If the response status code is not 2xx.
+
+        Examples
+        --------
+        >>> app.delete_managed_input("inp_123456789")  # Permanently deletes the managed input
+        """
+
+        _ = self.client.request(
+            method="DELETE",
+            endpoint=f"{self.endpoint}/inputs/{managed_input_id}",
+        )
 
     def list_managed_inputs(self: "Application") -> list[ManagedInput]:
         """
@@ -69,8 +96,8 @@ class ApplicationManagedInputMixin:
 
     def new_managed_input(
         self: "Application",
-        id: str,
-        name: str,
+        id: str | None = None,
+        name: str | None = None,
         description: str | None = None,
         upload_id: str | None = None,
         run_id: str | None = None,
@@ -90,17 +117,17 @@ class ApplicationManagedInputMixin:
 
         Parameters
         ----------
-        id: str
-            ID of the managed input.
-        name: str
-            Name of the managed input.
-        description: Optional[str]
+        id: Optional[str], default=None
+            ID of the managed input. Will be generated if not provided.
+        name: Optional[str], default=None
+            Name of the managed input. Will be generated if not provided.
+        description: Optional[str], default=None
             Optional description of the managed input.
-        upload_id: Optional[str]
+        upload_id: Optional[str], default=None
             ID of the upload to use for the managed input.
-        run_id: Optional[str]
+        run_id: Optional[str], default=None
             ID of the run to use for the managed input.
-        format: Optional[Format]
+        format: Optional[Format], default=None
             Format of the managed input. Default will be formatted as `JSON`.
 
         Returns
@@ -119,6 +146,11 @@ class ApplicationManagedInputMixin:
 
         if upload_id is None and run_id is None:
             raise ValueError("Either upload_id or run_id must be specified")
+
+        if id is None:
+            id = safe_id(prefix="managed-input")
+        if name is None:
+            name = id
 
         payload = {
             "id": id,


### PR DESCRIPTION
# Description

Adds the `nextmv cloud managed-input` command tree with the following commands:

- `create`
- `delete`
- `get`
- `list`
- `update`

Adds the missing `.delete_managed_input` method to the `cloud.Application` class. Makes the ID and name optional when creating the managed input, generating them automatically.