### PR TITLE
Adds the `nextmv cloud batch` command tree

### DIFF
--- a/nextmv/nextmv/__init__.py
+++ b/nextmv/nextmv/__init__.py
@@ -53,6 +53,7 @@ from .output import write as write
 from .output import write_local as write_local
 from .polling import DEFAULT_POLLING_OPTIONS as DEFAULT_POLLING_OPTIONS
 from .polling import PollingOptions as PollingOptions
+from .polling import default_polling_options as default_polling_options
 from .polling import poll as poll
 from .run import ErrorLog as ErrorLog
 from .run import ExternalRunResult as ExternalRunResult

--- a/nextmv/nextmv/cli/cloud/__init__.py
+++ b/nextmv/nextmv/cli/cloud/__init__.py
@@ -7,6 +7,7 @@ import typer
 from nextmv.cli.cloud.acceptance import app as acceptance_app
 from nextmv.cli.cloud.account import app as account_app
 from nextmv.cli.cloud.app import app as app_app
+from nextmv.cli.cloud.batch import app as batch_app
 from nextmv.cli.cloud.data import app as data_app
 from nextmv.cli.cloud.ensemble import app as ensemble_app
 from nextmv.cli.cloud.instance import app as instance_app
@@ -21,6 +22,7 @@ app = typer.Typer()
 app.add_typer(acceptance_app, name="acceptance")
 app.add_typer(account_app, name="account")
 app.add_typer(app_app, name="app")
+app.add_typer(batch_app, name="batch")
 app.add_typer(data_app, name="data")
 app.add_typer(ensemble_app, name="ensemble")
 app.add_typer(instance_app, name="instance")

--- a/nextmv/nextmv/cli/cloud/acceptance/create.py
+++ b/nextmv/nextmv/cli/cloud/acceptance/create.py
@@ -11,7 +11,7 @@ from nextmv.cli.configuration.config import build_app
 from nextmv.cli.message import enum_values, error, in_progress, print_json, success
 from nextmv.cli.options import AppIDOption, ProfileOption
 from nextmv.cloud.acceptance_test import Comparison, Metric, MetricToleranceType, MetricType, StatisticType
-from nextmv.polling import DEFAULT_POLLING_OPTIONS
+from nextmv.polling import default_polling_options
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -32,7 +32,8 @@ app = typer.Typer()
 
     Use the [code]--wait[/code] flag to wait for the acceptance test to
     complete, polling for results. Use the [code]--output[/code] flag to
-    specify a destination file for the results.
+    specify a destination file for the output obtained. Please note that using
+    the [code]--output[/code] flag will not activate waiting by itself.
 
     [bold][underline]Metrics[/underline][/bold]
 
@@ -243,7 +244,7 @@ def create(
         typer.Option(
             "--output",
             "-o",
-            help="Save the acceptance test results to this location.",
+            help="Save the acceptance test output to this location.",
             metavar="OUTPUT_PATH",
             rich_help_panel="Output control",
         ),
@@ -274,7 +275,7 @@ def create(
     metrics_list = build_metrics(metrics)
 
     # Build the polling options.
-    polling_options = DEFAULT_POLLING_OPTIONS
+    polling_options = default_polling_options()
     polling_options.max_duration = timeout
 
     # Create the acceptance test

--- a/nextmv/nextmv/cli/cloud/acceptance/create.py
+++ b/nextmv/nextmv/cli/cloud/acceptance/create.py
@@ -31,9 +31,8 @@ app = typer.Typer()
     experiment.
 
     Use the [code]--wait[/code] flag to wait for the acceptance test to
-    complete, polling for results. Using the [code]--output[/code] flag will
-    also activate waiting, and allows you to specify a destination file for the
-    results.
+    complete, polling for results. Use the [code]--output[/code] flag to
+    specify a destination file for the results.
 
     [bold][underline]Metrics[/underline][/bold]
 
@@ -244,7 +243,7 @@ def create(
         typer.Option(
             "--output",
             "-o",
-            help="Waits for the acceptance test to complete and saves the results to this location.",
+            help="Save the acceptance test results to this location.",
             metavar="OUTPUT_PATH",
             rich_help_panel="Output control",
         ),
@@ -278,11 +277,8 @@ def create(
     polling_options = DEFAULT_POLLING_OPTIONS
     polling_options.max_duration = timeout
 
-    # Determine if we should wait
-    should_wait = wait or (output is not None and output != "")
-
     # Create the acceptance test
-    if should_wait:
+    if wait:
         in_progress(msg="Creating acceptance test and waiting for results...")
         acceptance_test = cloud_app.new_acceptance_test_with_result(
             candidate_instance_id=candidate_instance_id,

--- a/nextmv/nextmv/cli/cloud/acceptance/get.py
+++ b/nextmv/nextmv/cli/cloud/acceptance/get.py
@@ -10,7 +10,7 @@ import typer
 from nextmv.cli.configuration.config import build_app
 from nextmv.cli.message import in_progress, print_json, success
 from nextmv.cli.options import AcceptanceTestIDOption, AppIDOption, ProfileOption
-from nextmv.polling import DEFAULT_POLLING_OPTIONS
+from nextmv.polling import default_polling_options
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -75,7 +75,7 @@ def get(
     cloud_app = build_app(app_id=app_id, profile=profile)
 
     # Build the polling options.
-    polling_options = DEFAULT_POLLING_OPTIONS
+    polling_options = default_polling_options()
     polling_options.max_duration = timeout
 
     # Determine if we should wait

--- a/nextmv/nextmv/cli/cloud/acceptance/update.py
+++ b/nextmv/nextmv/cli/cloud/acceptance/update.py
@@ -78,6 +78,10 @@ def update(
         name=name,
         description=description,
     )
+    success(
+        f"Acceptance test [magenta]{acceptance_test_id}[/magenta] updated successfully "
+        f"in application [magenta]{app_id}[/magenta]."
+    )
 
     acceptance_test_dict = acceptance_test.to_dict()
 

--- a/nextmv/nextmv/cli/cloud/batch/__init__.py
+++ b/nextmv/nextmv/cli/cloud/batch/__init__.py
@@ -1,0 +1,29 @@
+"""
+This module defines the cloud batch command tree for the Nextmv CLI.
+"""
+
+import typer
+
+from nextmv.cli.cloud.batch.create import app as create_app
+from nextmv.cli.cloud.batch.delete import app as delete_app
+from nextmv.cli.cloud.batch.get import app as get_app
+from nextmv.cli.cloud.batch.list import app as list_app
+from nextmv.cli.cloud.batch.metadata import app as metadata_app
+from nextmv.cli.cloud.batch.update import app as update_app
+
+# Set up subcommand application.
+app = typer.Typer()
+app.add_typer(create_app)
+app.add_typer(delete_app)
+app.add_typer(get_app)
+app.add_typer(list_app)
+app.add_typer(metadata_app)
+app.add_typer(update_app)
+
+
+@app.callback()
+def callback() -> None:
+    """
+    Create and manage Nextmv Cloud batch experiments.
+    """
+    pass

--- a/nextmv/nextmv/cli/cloud/batch/create.py
+++ b/nextmv/nextmv/cli/cloud/batch/create.py
@@ -1,0 +1,454 @@
+"""
+This module defines the cloud batch create command for the Nextmv CLI.
+"""
+
+import json
+from typing import Annotated
+
+import typer
+
+from nextmv.cli.configuration.config import build_app
+from nextmv.cli.message import error, in_progress, print_json, success
+from nextmv.cli.options import AppIDOption, ProfileOption
+from nextmv.cloud.batch_experiment import BatchExperimentRun
+from nextmv.polling import DEFAULT_POLLING_OPTIONS
+
+# Set up subcommand application.
+app = typer.Typer()
+
+
+@app.command()
+def create(
+    app_id: AppIDOption,
+    batch_id: Annotated[
+        str | None,
+        typer.Option(
+            "--batch-id",
+            "-b",
+            help="ID for the batch experiment. Will be generated if not provided.",
+            envvar="NEXTMV_BATCH_ID",
+            metavar="BATCH_ID",
+            rich_help_panel="Batch experiment configuration",
+        ),
+    ] = None,
+    description: Annotated[
+        str | None,
+        typer.Option(
+            "--description",
+            "-d",
+            help="Description of the batch experiment.",
+            metavar="DESCRIPTION",
+            rich_help_panel="Batch experiment configuration",
+        ),
+    ] = None,
+    input_set_id: Annotated[
+        str | None,
+        typer.Option(
+            "--input-set-id",
+            "-i",
+            help="ID of the input set to use for the batch experiment.",
+            metavar="INPUT_SET_ID",
+            rich_help_panel="Batch experiment configuration",
+        ),
+    ] = None,
+    name: Annotated[
+        str | None,
+        typer.Option(
+            "--name",
+            "-n",
+            help="Name of the batch experiment. If not provided, the ID will be used as the name.",
+            metavar="NAME",
+            rich_help_panel="Batch experiment configuration",
+        ),
+    ] = None,
+    option_sets: Annotated[
+        str | None,
+        typer.Option(
+            "--option-sets",
+            help="Option sets to use for the batch experiment. Data should be valid [magenta]json[/magenta]. "
+            "See command help for details on option sets formatting.",
+            metavar="OPTION_SETS",
+            rich_help_panel="Batch experiment configuration",
+        ),
+    ] = None,
+    output: Annotated[
+        str | None,
+        typer.Option(
+            "--output",
+            "-o",
+            help="Save the batch experiment results to this location.",
+            metavar="OUTPUT_PATH",
+            rich_help_panel="Output control",
+        ),
+    ] = None,
+    runs: Annotated[
+        list[str] | None,
+        typer.Option(
+            "--runs",
+            "-r",
+            help="Runs to execute for the batch experiment. Data should be valid [magenta]json[/magenta]. "
+            "Pass multiple runs by repeating the flag, or providing a list of objects. "
+            "See command help for details on run formatting.",
+            metavar="RUNS",
+            rich_help_panel="Batch experiment configuration",
+        ),
+    ] = None,
+    timeout: Annotated[
+        int,
+        typer.Option(
+            help="The maximum time in seconds to wait for results when polling. Poll indefinitely if not set.",
+            metavar="TIMEOUT_SECONDS",
+            rich_help_panel="Output control",
+        ),
+    ] = -1,
+    wait: Annotated[
+        bool,
+        typer.Option(
+            "--wait",
+            "-w",
+            help="Wait for the batch experiment to complete. Results are printed to [magenta]stdout[/magenta]. "
+            "Specify output location with [code]--output[/code].",
+            rich_help_panel="Output control",
+        ),
+    ] = False,
+    profile: ProfileOption = None,
+) -> None:
+    """
+    Create a new Nextmv Cloud batch experiment.
+
+    A batch experiment executes multiple runs across different inputs and/or
+    configurations. Each run is defined by a combination of input, instance or
+    version, and optional configuration options.
+
+    Use the [code]--wait[/code] flag to wait for the batch experiment to
+    complete, polling for results. Use the [code]--output[/code] flag to
+    specify a destination file for the results.
+
+    [bold][underline]Runs[/underline][/bold]
+
+    Runs are provided as [magenta]json[/magenta] objects using the
+    [code]--runs[/code] flag. Each run defines what input, instance/version,
+    and configuration to use.
+
+    You can provide runs in three ways:
+    - A single run as a [magenta]json[/magenta] object.
+    - Multiple runs by repeating the [code]--runs[/code] flag.
+    - Multiple runs as a [magenta]json[/magenta] array in a single [code]--runs[/code] flag.
+
+    Each run must have the following fields:
+    - [magenta]input_id[/magenta]: ID of the input to use for this run
+      (required). If a managed input is used, this should be the ID of the
+      managed input. If [magenta]input_set_id[/magenta] is provided for the run,
+      this should be the ID of an input within that input set.
+    - [magenta]instance_id[/magenta] OR [magenta]version_id[/magenta]: Either an instance ID or
+      version ID must be provided (at least one required).
+    - [magenta]option_set[/magenta]: ID of the option set to use (optional).
+      Make sure to define the option sets using the [code]--option-sets[/code] flag.
+    - [magenta]input_set_id[/magenta]: ID of the input set (optional).
+    - [magenta]scenario_id[/magenta]: Scenario ID if part of a scenario test (optional).
+    - [magenta]repetition[/magenta]: Repetition number (optional).
+
+    Object format:
+    [green]{
+        "input_id": "meadow-input-a1",
+        "instance_id": "bunny-hopper-v2",
+        "option_set": "speed-optimized",
+        "input_set_id": "spring-gardens"
+    }[/green]
+
+    [bold][underline]Option Sets[/underline][/bold]
+
+    Option sets are provided as a [magenta]json[/magenta] object using the
+    [code]--option-sets[/code] flag. Option sets define named collections of
+    runtime options that can be referenced by runs.
+
+    The option sets object is a dictionary where keys are option set IDs and
+    values are dictionaries of string key-value pairs representing the options.
+
+    Object format:
+    [green]{
+        "speed-optimized": {"timeout": "30", "algorithm": "fast"},
+        "quality-focused": {"timeout": "300", "algorithm": "thorough"}
+    }[/green]
+
+    [bold][underline]Examples[/underline][/bold]
+
+    - Create a batch experiment with a single run.
+        $ [green]RUN='{
+            "input_id": "carrot-patch-a",
+            "instance_id": "warren-planner-v1"
+        }'
+        nextmv cloud batch create --app-id hare-app --batch-id bunny-hop-test \\
+            --name "Spring Meadow Routes" --input-set-id spring-gardens --runs "$RUN"[/green]
+
+    - Create with multiple runs by repeating the flag.
+        $ [green]RUN1='{
+            "input_id": "lettuce-field-1",
+            "instance_id": "hop-optimizer"
+        }'
+        RUN2='{
+            "input_id": "lettuce-field-2",
+            "instance_id": "hop-optimizer"
+        }'
+        nextmv cloud batch create --app-id hare-app --batch-id lettuce-routes \\
+            --name "Lettuce Delivery Optimization" --input-set-id veggie-gardens \\
+            --runs "$RUN1" --runs "$RUN2"[/green]
+
+    - Create with multiple runs in a single JSON array.
+        $ [green]RUNS='[
+            {
+                "input_id": "warren-zone-a",
+                "instance_id": "burrow-builder"
+            },
+            {
+                "input_id": "warren-zone-b",
+                "version_id": "tunnel-planner-v3"
+            }
+        ]'
+        nextmv cloud batch create --app-id hare-app --batch-id warren-expansion \\
+            --name "Warren Construction Plans" --input-set-id burrow-sites --runs "$RUNS"[/green]
+
+    - Create a batch experiment and wait for it to complete.
+        $ [green]RUN='{
+            "input_id": "carrot-harvest",
+            "instance_id": "foraging-route"
+        }'
+        nextmv cloud batch create --app-id hare-app --batch-id harvest-time \\
+            --name "Autumn Carrot Collection" --input-set-id harvest-season \\
+            --runs "$RUN" --wait[/green]
+
+    - Create a batch experiment and save the results to a file.
+        $ [green]RUN='{
+            "input_id": "predator-zones",
+            "instance_id": "safe-hopper"
+        }'
+        nextmv cloud batch create --app-id hare-app --batch-id safety-analysis \\
+            --name "Fox Avoidance Routes" --input-set-id danger-zones \\
+            --runs "$RUN" --output bunny-safety-results.json[/green]
+
+    - Create a batch experiment with option sets.
+        $ [green]RUN1='{
+            "input_id": "garden-route-1",
+            "instance_id": "hop-optimizer",
+            "option_set": "fast-hops"
+        }'
+        RUN2='{
+            "input_id": "garden-route-1",
+            "instance_id": "hop-optimizer",
+            "option_set": "careful-hops"
+        }'
+        OPTION_SETS='{
+            "fast-hops": {"max_speed": "10", "caution_level": "low"},
+            "careful-hops": {"max_speed": "5", "caution_level": "high"}
+        }'
+        nextmv cloud batch create --app-id hare-app --batch-id hop-comparison \\
+            --name "Speed vs Safety Analysis" --input-set-id garden-paths \\
+            --runs "$RUN1" --runs "$RUN2" --option-sets "$OPTION_SETS"[/green]
+    """
+    cloud_app = build_app(app_id=app_id, profile=profile)
+
+    # Build the runs list from the CLI options
+    runs_list = build_runs(runs)
+
+    # Build the option sets from the CLI options
+    option_sets_dict = build_option_sets(option_sets)
+
+    # Build the polling options.
+    polling_options = DEFAULT_POLLING_OPTIONS
+    polling_options.max_duration = timeout
+
+    # Create the batch experiment
+    if wait:
+        in_progress(msg="Creating batch experiment and waiting for results...")
+        batch_experiment = cloud_app.new_batch_experiment_with_result(
+            id=batch_id,
+            name=name,
+            runs=runs_list,
+            description=description,
+            input_set_id=input_set_id,
+            option_sets=option_sets_dict,
+            polling_options=polling_options,
+        )
+        success(msg=f"Batch experiment [magenta]{batch_experiment.id}[/magenta] completed.")
+
+    else:
+        in_progress(msg="Creating batch experiment...")
+        batch_experiment_id = cloud_app.new_batch_experiment(
+            id=batch_id,
+            name=name,
+            runs=runs_list,
+            description=description,
+            input_set_id=input_set_id,
+            option_sets=option_sets_dict,
+        )
+        batch_experiment = cloud_app.batch_experiment(batch_id=batch_experiment_id)
+
+    batch_experiment_dict = batch_experiment.to_dict()
+
+    # Handle output
+    if output is not None and output != "":
+        with open(output, "w") as f:
+            json.dump(batch_experiment_dict, f, indent=2)
+
+        success(msg=f"Batch experiment results saved to [magenta]{output}[/magenta].")
+        return
+
+    print_json(batch_experiment_dict)
+
+
+def build_option_sets(option_sets: str | None) -> dict[str, dict[str, str]] | None:
+    """
+    Builds the option sets dictionary from the CLI option.
+
+    Parameters
+    ----------
+    option_sets : str | None
+        Option sets JSON string provided via the CLI.
+
+    Returns
+    -------
+    dict[str, dict[str, str]] | None
+        The built option sets dictionary, or None if not provided.
+    """
+    if option_sets is None:
+        return None
+
+    try:
+        option_sets_data = json.loads(option_sets)
+
+        if not isinstance(option_sets_data, dict):
+            error(
+                f"Invalid option sets format: [magenta]{option_sets}[/magenta]. "
+                "Expected [magenta]json[/magenta] object."
+            )
+
+        # Validate structure
+        for key, value in option_sets_data.items():
+            if not isinstance(value, dict):
+                error(
+                    f"Invalid option sets format: [magenta]{option_sets}[/magenta]. "
+                    f"Each option set must be a [magenta]json[/magenta] object. "
+                    f"Key [magenta]{key}[/magenta] has invalid value."
+                )
+
+        return option_sets_data
+
+    except json.JSONDecodeError as e:
+        error(f"Invalid option sets format: [magenta]{option_sets}[/magenta]. Error: {e}")
+
+
+def build_runs(runs: list[str] | None) -> list[BatchExperimentRun] | None:
+    """
+    Builds the runs list from the CLI option(s).
+
+    Parameters
+    ----------
+    runs : list[str] | None
+        List of runs provided via the CLI.
+
+    Returns
+    -------
+    list[BatchExperimentRun] | None
+        The built runs list, or None if no runs provided.
+    """
+    if runs is None:
+        return None
+
+    runs_list = []
+
+    for run_str in runs:
+        try:
+            run_data = json.loads(run_str)
+
+            # Handle the case where the value is a list of runs.
+            if isinstance(run_data, list):
+                runs_list.extend(_process_run_list(run_data, run_str))
+
+            # Handle the case where the value is a single run.
+            elif isinstance(run_data, dict):
+                runs_list.append(_process_single_run(run_data, run_str))
+
+            else:
+                error(
+                    f"Invalid run format: [magenta]{run_str}[/magenta]. "
+                    "Expected [magenta]json[/magenta] object or array."
+                )
+
+        except (json.JSONDecodeError, KeyError, ValueError) as e:
+            error(f"Invalid run format: [magenta]{run_str}[/magenta]. Error: {e}")
+
+    return runs_list if runs_list else None
+
+
+def _process_run_list(run_data: list, run_str: str) -> list[BatchExperimentRun]:
+    """
+    Process a list of run objects.
+
+    Parameters
+    ----------
+    run_data : list
+        List of run dictionaries.
+    run_str : str
+        Original string for error messages.
+
+    Returns
+    -------
+    list[BatchExperimentRun]
+        List of processed runs.
+    """
+    processed_runs = []
+    for ix, item in enumerate(run_data):
+        _validate_run_fields(item, run_str, ix)
+        run = BatchExperimentRun(**item)
+        processed_runs.append(run)
+    return processed_runs
+
+
+def _process_single_run(run_data: dict, run_str: str) -> BatchExperimentRun:
+    """
+    Process a single run object.
+
+    Parameters
+    ----------
+    run_data : dict
+        Run dictionary.
+    run_str : str
+        Original string for error messages.
+
+    Returns
+    -------
+    BatchExperimentRun]
+        Processed run.
+    """
+    _validate_run_fields(run_data, run_str)
+    return BatchExperimentRun(**run_data)
+
+
+def _validate_run_fields(run_data: dict, run_str: str, index: int | None = None) -> None:
+    """
+    Validate that required run fields are present.
+
+    Parameters
+    ----------
+    run_data : dict
+        Run dictionary to validate.
+    run_str : str
+        Original string for error messages.
+    index : int | None
+        Index in array if validating array element.
+    """
+    location = f"at index [magenta]{index}[/magenta] in " if index is not None else "in "
+
+    if run_data.get("input_id") is None:
+        error(
+            f"Invalid run format {location}"
+            f"[magenta]{run_str}[/magenta]. Each run must have "
+            "[magenta]input_id[/magenta] field."
+        )
+
+    if run_data.get("instance_id") is None and run_data.get("version_id") is None:
+        error(
+            f"Invalid run format {location}"
+            f"[magenta]{run_str}[/magenta]. Each run must have either "
+            "[magenta]instance_id[/magenta] or [magenta]version_id[/magenta] field."
+        )

--- a/nextmv/nextmv/cli/cloud/batch/create.py
+++ b/nextmv/nextmv/cli/cloud/batch/create.py
@@ -11,7 +11,7 @@ from nextmv.cli.configuration.config import build_app
 from nextmv.cli.message import error, in_progress, print_json, success
 from nextmv.cli.options import AppIDOption, ProfileOption
 from nextmv.cloud.batch_experiment import BatchExperimentRun
-from nextmv.polling import DEFAULT_POLLING_OPTIONS
+from nextmv.polling import default_polling_options
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -76,7 +76,7 @@ def create(
         typer.Option(
             "--output",
             "-o",
-            help="Save the batch experiment results to this location.",
+            help="Save the batch experiment output to this location.",
             metavar="OUTPUT_PATH",
             rich_help_panel="Output control",
         ),
@@ -122,7 +122,8 @@ def create(
 
     Use the [code]--wait[/code] flag to wait for the batch experiment to
     complete, polling for results. Use the [code]--output[/code] flag to
-    specify a destination file for the results.
+    specify a destination file for the output obtained. Please note that using
+    the [code]--output[/code] flag will not activate waiting by itself.
 
     [bold][underline]Runs[/underline][/bold]
 
@@ -254,7 +255,7 @@ def create(
     option_sets_dict = build_option_sets(option_sets)
 
     # Build the polling options.
-    polling_options = DEFAULT_POLLING_OPTIONS
+    polling_options = default_polling_options()
     polling_options.max_duration = timeout
 
     # Create the batch experiment
@@ -417,7 +418,7 @@ def _process_single_run(run_data: dict, run_str: str) -> BatchExperimentRun:
 
     Returns
     -------
-    BatchExperimentRun]
+    BatchExperimentRun
         Processed run.
     """
     _validate_run_fields(run_data, run_str)

--- a/nextmv/nextmv/cli/cloud/batch/delete.py
+++ b/nextmv/nextmv/cli/cloud/batch/delete.py
@@ -1,0 +1,68 @@
+"""
+This module defines the cloud batch delete command for the Nextmv CLI.
+"""
+
+from typing import Annotated
+
+import typer
+from rich.prompt import Confirm
+
+from nextmv.cli.configuration.config import build_app
+from nextmv.cli.message import info, success
+from nextmv.cli.options import AppIDOption, BatchExperimentIDOption, ProfileOption
+
+# Set up subcommand application.
+app = typer.Typer()
+
+
+@app.command()
+def delete(
+    app_id: AppIDOption,
+    batch_id: BatchExperimentIDOption,
+    yes: Annotated[
+        bool,
+        typer.Option(
+            "--yes",
+            "-y",
+            help="Agree to deletion confirmation prompt. Useful for non-interactive sessions.",
+        ),
+    ] = False,
+    profile: ProfileOption = None,
+) -> None:
+    """
+    Deletes a Nextmv Cloud batch experiment.
+
+    This action is permanent and cannot be undone. The batch experiment and all
+    associated data, including runs, will be deleted. Use the [code]--yes[/code]
+    flag to skip the confirmation prompt.
+
+    [bold][underline]Examples[/underline][/bold]
+
+    - Delete the batch experiment with the ID [magenta]hop-analysis[/magenta] from application
+      [magenta]hare-app[/magenta].
+        $ [green]nextmv cloud batch delete --app-id hare-app --batch-id hop-analysis[/green]
+
+    - Delete the batch experiment without confirmation prompt.
+        $ [green]nextmv cloud batch delete --app-id hare-app --batch-id carrot-routes --yes[/green]
+    """
+
+    if not yes:
+        confirm = Confirm.ask(
+            f"Are you sure you want to delete batch experiment [magenta]{batch_id}[/magenta] "
+            f"from application [magenta]{app_id}[/magenta]? This action cannot be undone.",
+            default=False,
+        )
+
+        if not confirm:
+            info(
+                msg=f"Batch experiment [magenta]{batch_id}[/magenta] will not be deleted.",
+                emoji=":bulb:",
+            )
+            return
+
+    cloud_app = build_app(app_id=app_id, profile=profile)
+    cloud_app.delete_batch_experiment(batch_id=batch_id)
+    success(
+        f"Batch experiment [magenta]{batch_id}[/magenta] deleted successfully "
+        f"from application [magenta]{app_id}[/magenta]."
+    )

--- a/nextmv/nextmv/cli/cloud/batch/get.py
+++ b/nextmv/nextmv/cli/cloud/batch/get.py
@@ -1,0 +1,103 @@
+"""
+This module defines the cloud batch get command for the Nextmv CLI.
+"""
+
+import json
+from typing import Annotated
+
+import typer
+
+from nextmv.cli.configuration.config import build_app
+from nextmv.cli.message import in_progress, print_json, success
+from nextmv.cli.options import AppIDOption, BatchExperimentIDOption, ProfileOption
+from nextmv.polling import DEFAULT_POLLING_OPTIONS
+
+# Set up subcommand application.
+app = typer.Typer()
+
+
+@app.command()
+def get(
+    app_id: AppIDOption,
+    batch_id: BatchExperimentIDOption,
+    output: Annotated[
+        str | None,
+        typer.Option(
+            "--output",
+            "-o",
+            help="Waits for the batch experiment to complete and saves the results to this location.",
+            metavar="OUTPUT_PATH",
+        ),
+    ] = None,
+    timeout: Annotated[
+        int,
+        typer.Option(
+            help="The maximum time in seconds to wait for results when polling. Poll indefinitely if not set.",
+            metavar="TIMEOUT_SECONDS",
+        ),
+    ] = -1,
+    wait: Annotated[
+        bool,
+        typer.Option(
+            "--wait",
+            "-w",
+            help="Wait for the batch experiment to complete. Results are printed to [magenta]stdout[/magenta]. "
+            "Specify output location with [code]--output[/code].",
+        ),
+    ] = False,
+    profile: ProfileOption = None,
+) -> None:
+    """
+    Get a Nextmv Cloud batch experiment.
+
+    Use the [code]--wait[/code] flag to wait for the batch experiment to
+    complete, polling for results. Using the [code]--output[/code] flag will
+    also activate waiting, and allows you to specify a destination file for the
+    results.
+
+    [bold][underline]Examples[/underline][/bold]
+
+    - Get the batch experiment with ID [magenta]carrot-optimization[/magenta] from application
+      [magenta]hare-app[/magenta].
+        $ [green]nextmv cloud batch get --app-id hare-app --batch-id carrot-optimization[/green]
+
+    - Get the batch experiment and wait for it to complete if necessary.
+        $ [green]nextmv cloud batch get --app-id hare-app --batch-id bunny-hop-test --wait[/green]
+
+    - Get the batch experiment and save the results to a file.
+        $ [green]nextmv cloud batch get --app-id hare-app \\
+            --batch-id warren-planning --output results.json[/green]
+
+    - Get the batch experiment using a specific profile.
+        $ [green]nextmv cloud batch get --app-id hare-app --batch-id lettuce-routes --profile prod[/green]
+    """
+
+    cloud_app = build_app(app_id=app_id, profile=profile)
+
+    # Build the polling options.
+    polling_options = DEFAULT_POLLING_OPTIONS
+    polling_options.max_duration = timeout
+
+    # Determine if we should wait
+    should_wait = wait or (output is not None and output != "")
+
+    in_progress(msg="Getting batch experiment...")
+    if should_wait:
+        batch_experiment = cloud_app.batch_experiment_with_polling(
+            batch_id=batch_id,
+            polling_options=polling_options,
+        )
+    else:
+        batch_experiment = cloud_app.batch_experiment(batch_id=batch_id)
+
+    batch_experiment_dict = batch_experiment.to_dict()
+
+    # Handle output
+    if output is not None and output != "":
+        with open(output, "w") as f:
+            json.dump(batch_experiment_dict, f, indent=2)
+
+        success(msg=f"Batch experiment results saved to [magenta]{output}[/magenta].")
+        return
+
+    print_json(batch_experiment_dict)

--- a/nextmv/nextmv/cli/cloud/batch/get.py
+++ b/nextmv/nextmv/cli/cloud/batch/get.py
@@ -10,7 +10,7 @@ import typer
 from nextmv.cli.configuration.config import build_app
 from nextmv.cli.message import in_progress, print_json, success
 from nextmv.cli.options import AppIDOption, BatchExperimentIDOption, ProfileOption
-from nextmv.polling import DEFAULT_POLLING_OPTIONS
+from nextmv.polling import default_polling_options
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -75,7 +75,7 @@ def get(
     cloud_app = build_app(app_id=app_id, profile=profile)
 
     # Build the polling options.
-    polling_options = DEFAULT_POLLING_OPTIONS
+    polling_options = default_polling_options()
     polling_options.max_duration = timeout
 
     # Determine if we should wait

--- a/nextmv/nextmv/cli/cloud/batch/list.py
+++ b/nextmv/nextmv/cli/cloud/batch/list.py
@@ -1,0 +1,62 @@
+"""
+This module defines the cloud batch list command for the Nextmv CLI.
+"""
+
+import json
+from typing import Annotated
+
+import typer
+
+from nextmv.cli.configuration.config import build_app
+from nextmv.cli.message import in_progress, print_json, success
+from nextmv.cli.options import AppIDOption, ProfileOption
+
+# Set up subcommand application.
+app = typer.Typer()
+
+
+@app.command()
+def list(
+    app_id: AppIDOption,
+    output: Annotated[
+        str | None,
+        typer.Option(
+            "--output",
+            "-o",
+            help="Saves the list of batch experiments to this location.",
+            metavar="OUTPUT_PATH",
+        ),
+    ] = None,
+    profile: ProfileOption = None,
+) -> None:
+    """
+    List all Nextmv Cloud batch experiments for an application.
+
+    This command retrieves all batch experiments associated with the specified
+    application.
+
+    [bold][underline]Examples[/underline][/bold]
+
+    - List all batch experiments for application [magenta]hare-app[/magenta].
+        $ [green]nextmv cloud batch list --app-id hare-app[/green]
+
+    - List all batch experiments and save to a file.
+        $ [green]nextmv cloud batch list --app-id hare-app --output experiments.json[/green]
+
+    - List all batch experiments using a specific profile.
+        $ [green]nextmv cloud batch list --app-id hare-app --profile prod[/green]
+    """
+
+    cloud_app = build_app(app_id=app_id, profile=profile)
+    in_progress(msg="Listing batch experiments...")
+    batch_experiments = cloud_app.list_batch_experiments()
+    batch_experiments_dict = [exp.to_dict() for exp in batch_experiments]
+
+    if output is not None:
+        with open(output, "w") as f:
+            json.dump(batch_experiments_dict, f, indent=2)
+
+        success(msg=f"Batch experiments list saved to [magenta]{output}[/magenta].")
+        return
+
+    print_json(batch_experiments_dict)

--- a/nextmv/nextmv/cli/cloud/batch/metadata.py
+++ b/nextmv/nextmv/cli/cloud/batch/metadata.py
@@ -1,0 +1,66 @@
+"""
+This module defines the cloud batch metadata command for the Nextmv CLI.
+"""
+
+import json
+from typing import Annotated
+
+import typer
+
+from nextmv.cli.configuration.config import build_app
+from nextmv.cli.message import in_progress, print_json, success
+from nextmv.cli.options import AppIDOption, BatchExperimentIDOption, ProfileOption
+
+# Set up subcommand application.
+app = typer.Typer()
+
+
+@app.command()
+def metadata(
+    app_id: AppIDOption,
+    batch_id: BatchExperimentIDOption,
+    output: Annotated[
+        str | None,
+        typer.Option(
+            "--output",
+            "-o",
+            help="Saves the batch experiment metadata to this location.",
+            metavar="OUTPUT_PATH",
+        ),
+    ] = None,
+    profile: ProfileOption = None,
+) -> None:
+    """
+    Get metadata for a Nextmv Cloud batch experiment.
+
+    This command retrieves metadata for a specific batch experiment, including
+    status, creation date, and other high-level information without the full
+    run details.
+
+    [bold][underline]Examples[/underline][/bold]
+
+    - Get metadata for batch experiment [magenta]bunny-warren-optimization[/magenta] from application
+      [magenta]hare-app[/magenta].
+        $ [green]nextmv cloud batch metadata --app-id hare-app --batch-id bunny-warren-optimization[/green]
+
+    - Get metadata and save to a file.
+        $ [green]nextmv cloud batch metadata --app-id hare-app --batch-id lettuce-delivery \\
+            --output metadata.json[/green]
+
+    - Get metadata using a specific profile.
+        $ [green]nextmv cloud batch metadata --app-id hare-app --batch-id hop-schedule --profile prod[/green]
+    """
+
+    cloud_app = build_app(app_id=app_id, profile=profile)
+    in_progress(msg="Getting batch experiment metadata...")
+    batch_metadata = cloud_app.batch_experiment_metadata(batch_id=batch_id)
+    batch_metadata_dict = batch_metadata.to_dict()
+
+    if output is not None:
+        with open(output, "w") as f:
+            json.dump(batch_metadata_dict, f, indent=2)
+
+        success(msg=f"Batch experiment metadata saved to [magenta]{output}[/magenta].")
+        return
+
+    print_json(batch_metadata_dict)

--- a/nextmv/nextmv/cli/cloud/batch/update.py
+++ b/nextmv/nextmv/cli/cloud/batch/update.py
@@ -1,0 +1,95 @@
+"""
+This module defines the cloud batch update command for the Nextmv CLI.
+"""
+
+import json
+from typing import Annotated
+
+import typer
+
+from nextmv.cli.configuration.config import build_app
+from nextmv.cli.message import in_progress, print_json, success
+from nextmv.cli.options import AppIDOption, BatchExperimentIDOption, ProfileOption
+
+# Set up subcommand application.
+app = typer.Typer()
+
+
+@app.command()
+def update(
+    app_id: AppIDOption,
+    batch_id: BatchExperimentIDOption,
+    description: Annotated[
+        str | None,
+        typer.Option(
+            "--description",
+            "-d",
+            help="Updated description of the batch experiment.",
+            metavar="DESCRIPTION",
+        ),
+    ] = None,
+    name: Annotated[
+        str | None,
+        typer.Option(
+            "--name",
+            "-n",
+            help="Updated name of the batch experiment.",
+            metavar="NAME",
+        ),
+    ] = None,
+    output: Annotated[
+        str | None,
+        typer.Option(
+            "--output",
+            "-o",
+            help="Saves the updated batch experiment information to this location.",
+            metavar="OUTPUT_PATH",
+        ),
+    ] = None,
+    profile: ProfileOption = None,
+) -> None:
+    """
+    Update a Nextmv Cloud batch experiment.
+
+    Update the name and/or description of a batch experiment. Any fields not
+    specified will remain unchanged.
+
+    [bold][underline]Examples[/underline][/bold]
+
+    - Update the name of a batch experiment.
+        $ [green]nextmv cloud batch update --app-id hare-app --batch-id carrot-feast \\
+            --name "Spring Carrot Harvest"[/green]
+
+    - Update the description of a batch experiment.
+        $ [green]nextmv cloud batch update --app-id hare-app --batch-id bunny-hop-routes \\
+            --description "Optimizing hop paths through the meadow"[/green]
+
+    - Update both name and description and save the result.
+        $ [green]nextmv cloud batch update --app-id hare-app --batch-id lettuce-delivery \\
+            --name "Warren Lettuce Express" --description "Fast lettuce delivery to all burrows" \\
+            --output updated-batch.json[/green]
+    """
+
+    cloud_app = build_app(app_id=app_id, profile=profile)
+
+    in_progress(msg="Updating batch experiment...")
+    batch_experiment = cloud_app.update_batch_experiment(
+        batch_experiment_id=batch_id,
+        name=name,
+        description=description,
+    )
+
+    batch_experiment_dict = batch_experiment.to_dict()
+    success(
+        f"Batch experiment [magenta]{batch_id}[/magenta] updated successfully "
+        f"in application [magenta]{app_id}[/magenta]."
+    )
+
+    if output is not None:
+        with open(output, "w") as f:
+            json.dump(batch_experiment_dict, f, indent=2)
+
+        success(msg=f"Updated batch experiment information saved to [magenta]{output}[/magenta].")
+        return
+
+    print_json(batch_experiment_dict)

--- a/nextmv/nextmv/cli/cloud/ensemble/create.py
+++ b/nextmv/nextmv/cli/cloud/ensemble/create.py
@@ -15,7 +15,157 @@ from nextmv.cloud.ensemble import EvaluationRule, RuleObjective, RuleTolerance, 
 app = typer.Typer()
 
 
-@app.command()
+@app.command(
+    # AVOID USING THE HELP PARAMETER WITH TYPER COMMAND DECORATOR. For
+    # consistency, commands should be documented using docstrings. We were
+    # forced to use help here to work around f-string limitations in
+    # docstrings.
+    help=f"""
+    Create a new Nextmv Cloud ensemble definition.
+
+    An ensemble definition coordinates the execution of multiple child runs for
+    an application and determines the optimal result from those runs. Each
+    ensemble definition contains run groups and evaluation rules.
+
+    [bold][underline]Run Groups[/underline][/bold]
+
+    Run groups are provided as [magenta]json[/magenta] objects using the
+    [code]--run-groups[/code] flag. Each run group specifies how child runs
+    are executed.
+
+    You can provide run groups in three ways:
+    - A single run group as a [magenta]json[/magenta] object.
+    - Multiple run groups by repeating the [code]--run-groups[/code] flag.
+    - Multiple run groups as a [magenta]json[/magenta] array in a single [code]--run-groups[/code] flag.
+
+    Each run group must have the following fields:
+    - [magenta]id[/magenta]: Unique identifier for the run group (required).
+    - [magenta]instance_id[/magenta]: The instance to execute runs on (required).
+    - [magenta]options[/magenta]: Runtime options/parameters (optional). Options should be provided as a
+      [magenta]json[/magenta] object with [magenta]string[/magenta] key-value pairs.
+    - [magenta]repetitions[/magenta]: Number of times to repeat the run (optional).
+
+    Object format:
+    [green]{{
+        "id": "rg1",
+        "instance_id": "inst-123",
+        "options": {{"param": "value"}},
+        "repetitions": 5
+    }}[/green]
+
+    [bold][underline]Evaluation Rules[/underline][/bold]
+
+    Evaluation rules are provided as [magenta]json[/magenta] objects using the
+    [code]--rules[/code] flag. Each rule determines how to evaluate and select
+    the best result from the child runs.
+
+    You can provide rules in three ways:
+    - A single rule as a [magenta]json[/magenta] object.
+    - Multiple rules by repeating the [code]--rules[/code] flag.
+    - Multiple rules as a [magenta]json[/magenta] array in a single [code]--rules[/code] flag.
+
+    Each rule must have the following fields:
+    - [magenta]id[/magenta]: Unique identifier for the rule (required).
+    - [magenta]statistics_path[/magenta]: JSONPath to the metric (e.g., [magenta]$.result.value[/magenta]) (required).
+    - [magenta]objective[/magenta]: Objective for the evaluation (required).
+      Allowed values: {enum_values(RuleObjective)}.
+    - [magenta]tolerance[/magenta]: Object with the following fields (required):
+        - [magenta]value[/magenta]: Tolerance value (float).
+        - [magenta]type[/magenta]: Tolerance type. Allowed values: {enum_values(RuleToleranceType)}.
+    - [magenta]index[/magenta]: Evaluation order - lower indices evaluated first (required).
+
+    Object format:
+    [green]{{
+        "id": "rule1",
+        "statistics_path": "$.result.value",
+        "objective": "minimize",
+        "tolerance": {{"value": 0.1, "type": "relative"}},
+        "index": 0
+    }}[/green]
+
+    [bold][underline]Examples[/underline][/bold]
+
+    - Create an ensemble definition with a single run group and rule.
+        $ [green]RUN_GROUP='{{
+            "id": "rg1",
+            "instance_id": "inst-123"
+        }}'
+        RULE='{{
+            "id": "rule1",
+            "statistics_path": "$.result.value",
+            "objective": "minimize",
+            "tolerance": {{"value": 0.1, "type": "relative"}},
+            "index": 0
+        }}'
+        nextmv cloud ensemble create --app-id hare-app --run-groups "$RUN_GROUP" --rules "$RULE"[/green]
+
+    - Create with multiple run groups by repeating the flag.
+        $ [green]RUN_GROUP_1='{{
+            "id": "rg1",
+            "instance_id": "inst-123"
+        }}'
+        RUN_GROUP_2='{{
+            "id": "rg2",
+            "instance_id": "inst-456",
+            "options": {{"param": "value"}}
+        }}'
+        RULE='{{
+            "id": "rule1",
+            "statistics_path": "$.result.value",
+            "objective": "minimize",
+            "tolerance": {{"value": 0.1, "type": "relative"}},
+            "index": 0
+        }}'
+        nextmv cloud ensemble create --app-id hare-app --run-groups "$RUN_GROUP_1" --run-groups "$RUN_GROUP_2" \\
+            --rules "$RULE"[/green]
+
+    - Create with multiple items in a single JSON array.
+        $ [green]RUN_GROUPS='[
+            {{"id": "rg1", "instance_id": "inst-123"}},
+            {{"id": "rg2", "instance_id": "inst-456"}}
+        ]'
+        RULES='[{{
+            "id": "rule1",
+            "statistics_path": "$.result.value",
+            "objective": "minimize",
+            "tolerance": {{"value": 0.1, "type": "relative"}},
+            "index": 0
+        }}]'
+        nextmv cloud ensemble create --app-id hare-app --run-groups "$RUN_GROUPS" --rules "$RULES"[/green]
+
+    - Create with custom ID, name, and description.
+        $ [green]RUN_GROUP='{{
+            "id": "rg1",
+            "instance_id": "inst-123"
+        }}'
+        RULE='{{
+            "id": "rule1",
+            "statistics_path": "$.result.value",
+            "objective": "minimize",
+            "tolerance": {{"value": 0.1, "type": "relative"}},
+            "index": 0
+        }}'
+        nextmv cloud ensemble create --app-id hare-app \\
+            --ensemble-definition-id prod-ensemble --name "Production Ensemble" \\
+            --description "Production ensemble with multiple solvers" \\
+            --run-groups "$RUN_GROUP" --rules "$RULE"[/green]
+
+    - Create with run group repetitions.
+        $ [green]RUN_GROUP='{{
+            "id": "rg1",
+            "instance_id": "inst-123",
+            "repetitions": 5
+        }}'
+        RULE='{{
+            "id": "rule1",
+            "statistics_path": "$.result.value",
+            "objective": "minimize",
+            "tolerance": {{"value": 0.1, "type": "relative"}},
+            "index": 0
+        }}'
+        nextmv cloud ensemble create --app-id hare-app --run-groups "$RUN_GROUP" --rules "$RULE"[/green]
+    """
+)
 def create(
     app_id: AppIDOption,
     run_groups: Annotated[
@@ -25,9 +175,7 @@ def create(
             "-r",
             help="Run groups to configure for the ensemble. Data should be valid [magenta]json[/magenta]. "
             "Pass multiple run groups by repeating the flag, or providing a list of objects. "
-            "Object format: [magenta]{'id': id, 'instance_id': instance_id, "
-            "'options': options, 'repetitions': repetitions}[/magenta]. "
-            "The [magenta]options[/magenta] and [magenta]repetitions[/magenta] fields are optional.",
+            "See command help for details on run group formatting.",
             metavar="RUN_GROUPS",
         ),
     ],
@@ -38,12 +186,7 @@ def create(
             "-u",
             help="Evaluation rules to configure for the ensemble. Data should be valid [magenta]json[/magenta]. "
             "Pass multiple rules by repeating the flag, or providing a list of objects. "
-            "Allowed values for [magenta]objective[/magenta] are: "
-            f"{enum_values(RuleObjective)}. "
-            "Allowed values for [magenta]tolerance.type[/magenta] are: "
-            f"{enum_values(RuleToleranceType)}. "
-            "Object format: [magenta]{'id': id, 'statistics_path': path, 'objective': objective, "
-            "'tolerance': {'value': value, 'type': type}, 'index': index}[/magenta].",
+            "See command help for details on rule formatting.",
             metavar="RULES",
         ),
     ],
@@ -77,116 +220,6 @@ def create(
     ] = None,
     profile: ProfileOption = None,
 ) -> None:
-    """
-    Create a new Nextmv Cloud ensemble definition.
-
-    An ensemble definition coordinates the execution of multiple child runs for
-    an application and determines the optimal result from those runs. Each
-    ensemble definition contains run groups and evaluation rules.
-
-    [bold]Run Groups[/bold] specify how child runs are executed:
-    - [magenta]id[/magenta]: Unique identifier for the run group.
-    - [magenta]instance_id[/magenta]: The instance to execute runs on.
-    - [magenta]options[/magenta] (optional): Runtime options/parameters. Options should be provded as a
-        [magenta]json[/magenta] object, with [magenta]string[/magenta] key-value pairs.
-    - [magenta]repetitions[/magenta] (optional): Number of times to repeat the run.
-
-    [bold]Evaluation Rules[/bold] determine the best result:
-    - [magenta]id[/magenta]: Unique identifier for the rule.
-    - [magenta]statistics_path[/magenta]: JSONPath to the metric (e.g., [magenta]$.result.value[/magenta]).
-    - [magenta]objective[/magenta]: Either [magenta]maximize[/magenta] or [magenta]minimize[/magenta].
-    - [magenta]tolerance[/magenta]: Object with [magenta]value[/magenta] (float) and [magenta]type[/magenta]
-      ([magenta]absolute[/magenta] or [magenta]relative[/magenta]).
-    - [magenta]index[/magenta]: Evaluation order (lower indices evaluated first).
-
-    You can provide run groups and rules in three ways:
-    - A single object as [magenta]json[/magenta].
-    - Multiple objects by repeating the flag.
-    - Multiple objects as a [magenta]json[/magenta] array in a single flag.
-
-    [bold][underline]Examples[/underline][/bold]
-
-    - Create an ensemble definition with a single run group and rule.
-        $ [green]RUN_GROUP='{
-            "id": "rg1",
-            "instance_id": "inst-123"
-        }'
-        RULE='{
-            "id": "rule1",
-            "statistics_path": "$.result.value",
-            "objective": "minimize",
-            "tolerance": {"value": 0.1, "type": "relative"},
-            "index": 0
-        }'
-        nextmv cloud ensemble create --app-id hare-app --run-groups "$RUN_GROUP" --rules "$RULE"[/green]
-
-    - Create with multiple run groups by repeating the flag.
-        $ [green]RUN_GROUP_1='{
-            "id": "rg1",
-            "instance_id": "inst-123"
-        }'
-        RUN_GROUP_2='{
-            "id": "rg2",
-            "instance_id": "inst-456",
-            "options": {"param": "value"}
-        }'
-        RULE='{
-            "id": "rule1",
-            "statistics_path": "$.result.value",
-            "objective": "minimize",
-            "tolerance": {"value": 0.1, "type": "relative"},
-            "index": 0
-        }'
-        nextmv cloud ensemble create --app-id hare-app --run-groups "$RUN_GROUP_1" --run-groups "$RUN_GROUP_2" \\
-            --rules "$RULE"[/green]
-
-    - Create with multiple items in a single JSON array.
-        $ [green]RUN_GROUPS='[
-            {"id": "rg1", "instance_id": "inst-123"},
-            {"id": "rg2", "instance_id": "inst-456"}
-        ]'
-        RULES='[{
-            "id": "rule1",
-            "statistics_path": "$.result.value",
-            "objective": "minimize",
-            "tolerance": {"value": 0.1, "type": "relative"},
-            "index": 0
-        }]'
-        nextmv cloud ensemble create --app-id hare-app --run-groups "$RUN_GROUPS" --rules "$RULES"[/green]
-
-    - Create with custom ID, name, and description.
-        $ [green]RUN_GROUP='{
-            "id": "rg1",
-            "instance_id": "inst-123"
-        }'
-        RULE='{
-            "id": "rule1",
-            "statistics_path": "$.result.value",
-            "objective": "minimize",
-            "tolerance": {"value": 0.1, "type": "relative"},
-            "index": 0
-        }'
-        nextmv cloud ensemble create --app-id hare-app \\
-            --ensemble-definition-id prod-ensemble --name "Production Ensemble" \\
-            --description "Production ensemble with multiple solvers" \\
-            --run-groups "$RUN_GROUP" --rules "$RULE"[/green]
-
-    - Create with run group repetitions.
-        $ [green]RUN_GROUP='{
-            "id": "rg1",
-            "instance_id": "inst-123",
-            "repetitions": 5
-        }'
-        RULE='{
-            "id": "rule1",
-            "statistics_path": "$.result.value",
-            "objective": "minimize",
-            "tolerance": {"value": 0.1, "type": "relative"},
-            "index": 0
-        }'
-        nextmv cloud ensemble create --app-id hare-app --run-groups "$RUN_GROUP" --rules "$RULE"[/green]
-    """
-
     cloud_app = build_app(app_id=app_id, profile=profile)
     in_progress(msg="Creating ensemble definition...")
 

--- a/nextmv/nextmv/cli/cloud/ensemble/update.py
+++ b/nextmv/nextmv/cli/cloud/ensemble/update.py
@@ -87,6 +87,10 @@ def update(
         name=name,
         description=description,
     )
+    success(
+        f"Ensemble definition [magenta]{ensemble_definition_id}[/magenta] updated successfully "
+        f"in application [magenta]{app_id}[/magenta]."
+    )
 
     if output is not None:
         with open(output, "w") as f:

--- a/nextmv/nextmv/cli/cloud/instance/create.py
+++ b/nextmv/nextmv/cli/cloud/instance/create.py
@@ -97,7 +97,7 @@ def create(
         ),
     ] = False,
     options: Annotated[
-        list[str],
+        list[str] | None,
         typer.Option(
             "--options",
             "-o",

--- a/nextmv/nextmv/cli/cloud/run/create.py
+++ b/nextmv/nextmv/cli/cloud/run/create.py
@@ -158,7 +158,7 @@ def create(
         ),
     ] = False,
     options: Annotated[
-        list[str],
+        list[str] | None,
         typer.Option(
             "--options",
             "-o",

--- a/nextmv/nextmv/cli/cloud/run/create.py
+++ b/nextmv/nextmv/cli/cloud/run/create.py
@@ -17,7 +17,7 @@ from nextmv.cli.message import enum_values, error, print_json, success
 from nextmv.cli.options import AppIDOption, ProfileOption
 from nextmv.cloud.application import Application
 from nextmv.input import InputFormat
-from nextmv.polling import DEFAULT_POLLING_OPTIONS
+from nextmv.polling import default_polling_options
 from nextmv.run import Format, FormatInput, RunConfiguration, RunQueuing, RunType, RunTypeConfiguration
 
 # Set up subcommand application.
@@ -321,7 +321,7 @@ def create(
     run_options = build_run_options(options)
 
     # Build the polling options.
-    polling_options = DEFAULT_POLLING_OPTIONS
+    polling_options = default_polling_options()
     polling_options.max_duration = timeout
 
     # Handles the default instance.

--- a/nextmv/nextmv/cli/cloud/run/get.py
+++ b/nextmv/nextmv/cli/cloud/run/get.py
@@ -12,7 +12,7 @@ from nextmv.cli.message import in_progress, print_json, success
 from nextmv.cli.options import AppIDOption, ProfileOption, RunIDOption
 from nextmv.cloud.application import Application
 from nextmv.output import OutputFormat
-from nextmv.polling import DEFAULT_POLLING_OPTIONS, PollingOptions
+from nextmv.polling import PollingOptions, default_polling_options
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -87,7 +87,7 @@ def get(
     cloud_app = build_app(app_id=app_id, profile=profile)
 
     # Build the polling options.
-    polling_options = DEFAULT_POLLING_OPTIONS
+    polling_options = default_polling_options()
     polling_options.max_duration = timeout
 
     handle_outputs(

--- a/nextmv/nextmv/cli/cloud/run/logs.py
+++ b/nextmv/nextmv/cli/cloud/run/logs.py
@@ -13,7 +13,7 @@ from nextmv.cli.configuration.config import build_app
 from nextmv.cli.message import in_progress, success
 from nextmv.cli.options import AppIDOption, ProfileOption, RunIDOption
 from nextmv.cloud.application import Application
-from nextmv.polling import DEFAULT_POLLING_OPTIONS, PollingOptions
+from nextmv.polling import PollingOptions, default_polling_options
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -85,7 +85,7 @@ def logs(
     cloud_app = build_app(app_id=app_id, profile=profile)
 
     # Build the polling options.
-    polling_options = DEFAULT_POLLING_OPTIONS
+    polling_options = default_polling_options()
     polling_options.max_duration = timeout
 
     handle_logs(

--- a/nextmv/nextmv/cli/cloud/secrets/create.py
+++ b/nextmv/nextmv/cli/cloud/secrets/create.py
@@ -27,7 +27,7 @@ def create(
             "Pass multiple secrets by repeating the flag, or providing a list of objects. "
             "Allowed values for [magenta]type[/magenta] are: "
             f"{enum_values(SecretType)}. "
-            "Object format: [magenta]{'type': type, 'location': location, 'value': value}[/magenta].",
+            "Object format: [green]{'type': type, 'location': location, 'value': value}[/green].",
             metavar="SECRETS",
         ),
     ],

--- a/nextmv/nextmv/cli/cloud/secrets/update.py
+++ b/nextmv/nextmv/cli/cloud/secrets/update.py
@@ -131,6 +131,10 @@ def update(
         description=description,
         secrets=secrets_list,
     )
+    success(
+        f"Secrets collection [magenta]{secrets_collection_id}[/magenta] updated successfully "
+        f"in application [magenta]{app_id}[/magenta]."
+    )
 
     if output is not None:
         with open(output, "w") as f:

--- a/nextmv/nextmv/cli/options.py
+++ b/nextmv/nextmv/cli/options.py
@@ -148,3 +148,17 @@ AcceptanceTestIDOption = Annotated[
         metavar="ACCEPTANCE_TEST_ID",
     ),
 ]
+
+# batch_experiment_id option - can be used in any command that requires a batch experiment ID.
+# Define it as follows in commands or callbacks, as necessary:
+# batch_experiment_id: BatchExperimentIDOption
+BatchExperimentIDOption = Annotated[
+    str,
+    typer.Option(
+        "--batch-id",
+        "-b",
+        help="The Nextmv Cloud batch experiment ID to use for this action.",
+        envvar="NEXTMV_BATCH_ID",
+        metavar="BATCH_ID",
+    ),
+]

--- a/nextmv/nextmv/cloud/application/_batch_scenario.py
+++ b/nextmv/nextmv/cloud/application/_batch_scenario.py
@@ -16,7 +16,7 @@ from nextmv.cloud.input_set import InputSet, ManagedInput
 from nextmv.cloud.scenario import Scenario, ScenarioInputType, _option_sets, _scenarios_by_id
 from nextmv.polling import DEFAULT_POLLING_OPTIONS, PollingOptions, poll
 from nextmv.run import Run
-from nextmv.safe import safe_name_and_id
+from nextmv.safe import safe_id, safe_name_and_id
 
 if TYPE_CHECKING:
     from . import Application
@@ -254,9 +254,9 @@ class ApplicationBatchMixin:
 
         return [BatchExperimentMetadata.from_dict(batch_experiment) for batch_experiment in response.json()]
 
-    def new_batch_experiment(
+    def new_batch_experiment(  # noqa: C901
         self: "Application",
-        name: str,
+        name: str | None = None,
         input_set_id: str | None = None,
         instance_ids: list[str] | None = None,
         description: str | None = None,
@@ -270,13 +270,13 @@ class ApplicationBatchMixin:
 
         Parameters
         ----------
-        name: str
-            Name of the batch experiment.
-        input_set_id: str
+        name: Optional[str]
+            Name of the batch experiment. If not provided, the ID will be used as the name.
+        input_set_id: str | None
             ID of the input set to use for the batch experiment.
         instance_ids: list[str]
-            List of instance IDs to use for the batch experiment.
             This argument is deprecated, use `runs` instead.
+            List of instance IDs to use for the batch experiment.
         description: Optional[str]
             Optional description of the batch experiment.
         id: Optional[str]
@@ -303,7 +303,16 @@ class ApplicationBatchMixin:
             If the response status code is not 2xx.
         """
 
+        # Generate ID if not provided
+        if id is None:
+            id = safe_id("batch")
+
+        # Use ID as name if name not provided
+        if name is None:
+            name = id
+
         payload = {
+            "id": id,
             "name": name,
         }
         if input_set_id is not None:
@@ -315,8 +324,6 @@ class ApplicationBatchMixin:
             payload["runs"] = payload_runs
         if description is not None:
             payload["description"] = description
-        if id is not None:
-            payload["id"] = id
         if option_sets is not None:
             payload["option_sets"] = option_sets
         if runs is not None:
@@ -337,7 +344,7 @@ class ApplicationBatchMixin:
 
     def new_batch_experiment_with_result(
         self: "Application",
-        name: str,
+        name: str | None = None,
         input_set_id: str | None = None,
         instance_ids: list[str] | None = None,
         description: str | None = None,
@@ -357,8 +364,8 @@ class ApplicationBatchMixin:
 
         Parameters
         ----------
-        name: str
-            Name of the batch experiment.
+        name: Optional[str]
+            Name of the batch experiment. If not provided, the ID will be used as the name.
         input_set_id: str
             ID of the input set to use for the batch experiment.
         instance_ids: list[str]

--- a/nextmv/nextmv/cloud/batch_experiment.py
+++ b/nextmv/nextmv/cloud/batch_experiment.py
@@ -223,7 +223,9 @@ class BatchExperimentRun(BaseModel):
     Parameters
     ----------
     input_id : str
-        ID of the input used for the experiment.
+        ID of the input used for the experiment. If a managed input is used,
+        this should be the ID of the managed input. If `input_set_id` is provided
+        for the run, this should be the ID of an input within that input set.
     option_set : str
         Option set used for the experiment. Defaults to None.
     instance_id : str, optional

--- a/nextmv/nextmv/polling.py
+++ b/nextmv/nextmv/polling.py
@@ -140,11 +140,35 @@ class PollingOptions:
 
 DEFAULT_POLLING_OPTIONS: PollingOptions = PollingOptions()
 """
+!!! warning
+    `DEFAULT_POLLING_OPTIONS` is a mutable global variable. Use the `default_polling_options`
+    function to obtain a fresh instance of `PollingOptions` with default settings.
+
 Default polling options to use when polling for a run result. This constant
 provides the default values for `PollingOptions` used across the module.
-Using these defaults is recommended for most use cases unless specific timing
-needs are required.
 """
+
+
+def default_polling_options() -> PollingOptions:
+    """
+    Returns a new instance of PollingOptions with default settings.
+
+    This function can be used to obtain a fresh set of default polling options
+    that can be modified as needed without affecting the global defaults.
+
+    You can import the `default_polling_options` function directly from `nextmv`:
+
+    ```python
+    from nextmv import default_polling_options
+    ```
+
+    Returns
+    -------
+    PollingOptions
+        A new instance of PollingOptions with default values.
+    """
+
+    return PollingOptions()
 
 
 def poll(  # noqa: C901


### PR DESCRIPTION
# Description

Adds the `nextmv cloud batch` command tree with the following subcommands:

- `create`
- `delete`
- `get`
- `list`
- `metadata`
- `update`

Makes some modifications to formatting in other commands to avoid having long messages in the help of options.  Rectifies the usage of the `--wait` and `--output` flags for acceptance tests, so that they are independent of each other.