### PR TITLE
Adds the `nextmv cloud scenario` command tree

### DIFF
--- a/nextmv/nextmv/cli/CONTRIBUTING.md
+++ b/nextmv/nextmv/cli/CONTRIBUTING.md
@@ -332,7 +332,7 @@ to use it.
       )
       cloud_app_dict = cloud_app.to_dict()
 
-      if output is not None:
+      if output is not None and output != "":
           with open(output, "w") as f:
               json.dump(cloud_app_dict, f, indent=2)
 

--- a/nextmv/nextmv/cli/cloud/__init__.py
+++ b/nextmv/nextmv/cli/cloud/__init__.py
@@ -13,6 +13,7 @@ from nextmv.cli.cloud.ensemble import app as ensemble_app
 from nextmv.cli.cloud.instance import app as instance_app
 from nextmv.cli.cloud.managed_input import app as managed_input_app
 from nextmv.cli.cloud.run import app as run_app
+from nextmv.cli.cloud.scenario import app as scenario_app
 from nextmv.cli.cloud.secrets import app as secrets_app
 from nextmv.cli.cloud.upload import app as upload_app
 from nextmv.cli.cloud.version import app as version_app
@@ -28,6 +29,7 @@ app.add_typer(ensemble_app, name="ensemble")
 app.add_typer(instance_app, name="instance")
 app.add_typer(managed_input_app, name="managed-input")
 app.add_typer(run_app, name="run")
+app.add_typer(scenario_app, name="scenario")
 app.add_typer(secrets_app, name="secrets")
 app.add_typer(upload_app, name="upload")
 app.add_typer(version_app, name="version")

--- a/nextmv/nextmv/cli/cloud/acceptance/create.py
+++ b/nextmv/nextmv/cli/cloud/acceptance/create.py
@@ -31,9 +31,9 @@ app = typer.Typer()
     experiment.
 
     Use the [code]--wait[/code] flag to wait for the acceptance test to
-    complete, polling for results. Use the [code]--output[/code] flag to
-    specify a destination file for the output obtained. Please note that using
-    the [code]--output[/code] flag will not activate waiting by itself.
+    complete, polling for results. Using the [code]--output[/code] flag will
+    also activate waiting, and allows you to specify a destination file for the
+    results.
 
     [bold][underline]Metrics[/underline][/bold]
 
@@ -109,7 +109,7 @@ app = typer.Typer()
             --candidate-instance-id candidate-123 --baseline-instance-id baseline-456 \\
             --metrics "$METRIC1" --metrics "$METRIC2" --input-set-id input-set-123[/green]
 
-    - Create with multiple metrics in a single JSON array.
+    - Create with multiple metrics in a single [magenta]json[/magenta] array.
         $ [green]METRICS='[
             {{
                 "field": "solution.objective",
@@ -148,7 +148,7 @@ app = typer.Typer()
             --candidate-instance-id candidate-123 --baseline-instance-id baseline-456 \\
             --metrics "$METRIC" --input-set-id input-set-123 --wait[/green]
 
-    - Create an acceptance test and save the results to a file.
+    - Create an acceptance test and save the results to a file, waiting for completion.
         $ [green]METRIC='{{
             "field": "solution.objective",
             "metric_type": "direct-comparison",
@@ -165,6 +165,7 @@ app = typer.Typer()
 )
 def create(
     app_id: AppIDOption,
+    # Options for acceptance test configuration.
     acceptance_test_id: Annotated[
         str,
         typer.Option(
@@ -239,12 +240,13 @@ def create(
             rich_help_panel="Acceptance test configuration",
         ),
     ] = None,
+    # Options for controlling output.
     output: Annotated[
         str | None,
         typer.Option(
             "--output",
             "-o",
-            help="Save the acceptance test output to this location.",
+            help="Waits for the test to complete and saves the results to this location.",
             metavar="OUTPUT_PATH",
             rich_help_panel="Output control",
         ),
@@ -274,37 +276,34 @@ def create(
     # Build the metrics list from the CLI options
     metrics_list = build_metrics(metrics)
 
+    new_test = cloud_app.new_acceptance_test(
+        candidate_instance_id=candidate_instance_id,
+        baseline_instance_id=baseline_instance_id,
+        id=acceptance_test_id,
+        metrics=metrics_list,
+        name=name,
+        input_set_id=input_set_id,
+        description=description,
+    )
+    acceptance_id = new_test.id
+
+    # If we don't need to poll at all we are done.
+    if not wait and (output is None or output == ""):
+        print_json({"acceptance_test_id": acceptance_id})
+
+        return
+
+    success(f"Acceptance test [magenta]{acceptance_id}[/magenta] created.")
+
     # Build the polling options.
     polling_options = default_polling_options()
     polling_options.max_duration = timeout
 
-    # Create the acceptance test
-    if wait:
-        in_progress(msg="Creating acceptance test and waiting for results...")
-        acceptance_test = cloud_app.new_acceptance_test_with_result(
-            candidate_instance_id=candidate_instance_id,
-            baseline_instance_id=baseline_instance_id,
-            id=acceptance_test_id,
-            metrics=metrics_list,
-            name=name,
-            input_set_id=input_set_id,
-            description=description,
-            polling_options=polling_options,
-        )
-        success(msg=f"Acceptance test [magenta]{acceptance_test.id}[/magenta] completed.")
-
-    else:
-        in_progress(msg="Creating acceptance test...")
-        acceptance_test = cloud_app.new_acceptance_test(
-            candidate_instance_id=candidate_instance_id,
-            baseline_instance_id=baseline_instance_id,
-            id=acceptance_test_id,
-            metrics=metrics_list,
-            name=name,
-            input_set_id=input_set_id,
-            description=description,
-        )
-
+    in_progress(msg="Getting acceptance test results...")
+    acceptance_test = cloud_app.acceptance_test_with_polling(
+        acceptance_test_id=acceptance_id,
+        polling_options=polling_options,
+    )
     acceptance_test_dict = acceptance_test.to_dict()
 
     # Handle output
@@ -313,6 +312,7 @@ def create(
             json.dump(acceptance_test_dict, f, indent=2)
 
         success(msg=f"Acceptance test results saved to [magenta]{output}[/magenta].")
+
         return
 
     print_json(acceptance_test_dict)

--- a/nextmv/nextmv/cli/cloud/acceptance/get.py
+++ b/nextmv/nextmv/cli/cloud/acceptance/get.py
@@ -98,6 +98,7 @@ def get(
             json.dump(acceptance_test_dict, f, indent=2)
 
         success(msg=f"Acceptance test results saved to [magenta]{output}[/magenta].")
+
         return
 
     print_json(acceptance_test_dict)

--- a/nextmv/nextmv/cli/cloud/acceptance/list.py
+++ b/nextmv/nextmv/cli/cloud/acceptance/list.py
@@ -52,7 +52,7 @@ def list(
     acceptance_tests = cloud_app.list_acceptance_tests()
     acceptance_tests_dict = [test.to_dict() for test in acceptance_tests]
 
-    if output is not None:
+    if output is not None and output != "":
         with open(output, "w") as f:
             json.dump(acceptance_tests_dict, f, indent=2)
 

--- a/nextmv/nextmv/cli/cloud/acceptance/update.py
+++ b/nextmv/nextmv/cli/cloud/acceptance/update.py
@@ -85,7 +85,7 @@ def update(
 
     acceptance_test_dict = acceptance_test.to_dict()
 
-    if output is not None:
+    if output is not None and output != "":
         with open(output, "w") as f:
             json.dump(acceptance_test_dict, f, indent=2)
 

--- a/nextmv/nextmv/cli/cloud/account/get.py
+++ b/nextmv/nextmv/cli/cloud/account/get.py
@@ -55,7 +55,7 @@ def get(
     )
     cloud_account_dict = cloud_account.to_dict()
 
-    if output is not None:
+    if output is not None and output != "":
         with open(output, "w") as f:
             json.dump(cloud_account_dict, f, indent=2)
 

--- a/nextmv/nextmv/cli/cloud/account/update.py
+++ b/nextmv/nextmv/cli/cloud/account/update.py
@@ -59,7 +59,7 @@ def update(
     success(f"Account [magenta]{account_id}[/magenta] updated successfully.")
     updated_account_dict = updated_account.to_dict()
 
-    if output is not None:
+    if output is not None and output != "":
         with open(output, "w") as f:
             json.dump(updated_account_dict, f, indent=2)
 

--- a/nextmv/nextmv/cli/cloud/app/get.py
+++ b/nextmv/nextmv/cli/cloud/app/get.py
@@ -55,7 +55,7 @@ def get(
     )
     cloud_app_dict = cloud_app.to_dict()
 
-    if output is not None:
+    if output is not None and output != "":
         with open(output, "w") as f:
             json.dump(cloud_app_dict, f, indent=2)
 

--- a/nextmv/nextmv/cli/cloud/app/list.py
+++ b/nextmv/nextmv/cli/cloud/app/list.py
@@ -50,7 +50,7 @@ def list(
     cloud_apps = list_applications(client)
     cloud_apps_dicts = [app.to_dict() for app in cloud_apps]
 
-    if output is not None:
+    if output is not None and output != "":
         with open(output, "w") as f:
             json.dump(cloud_apps_dicts, f, indent=2)
 

--- a/nextmv/nextmv/cli/cloud/app/update.py
+++ b/nextmv/nextmv/cli/cloud/app/update.py
@@ -113,7 +113,7 @@ def update(
     success(f"Application [magenta]{app_id}[/magenta] updated successfully.")
     updated_app_dict = updated_app.to_dict()
 
-    if output is not None:
+    if output is not None and output != "":
         with open(output, "w") as f:
             json.dump(updated_app_dict, f, indent=2)
 

--- a/nextmv/nextmv/cli/cloud/batch/create.py
+++ b/nextmv/nextmv/cli/cloud/batch/create.py
@@ -20,14 +20,15 @@ app = typer.Typer()
 @app.command()
 def create(
     app_id: AppIDOption,
-    batch_id: Annotated[
+    # Options for batch experiment configuration.
+    batch_experiment_id: Annotated[
         str | None,
         typer.Option(
-            "--batch-id",
+            "--batch-experiment-id",
             "-b",
             help="ID for the batch experiment. Will be generated if not provided.",
-            envvar="NEXTMV_BATCH_ID",
-            metavar="BATCH_ID",
+            envvar="NEXTMV_BATCH_EXPERIMENT_ID",
+            metavar="BATCH_EXPERIMENT_ID",
             rich_help_panel="Batch experiment configuration",
         ),
     ] = None,
@@ -71,16 +72,6 @@ def create(
             rich_help_panel="Batch experiment configuration",
         ),
     ] = None,
-    output: Annotated[
-        str | None,
-        typer.Option(
-            "--output",
-            "-o",
-            help="Save the batch experiment output to this location.",
-            metavar="OUTPUT_PATH",
-            rich_help_panel="Output control",
-        ),
-    ] = None,
     runs: Annotated[
         list[str] | None,
         typer.Option(
@@ -91,6 +82,17 @@ def create(
             "See command help for details on run formatting.",
             metavar="RUNS",
             rich_help_panel="Batch experiment configuration",
+        ),
+    ] = None,
+    # Options for controlling output.
+    output: Annotated[
+        str | None,
+        typer.Option(
+            "--output",
+            "-o",
+            help="Waits for the experiment to complete and saves the results to this location.",
+            metavar="OUTPUT_PATH",
+            rich_help_panel="Output control",
         ),
     ] = None,
     timeout: Annotated[
@@ -121,9 +123,9 @@ def create(
     version, and optional configuration options.
 
     Use the [code]--wait[/code] flag to wait for the batch experiment to
-    complete, polling for results. Use the [code]--output[/code] flag to
-    specify a destination file for the output obtained. Please note that using
-    the [code]--output[/code] flag will not activate waiting by itself.
+    complete, polling for results. Using the [code]--output[/code] flag will
+    also activate waiting, and allows you to specify a destination file for the
+    results.
 
     [bold][underline]Runs[/underline][/bold]
 
@@ -179,7 +181,7 @@ def create(
             "input_id": "carrot-patch-a",
             "instance_id": "warren-planner-v1"
         }'
-        nextmv cloud batch create --app-id hare-app --batch-id bunny-hop-test \\
+        nextmv cloud batch create --app-id hare-app --batch-experiment-id bunny-hop-test \\
             --name "Spring Meadow Routes" --input-set-id spring-gardens --runs "$RUN"[/green]
 
     - Create with multiple runs by repeating the flag.
@@ -191,11 +193,11 @@ def create(
             "input_id": "lettuce-field-2",
             "instance_id": "hop-optimizer"
         }'
-        nextmv cloud batch create --app-id hare-app --batch-id lettuce-routes \\
+        nextmv cloud batch create --app-id hare-app --batch-experiment-id lettuce-routes \\
             --name "Lettuce Delivery Optimization" --input-set-id veggie-gardens \\
             --runs "$RUN1" --runs "$RUN2"[/green]
 
-    - Create with multiple runs in a single JSON array.
+    - Create with multiple runs in a single [magenta]json[/magenta] array.
         $ [green]RUNS='[
             {
                 "input_id": "warren-zone-a",
@@ -206,7 +208,7 @@ def create(
                 "version_id": "tunnel-planner-v3"
             }
         ]'
-        nextmv cloud batch create --app-id hare-app --batch-id warren-expansion \\
+        nextmv cloud batch create --app-id hare-app --batch-experiment-id warren-expansion \\
             --name "Warren Construction Plans" --input-set-id burrow-sites --runs "$RUNS"[/green]
 
     - Create a batch experiment and wait for it to complete.
@@ -214,16 +216,16 @@ def create(
             "input_id": "carrot-harvest",
             "instance_id": "foraging-route"
         }'
-        nextmv cloud batch create --app-id hare-app --batch-id harvest-time \\
+        nextmv cloud batch create --app-id hare-app --batch-experiment-id harvest-time \\
             --name "Autumn Carrot Collection" --input-set-id harvest-season \\
             --runs "$RUN" --wait[/green]
 
-    - Create a batch experiment and save the results to a file.
+    - Create a batch experiment and save the results to a file, waiting for completion.
         $ [green]RUN='{
             "input_id": "predator-zones",
             "instance_id": "safe-hopper"
         }'
-        nextmv cloud batch create --app-id hare-app --batch-id safety-analysis \\
+        nextmv cloud batch create --app-id hare-app --batch-experiment-id safety-analysis \\
             --name "Fox Avoidance Routes" --input-set-id danger-zones \\
             --runs "$RUN" --output bunny-safety-results.json[/green]
 
@@ -242,10 +244,11 @@ def create(
             "fast-hops": {"max_speed": "10", "caution_level": "low"},
             "careful-hops": {"max_speed": "5", "caution_level": "high"}
         }'
-        nextmv cloud batch create --app-id hare-app --batch-id hop-comparison \\
+        nextmv cloud batch create --app-id hare-app --batch-experiment-id hop-comparison \\
             --name "Speed vs Safety Analysis" --input-set-id garden-paths \\
             --runs "$RUN1" --runs "$RUN2" --option-sets "$OPTION_SETS"[/green]
     """
+
     cloud_app = build_app(app_id=app_id, profile=profile)
 
     # Build the runs list from the CLI options
@@ -254,36 +257,32 @@ def create(
     # Build the option sets from the CLI options
     option_sets_dict = build_option_sets(option_sets)
 
+    batch_id = cloud_app.new_batch_experiment(
+        id=batch_experiment_id,
+        name=name,
+        runs=runs_list,
+        description=description,
+        input_set_id=input_set_id,
+        option_sets=option_sets_dict,
+    )
+
+    # If we don't need to poll at all we are done.
+    if not wait and (output is None or output == ""):
+        print_json({"batch_experiment_id": batch_id})
+
+        return
+
+    success(f"Batch experiment [magenta]{batch_id}[/magenta] created.")
+
     # Build the polling options.
     polling_options = default_polling_options()
     polling_options.max_duration = timeout
 
-    # Create the batch experiment
-    if wait:
-        in_progress(msg="Creating batch experiment and waiting for results...")
-        batch_experiment = cloud_app.new_batch_experiment_with_result(
-            id=batch_id,
-            name=name,
-            runs=runs_list,
-            description=description,
-            input_set_id=input_set_id,
-            option_sets=option_sets_dict,
-            polling_options=polling_options,
-        )
-        success(msg=f"Batch experiment [magenta]{batch_experiment.id}[/magenta] completed.")
-
-    else:
-        in_progress(msg="Creating batch experiment...")
-        batch_experiment_id = cloud_app.new_batch_experiment(
-            id=batch_id,
-            name=name,
-            runs=runs_list,
-            description=description,
-            input_set_id=input_set_id,
-            option_sets=option_sets_dict,
-        )
-        batch_experiment = cloud_app.batch_experiment(batch_id=batch_experiment_id)
-
+    in_progress(msg="Getting batch experiment results...")
+    batch_experiment = cloud_app.batch_experiment_with_polling(
+        batch_id=batch_id,
+        polling_options=polling_options,
+    )
     batch_experiment_dict = batch_experiment.to_dict()
 
     # Handle output
@@ -443,13 +442,13 @@ def _validate_run_fields(run_data: dict, run_str: str, index: int | None = None)
     if run_data.get("input_id") is None:
         error(
             f"Invalid run format {location}"
-            f"[magenta]{run_str}[/magenta]. Each run must have "
+            f"[magenta]{run_str}[/magenta]. Each run must have an "
             "[magenta]input_id[/magenta] field."
         )
 
     if run_data.get("instance_id") is None and run_data.get("version_id") is None:
         error(
             f"Invalid run format {location}"
-            f"[magenta]{run_str}[/magenta]. Each run must have either "
+            f"[magenta]{run_str}[/magenta]. Each run must have either an "
             "[magenta]instance_id[/magenta] or [magenta]version_id[/magenta] field."
         )

--- a/nextmv/nextmv/cli/cloud/batch/delete.py
+++ b/nextmv/nextmv/cli/cloud/batch/delete.py
@@ -18,7 +18,7 @@ app = typer.Typer()
 @app.command()
 def delete(
     app_id: AppIDOption,
-    batch_id: BatchExperimentIDOption,
+    batch_experiment_id: BatchExperimentIDOption,
     yes: Annotated[
         bool,
         typer.Option(
@@ -40,29 +40,29 @@ def delete(
 
     - Delete the batch experiment with the ID [magenta]hop-analysis[/magenta] from application
       [magenta]hare-app[/magenta].
-        $ [green]nextmv cloud batch delete --app-id hare-app --batch-id hop-analysis[/green]
+        $ [green]nextmv cloud batch delete --app-id hare-app --batch-experiment-id hop-analysis[/green]
 
     - Delete the batch experiment without confirmation prompt.
-        $ [green]nextmv cloud batch delete --app-id hare-app --batch-id carrot-routes --yes[/green]
+        $ [green]nextmv cloud batch delete --app-id hare-app --batch-experiment-id carrot-routes --yes[/green]
     """
 
     if not yes:
         confirm = Confirm.ask(
-            f"Are you sure you want to delete batch experiment [magenta]{batch_id}[/magenta] "
+            f"Are you sure you want to delete batch experiment [magenta]{batch_experiment_id}[/magenta] "
             f"from application [magenta]{app_id}[/magenta]? This action cannot be undone.",
             default=False,
         )
 
         if not confirm:
             info(
-                msg=f"Batch experiment [magenta]{batch_id}[/magenta] will not be deleted.",
+                msg=f"Batch experiment [magenta]{batch_experiment_id}[/magenta] will not be deleted.",
                 emoji=":bulb:",
             )
             return
 
     cloud_app = build_app(app_id=app_id, profile=profile)
-    cloud_app.delete_batch_experiment(batch_id=batch_id)
+    cloud_app.delete_batch_experiment(batch_id=batch_experiment_id)
     success(
-        f"Batch experiment [magenta]{batch_id}[/magenta] deleted successfully "
+        f"Batch experiment [magenta]{batch_experiment_id}[/magenta] deleted successfully "
         f"from application [magenta]{app_id}[/magenta]."
     )

--- a/nextmv/nextmv/cli/cloud/batch/get.py
+++ b/nextmv/nextmv/cli/cloud/batch/get.py
@@ -19,7 +19,7 @@ app = typer.Typer()
 @app.command()
 def get(
     app_id: AppIDOption,
-    batch_id: BatchExperimentIDOption,
+    batch_experiment_id: BatchExperimentIDOption,
     output: Annotated[
         str | None,
         typer.Option(
@@ -59,17 +59,17 @@ def get(
 
     - Get the batch experiment with ID [magenta]carrot-optimization[/magenta] from application
       [magenta]hare-app[/magenta].
-        $ [green]nextmv cloud batch get --app-id hare-app --batch-id carrot-optimization[/green]
+        $ [green]nextmv cloud batch get --app-id hare-app --batch-experiment-id carrot-optimization[/green]
 
     - Get the batch experiment and wait for it to complete if necessary.
-        $ [green]nextmv cloud batch get --app-id hare-app --batch-id bunny-hop-test --wait[/green]
+        $ [green]nextmv cloud batch get --app-id hare-app --batch-experiment-id bunny-hop-test --wait[/green]
 
     - Get the batch experiment and save the results to a file.
-        $ [green]nextmv cloud batch get --app-id hare-app \\
-            --batch-id warren-planning --output results.json[/green]
+        $ [green]nextmv cloud batch get --app-id hare-app --batch-experiment-id warren-planning \\
+            --output results.json[/green]
 
     - Get the batch experiment using a specific profile.
-        $ [green]nextmv cloud batch get --app-id hare-app --batch-id lettuce-routes --profile prod[/green]
+        $ [green]nextmv cloud batch get --app-id hare-app --batch-experiment-id lettuce-routes --profile prod[/green]
     """
 
     cloud_app = build_app(app_id=app_id, profile=profile)
@@ -84,11 +84,11 @@ def get(
     in_progress(msg="Getting batch experiment...")
     if should_wait:
         batch_experiment = cloud_app.batch_experiment_with_polling(
-            batch_id=batch_id,
+            batch_id=batch_experiment_id,
             polling_options=polling_options,
         )
     else:
-        batch_experiment = cloud_app.batch_experiment(batch_id=batch_id)
+        batch_experiment = cloud_app.batch_experiment(batch_id=batch_experiment_id)
 
     batch_experiment_dict = batch_experiment.to_dict()
 
@@ -98,6 +98,7 @@ def get(
             json.dump(batch_experiment_dict, f, indent=2)
 
         success(msg=f"Batch experiment results saved to [magenta]{output}[/magenta].")
+
         return
 
     print_json(batch_experiment_dict)

--- a/nextmv/nextmv/cli/cloud/batch/list.py
+++ b/nextmv/nextmv/cli/cloud/batch/list.py
@@ -52,7 +52,7 @@ def list(
     batch_experiments = cloud_app.list_batch_experiments()
     batch_experiments_dict = [exp.to_dict() for exp in batch_experiments]
 
-    if output is not None:
+    if output is not None and output != "":
         with open(output, "w") as f:
             json.dump(batch_experiments_dict, f, indent=2)
 

--- a/nextmv/nextmv/cli/cloud/batch/list.py
+++ b/nextmv/nextmv/cli/cloud/batch/list.py
@@ -57,6 +57,7 @@ def list(
             json.dump(batch_experiments_dict, f, indent=2)
 
         success(msg=f"Batch experiments list saved to [magenta]{output}[/magenta].")
+
         return
 
     print_json(batch_experiments_dict)

--- a/nextmv/nextmv/cli/cloud/batch/metadata.py
+++ b/nextmv/nextmv/cli/cloud/batch/metadata.py
@@ -18,7 +18,7 @@ app = typer.Typer()
 @app.command()
 def metadata(
     app_id: AppIDOption,
-    batch_id: BatchExperimentIDOption,
+    batch_experiment_id: BatchExperimentIDOption,
     output: Annotated[
         str | None,
         typer.Option(
@@ -41,19 +41,19 @@ def metadata(
 
     - Get metadata for batch experiment [magenta]bunny-warren-optimization[/magenta] from application
       [magenta]hare-app[/magenta].
-        $ [green]nextmv cloud batch metadata --app-id hare-app --batch-id bunny-warren-optimization[/green]
+        $ [green]nextmv cloud batch metadata --app-id hare-app --batch-experiment-id bunny-warren-optimization[/green]
 
     - Get metadata and save to a file.
-        $ [green]nextmv cloud batch metadata --app-id hare-app --batch-id lettuce-delivery \\
+        $ [green]nextmv cloud batch metadata --app-id hare-app --batch-experiment-id lettuce-delivery \\
             --output metadata.json[/green]
 
     - Get metadata using a specific profile.
-        $ [green]nextmv cloud batch metadata --app-id hare-app --batch-id hop-schedule --profile prod[/green]
+        $ [green]nextmv cloud batch metadata --app-id hare-app --batch-experiment-id hop-schedule --profile prod[/green]
     """
 
     cloud_app = build_app(app_id=app_id, profile=profile)
     in_progress(msg="Getting batch experiment metadata...")
-    batch_metadata = cloud_app.batch_experiment_metadata(batch_id=batch_id)
+    batch_metadata = cloud_app.batch_experiment_metadata(batch_id=batch_experiment_id)
     batch_metadata_dict = batch_metadata.to_dict()
 
     if output is not None:

--- a/nextmv/nextmv/cli/cloud/batch/metadata.py
+++ b/nextmv/nextmv/cli/cloud/batch/metadata.py
@@ -56,7 +56,7 @@ def metadata(
     batch_metadata = cloud_app.batch_experiment_metadata(batch_id=batch_experiment_id)
     batch_metadata_dict = batch_metadata.to_dict()
 
-    if output is not None:
+    if output is not None and output != "":
         with open(output, "w") as f:
             json.dump(batch_metadata_dict, f, indent=2)
 

--- a/nextmv/nextmv/cli/cloud/batch/update.py
+++ b/nextmv/nextmv/cli/cloud/batch/update.py
@@ -85,7 +85,7 @@ def update(
         f"in application [magenta]{app_id}[/magenta]."
     )
 
-    if output is not None:
+    if output is not None and output != "":
         with open(output, "w") as f:
             json.dump(batch_experiment_dict, f, indent=2)
 

--- a/nextmv/nextmv/cli/cloud/ensemble/get.py
+++ b/nextmv/nextmv/cli/cloud/ensemble/get.py
@@ -54,7 +54,7 @@ def get(
     ensemble_definition = cloud_app.ensemble_definition(ensemble_definition_id=ensemble_definition_id)
     ensemble_definition_dict = ensemble_definition.to_dict()
 
-    if output is not None:
+    if output is not None and output != "":
         with open(output, "w") as f:
             json.dump(ensemble_definition_dict, f, indent=2)
 

--- a/nextmv/nextmv/cli/cloud/ensemble/update.py
+++ b/nextmv/nextmv/cli/cloud/ensemble/update.py
@@ -92,7 +92,7 @@ def update(
         f"in application [magenta]{app_id}[/magenta]."
     )
 
-    if output is not None:
+    if output is not None and output != "":
         with open(output, "w") as f:
             json.dump(ensemble_definition.to_dict(), f, indent=2)
 

--- a/nextmv/nextmv/cli/cloud/instance/get.py
+++ b/nextmv/nextmv/cli/cloud/instance/get.py
@@ -51,7 +51,7 @@ def get(
     instance = cloud_app.instance(instance_id=instance_id)
     instance_dict = instance.to_dict()
 
-    if output is not None:
+    if output is not None and output != "":
         with open(output, "w") as f:
             json.dump(instance_dict, f, indent=2)
 

--- a/nextmv/nextmv/cli/cloud/instance/list.py
+++ b/nextmv/nextmv/cli/cloud/instance/list.py
@@ -49,7 +49,7 @@ def list(
     instances = cloud_app.list_instances()
     instances_dicts = [instance.to_dict() for instance in instances]
 
-    if output is not None:
+    if output is not None and output != "":
         with open(output, "w") as f:
             json.dump(instances_dicts, f, indent=2)
 

--- a/nextmv/nextmv/cli/cloud/instance/update.py
+++ b/nextmv/nextmv/cli/cloud/instance/update.py
@@ -205,7 +205,7 @@ def update(
     )
     updated_instance_dict = updated_instance.to_dict()
 
-    if output is not None:
+    if output is not None and output != "":
         with open(output, "w") as f:
             json.dump(updated_instance_dict, f, indent=2)
 

--- a/nextmv/nextmv/cli/cloud/managed_input/get.py
+++ b/nextmv/nextmv/cli/cloud/managed_input/get.py
@@ -52,7 +52,7 @@ def get(
     managed_input = cloud_app.managed_input(managed_input_id=managed_input_id)
     managed_input_dict = managed_input.to_dict()
 
-    if output is not None:
+    if output is not None and output != "":
         with open(output, "w") as f:
             json.dump(managed_input_dict, f, indent=2)
 

--- a/nextmv/nextmv/cli/cloud/managed_input/list.py
+++ b/nextmv/nextmv/cli/cloud/managed_input/list.py
@@ -49,7 +49,7 @@ def list(
     managed_inputs = cloud_app.list_managed_inputs()
     managed_inputs_dicts = [managed_input.to_dict() for managed_input in managed_inputs]
 
-    if output is not None:
+    if output is not None and output != "":
         with open(output, "w") as f:
             json.dump(managed_inputs_dicts, f, indent=2)
 

--- a/nextmv/nextmv/cli/cloud/managed_input/update.py
+++ b/nextmv/nextmv/cli/cloud/managed_input/update.py
@@ -86,7 +86,7 @@ def update(
     )
     updated_managed_input_dict = updated_managed_input.to_dict()
 
-    if output is not None:
+    if output is not None and output != "":
         with open(output, "w") as f:
             json.dump(updated_managed_input_dict, f, indent=2)
 

--- a/nextmv/nextmv/cli/cloud/run/create.py
+++ b/nextmv/nextmv/cli/cloud/run/create.py
@@ -320,10 +320,6 @@ def create(
     )
     run_options = build_run_options(options)
 
-    # Build the polling options.
-    polling_options = default_polling_options()
-    polling_options.max_duration = timeout
-
     # Handles the default instance.
     if instance_id == "default":
         instance_id = ""
@@ -350,6 +346,10 @@ def create(
         return
 
     success(f"Run [magenta]{run_id}[/magenta] created.")
+
+    # Build the polling options.
+    polling_options = default_polling_options()
+    polling_options.max_duration = timeout
 
     # Handle what happens after the run is created for logging and result
     # retrieval.

--- a/nextmv/nextmv/cli/cloud/run/get.py
+++ b/nextmv/nextmv/cli/cloud/run/get.py
@@ -187,12 +187,12 @@ def handle_outputs(
 
     # At this point, we know that the output is multi-file or csv-archive.
     result_dict = run_result.to_dict()
-    if "output" in result_dict and run_info.metadata.run_is_finalized():
+    if "output" in result_dict and run_result.metadata.run_is_finalized():
         del result_dict["output"]
         success(f"Run outputs downloaded to [magenta]{output_dir}[/magenta]. Here is the metadata.")
     else:
         success(
-            f"Run is not finalized (status: [magenta]{run_info.metadata.status_v2.value}[/magenta]). "
+            f"Run is not finalized (status: [magenta]{run_result.metadata.status_v2.value}[/magenta]). "
             "Here is the metadata."
         )
 

--- a/nextmv/nextmv/cli/cloud/run/list.py
+++ b/nextmv/nextmv/cli/cloud/run/list.py
@@ -69,7 +69,7 @@ def list(
     runs = cloud_app.list_runs(status=status)
     runs_dicts = [run.to_dict() for run in runs]
 
-    if output is not None:
+    if output is not None and output != "":
         with open(output, "w") as f:
             json.dump(runs_dicts, f, indent=2)
 

--- a/nextmv/nextmv/cli/cloud/run/metadata.py
+++ b/nextmv/nextmv/cli/cloud/run/metadata.py
@@ -56,7 +56,7 @@ def metadata(
     run_info = cloud_app.run_metadata(run_id)
     info_dict = run_info.to_dict()
 
-    if output is not None:
+    if output is not None and output != "":
         with open(output, "w") as f:
             json.dump(info_dict, f, indent=2)
 

--- a/nextmv/nextmv/cli/cloud/scenario/__init__.py
+++ b/nextmv/nextmv/cli/cloud/scenario/__init__.py
@@ -1,0 +1,29 @@
+"""
+This module defines the cloud scenario command tree for the Nextmv CLI.
+"""
+
+import typer
+
+from nextmv.cli.cloud.scenario.create import app as create_app
+from nextmv.cli.cloud.scenario.delete import app as delete_app
+from nextmv.cli.cloud.scenario.get import app as get_app
+from nextmv.cli.cloud.scenario.list import app as list_app
+from nextmv.cli.cloud.scenario.metadata import app as metadata_app
+from nextmv.cli.cloud.scenario.update import app as update_app
+
+# Set up subcommand application.
+app = typer.Typer()
+app.add_typer(create_app)
+app.add_typer(delete_app)
+app.add_typer(get_app)
+app.add_typer(list_app)
+app.add_typer(metadata_app)
+app.add_typer(update_app)
+
+
+@app.callback()
+def callback() -> None:
+    """
+    Create and manage Nextmv Cloud scenario tests.
+    """
+    pass

--- a/nextmv/nextmv/cli/cloud/scenario/create.py
+++ b/nextmv/nextmv/cli/cloud/scenario/create.py
@@ -1,5 +1,5 @@
 """
-This module defines the cloud batch create command for the Nextmv CLI.
+This module defines the cloud scenario create command for the Nextmv CLI.
 """
 
 import json
@@ -274,7 +274,7 @@ def create(
 
     cloud_app = build_app(app_id=app_id, profile=profile)
 
-    # Build the runs list from the CLI options
+    # Build the scenario list from the CLI options
     scenario_list = build_scenarios(scenarios)
 
     scenario_id = cloud_app.new_scenario_test(
@@ -297,7 +297,7 @@ def create(
     polling_options = default_polling_options()
     polling_options.max_duration = timeout
 
-    in_progress(msg="Getting batch experiment results...")
+    in_progress(msg="Getting scenario test results...")
     scenario_test = cloud_app.scenario_test_with_polling(
         scenario_test_id=scenario_id,
         polling_options=polling_options,
@@ -374,13 +374,13 @@ def _process_scenario_list(scenario_data: list, scenario_str: str) -> list[Scena
     list[Scenario]
         List of processed Scenario objects.
     """
-    from nextmv.cloud.scenario import Scenario
 
     processed_scenarios = []
     for ix, item in enumerate(scenario_data):
         _validate_scenario_fields(item, scenario_str, ix)
         scenario = Scenario.from_dict(item)
         processed_scenarios.append(scenario)
+
     return processed_scenarios
 
 
@@ -400,9 +400,9 @@ def _process_single_scenario(scenario_data: dict, scenario_str: str) -> "Scenari
     Scenario
         Processed Scenario object.
     """
-    from nextmv.cloud.scenario import Scenario
 
     _validate_scenario_fields(scenario_data, scenario_str)
+
     return Scenario.from_dict(scenario_data)
 
 

--- a/nextmv/nextmv/cli/cloud/scenario/create.py
+++ b/nextmv/nextmv/cli/cloud/scenario/create.py
@@ -1,0 +1,451 @@
+"""
+This module defines the cloud batch create command for the Nextmv CLI.
+"""
+
+import json
+from typing import Annotated
+
+import typer
+
+from nextmv.cli.configuration.config import build_app
+from nextmv.cli.message import error, in_progress, print_json, success
+from nextmv.cli.options import AppIDOption, ProfileOption
+from nextmv.cloud.scenario import Scenario
+from nextmv.polling import default_polling_options
+
+# Set up subcommand application.
+app = typer.Typer()
+
+
+@app.command()
+def create(
+    app_id: AppIDOption,
+    # Options for scenario test configuration.
+    scenarios: Annotated[
+        list[str],
+        typer.Option(
+            "--scenarios",
+            "-s",
+            help="Scenarios to use for the test. Data should be valid [magenta]json[/magenta]. "
+            "Pass multiple scenarios by repeating the flag, or providing a list of objects. "
+            "See command help for details on scenario formatting.",
+            metavar="SCENARIOS",
+            rich_help_panel="Scenario test configuration",
+        ),
+    ],
+    description: Annotated[
+        str | None,
+        typer.Option(
+            "--description",
+            "-d",
+            help="Description of the scenario test.",
+            metavar="DESCRIPTION",
+            rich_help_panel="Scenario test configuration",
+        ),
+    ] = None,
+    name: Annotated[
+        str | None,
+        typer.Option(
+            "--name",
+            "-n",
+            help="Name of the scenario test. If not provided, the ID will be used as the name.",
+            metavar="NAME",
+            rich_help_panel="Scenario test configuration",
+        ),
+    ] = None,
+    repetitions: Annotated[
+        int | None,
+        typer.Option(
+            "--repetitions",
+            "-r",
+            help="Number of times the scenario test is [italic]repeated[/italic]. "
+            "0 repetitions = 1 execution, 1 repetition = 2 executions, etc.",
+            metavar="REPETITIONS",
+            rich_help_panel="Scenario test configuration",
+        ),
+    ] = 0,
+    scenario_test_id: Annotated[
+        str | None,
+        typer.Option(
+            "--scenario-test-id",
+            "-i",
+            help="ID for the scenario test. Will be generated if not provided.",
+            envvar="NEXTMV_SCENARIO_TEST_ID",
+            metavar="SCENARIO_TEST_ID",
+            rich_help_panel="Scenario test configuration",
+        ),
+    ] = None,
+    # Options for controlling output.
+    output: Annotated[
+        str | None,
+        typer.Option(
+            "--output",
+            "-o",
+            help="Waits for the test to complete and saves the results to this location.",
+            metavar="OUTPUT_PATH",
+            rich_help_panel="Output control",
+        ),
+    ] = None,
+    timeout: Annotated[
+        int,
+        typer.Option(
+            help="The maximum time in seconds to wait for results when polling. Poll indefinitely if not set.",
+            metavar="TIMEOUT_SECONDS",
+            rich_help_panel="Output control",
+        ),
+    ] = -1,
+    wait: Annotated[
+        bool,
+        typer.Option(
+            "--wait",
+            "-w",
+            help="Wait for the scenario test to complete. Results are printed to [magenta]stdout[/magenta]. "
+            "Specify output location with [code]--output[/code].",
+            rich_help_panel="Output control",
+        ),
+    ] = False,
+    profile: ProfileOption = None,
+) -> None:
+    """
+    Create a new Nextmv Cloud scenario test.
+
+    A scenario test allows you to run multiple scenarios with different inputs,
+    instances/versions, and configurations in a single test.
+
+    Use the [code]--wait[/code] flag to wait for the scenario test to complete,
+    polling for results. Using the [code]--output[/code] flag will also
+    activate waiting, and allows you to specify a destination file for the
+    results.
+
+    [bold][underline]Scenarios[/underline][/bold]
+
+    Scenarios are provided as [magenta]json[/magenta] objects using the
+    [code]--scenarios[/code] flag. Each scenario defines the configuration for
+    a scenario test execution.
+
+    You can provide scenarios in three ways:
+    - A single scenario as a [magenta]json[/magenta] object.
+    - Multiple scenarios by repeating the [code]--scenarios[/code] flag.
+    - Multiple scenarios as a [magenta]json[/magenta] array in a single [code]--scenarios[/code] flag.
+
+    Each scenario must have the following fields:
+    - [magenta]instance_id[/magenta]: ID of the instance to use for this scenario (required).
+    - [magenta]scenario_input[/magenta]: Object containing the scenario input (required), with:
+        - [magenta]scenario_input_type[/magenta]: Type of the scenario input (required).
+        - [magenta]scenario_input_data[/magenta]: Data for the scenario input (required).
+    - [magenta]scenario_id[/magenta]: ID of the scenario (optional). The
+      default value will be set as [magenta]scenario-<index>[/magenta] if not set.
+    - [magenta]configuration[/magenta]: An array of configuration objects
+      (optional). Use this attribute to configure variation of options for the scenario. Each scenario
+      configuration object requires:
+        - [magenta]name[/magenta]: Name of the configuration option.
+        - [magenta]values[/magenta]: List of values for the configuration option.
+
+    Example object format:
+    [green]{
+        "instance_id": "bunny-hopper-v2",
+        "scenario_input": {
+            "scenario_input_type": "input_set",
+            "scenario_input_data": {
+                "input_id": "meadow-input-a1",
+                "input_set_id": "spring-gardens"
+            }
+        },
+        "configuration": [
+            {
+                "name": "speed",
+                "values": ["optimized", "balanced", "safe"]
+            }
+        ]
+    }[/green]
+
+    [bold][underline]Examples[/underline][/bold]
+
+    - Create a scenario test with a single scenario.
+        $ [green]SCENARIO='{
+            "instance_id": "warren-planner-v1",
+            "scenario_input": {
+                "scenario_input_type": "input_set",
+                "scenario_input_data": {
+                    "input_id": "carrot-patch-a",
+                    "input_set_id": "spring-gardens"
+                }
+            }
+        }'
+        nextmv cloud scenario create --app-id hare-app --name "Spring Meadow Routes" --scenarios "$SCENARIO"[/green]
+
+    - Create with multiple scenarios by repeating the flag.
+        $ [green]SCENARIO1='{
+            "instance_id": "hop-optimizer",
+            "scenario_input": {
+                "scenario_input_type": "input_set",
+                "scenario_input_data": {
+                    "input_id": "lettuce-field-1",
+                    "input_set_id": "veggie-gardens"
+                }
+            }
+        }'
+        SCENARIO2='{
+            "instance_id": "hop-optimizer",
+            "scenario_input": {
+                "scenario_input_type": "input_set",
+                "scenario_input_data": {
+                    "input_id": "lettuce-field-2",
+                    "input_set_id": "veggie-gardens"
+                }
+            }
+        }'
+        nextmv cloud scenario create --app-id hare-app --name "Lettuce Delivery Optimization" \\
+            --scenarios "$SCENARIO1" --scenarios "$SCENARIO2"[/green]
+
+    - Create with multiple scenarios in a single [magenta]json[/magenta] array.
+        $ [green]SCENARIOS='[
+            {
+                "instance_id": "burrow-builder",
+                "scenario_input": {
+                    "scenario_input_type": "input_set",
+                    "scenario_input_data": {
+                        "input_id": "warren-zone-a",
+                        "input_set_id": "burrow-sites"
+                    }
+                }
+            },
+            {
+                "instance_id": "tunnel-planner-v3",
+                "scenario_input": {
+                    "scenario_input_type": "input_set",
+                    "scenario_input_data": {
+                        "input_id": "warren-zone-b",
+                        "input_set_id": "burrow-sites"
+                    }
+                }
+            }
+        ]'
+        nextmv cloud scenario create --app-id hare-app --name "Warren Construction Plans" \\
+            --scenarios "$SCENARIOS"[/green]
+
+    - Create a scenario test and wait for it to complete.
+        $ [green]SCENARIO='{
+            "instance_id": "foraging-route",
+            "scenario_input": {
+                "scenario_input_type": "input_set",
+                "scenario_input_data": {
+                    "input_id": "carrot-harvest",
+                    "input_set_id": "harvest-season"
+                }
+            }
+        }'
+        nextmv cloud scenario create --app-id hare-app --name "Autumn Carrot Collection" --scenarios "$SCENARIO" \\
+            --wait[/green]
+
+    - Create a scenario test and save the results to a file, waiting for completion.
+        $ [green]SCENARIO='{
+            "instance_id": "safe-hopper",
+            "scenario_input": {
+                "scenario_input_type": "input_set",
+                "scenario_input_data": {
+                    "input_id": "predator-zones",
+                    "input_set_id": "danger-zones"
+                }
+            }
+        }'
+        nextmv cloud scenario create --app-id hare-app --name "Fox Avoidance Routes" --scenarios "$SCENARIO" \\
+            --output bunny-safety-results.json[/green]
+
+    - Create a scenario test with configuration options.
+        $ [green]SCENARIO='{
+            "instance_id": "hop-optimizer",
+            "scenario_input": {
+                "scenario_input_type": "input_set",
+                "scenario_input_data": {
+                    "input_id": "garden-route-1",
+                    "input_set_id": "garden-paths"
+                }
+            },
+            "configuration": [
+                {
+                    "name": "speed",
+                    "values": ["fast", "careful"]
+                }
+            ]
+        }'
+        nextmv cloud scenario create --app-id hare-app --name "Speed Analysis" --scenarios "$SCENARIO"[/green]
+    """
+
+    cloud_app = build_app(app_id=app_id, profile=profile)
+
+    # Build the runs list from the CLI options
+    scenario_list = build_scenarios(scenarios)
+
+    scenario_id = cloud_app.new_scenario_test(
+        scenarios=scenario_list,
+        id=scenario_test_id,
+        name=name,
+        description=description,
+        repetitions=repetitions,
+    )
+
+    # If we don't need to poll at all we are done.
+    if not wait and (output is None or output == ""):
+        print_json({"scenario_test_id": scenario_id})
+
+        return
+
+    success(f"Scenario test [magenta]{scenario_id}[/magenta] created.")
+
+    # Build the polling options.
+    polling_options = default_polling_options()
+    polling_options.max_duration = timeout
+
+    in_progress(msg="Getting batch experiment results...")
+    scenario_test = cloud_app.scenario_test_with_polling(
+        scenario_test_id=scenario_id,
+        polling_options=polling_options,
+    )
+    scenario_test_dict = scenario_test.to_dict()
+
+    # Handle output
+    if output is not None and output != "":
+        with open(output, "w") as f:
+            json.dump(scenario_test_dict, f, indent=2)
+
+        success(msg=f"Scenario test output saved to [magenta]{output}[/magenta].")
+
+        return
+
+    print_json(scenario_test_dict)
+
+
+def build_scenarios(scenarios: list[str]) -> list[Scenario]:
+    """
+    Build a list of Scenario objects from CLI JSON input.
+
+    Parameters
+    ----------
+    scenarios : list[str]
+        List of scenario JSON strings provided via the CLI. Each string can be
+        a single scenario object or a list of scenario objects.
+
+    Returns
+    -------
+    list[Scenario]
+        The built list of Scenario objects.
+    """
+
+    scenario_list = []
+
+    for scenario_str in scenarios:
+        try:
+            scenario_data = json.loads(scenario_str)
+
+            # Handle the case where the value is a list of scenarios.
+            if isinstance(scenario_data, list):
+                scenario_list.extend(_process_scenario_list(scenario_data, scenario_str))
+
+            # Handle the case where the value is a single scenario.
+            elif isinstance(scenario_data, dict):
+                scenario_list.append(_process_single_scenario(scenario_data, scenario_str))
+
+            else:
+                error(
+                    f"Invalid scenario format: [magenta]{scenario_str}[/magenta]. "
+                    "Expected [magenta]json[/magenta] object or array."
+                )
+
+        except (json.JSONDecodeError, KeyError, ValueError) as e:
+            error(f"Invalid scenario format: [magenta]{scenario_str}[/magenta]. Error: {e}")
+
+    return scenario_list
+
+
+def _process_scenario_list(scenario_data: list, scenario_str: str) -> list[Scenario]:
+    """
+    Process a list of scenario dictionaries into Scenario objects.
+
+    Parameters
+    ----------
+    scenario_data : list
+        List of scenario dictionaries.
+    scenario_str : str
+        Original string for error messages.
+
+    Returns
+    -------
+    list[Scenario]
+        List of processed Scenario objects.
+    """
+    from nextmv.cloud.scenario import Scenario
+
+    processed_scenarios = []
+    for ix, item in enumerate(scenario_data):
+        _validate_scenario_fields(item, scenario_str, ix)
+        scenario = Scenario.from_dict(item)
+        processed_scenarios.append(scenario)
+    return processed_scenarios
+
+
+def _process_single_scenario(scenario_data: dict, scenario_str: str) -> "Scenario":
+    """
+    Process a single scenario dictionary into a Scenario object.
+
+    Parameters
+    ----------
+    scenario_data : dict
+        Scenario dictionary.
+    scenario_str : str
+        Original string for error messages.
+
+    Returns
+    -------
+    Scenario
+        Processed Scenario object.
+    """
+    from nextmv.cloud.scenario import Scenario
+
+    _validate_scenario_fields(scenario_data, scenario_str)
+    return Scenario.from_dict(scenario_data)
+
+
+def _validate_scenario_fields(scenario_data: dict, scenario_str: str, index: int | None = None) -> None:
+    """
+    Validate that required fields are present in a scenario dictionary.
+
+    Parameters
+    ----------
+    scenario_data : dict
+        Scenario dictionary to validate.
+    scenario_str : str
+        Original string for error messages.
+    index : int | None
+        Index in array if validating array element (for error reporting).
+    """
+    location = f"at index [magenta]{index}[/magenta] in " if index is not None else "in "
+
+    if scenario_data.get("instance_id") is None:
+        error(
+            f"Invalid scenario format {location}"
+            f"[magenta]{scenario_str}[/magenta]. Each scenario must have an "
+            "[magenta]instance_id[/magenta] field."
+        )
+
+    scenario_input = scenario_data.get("scenario_input")
+    if scenario_input is None:
+        error(
+            f"Invalid scenario format {location}"
+            f"[magenta]{scenario_str}[/magenta]. Each scenario must have a "
+            "[magenta]scenario_input[/magenta] field."
+        )
+
+    if scenario_input.get("scenario_input_type") is None:
+        error(
+            f"Invalid scenario format {location}"
+            f"[magenta]{scenario_str}[/magenta]. Each [magenta]scenario_input[/magenta] must have a "
+            "[magenta]scenario_input_type[/magenta] field."
+        )
+
+    if scenario_input.get("scenario_input_data") is None:
+        error(
+            f"Invalid scenario format {location}"
+            f"[magenta]{scenario_str}[/magenta]. Each [magenta]scenario_input[/magenta] must have a "
+            "[magenta]scenario_input_data[/magenta] field."
+        )

--- a/nextmv/nextmv/cli/cloud/scenario/delete.py
+++ b/nextmv/nextmv/cli/cloud/scenario/delete.py
@@ -1,0 +1,65 @@
+"""
+This module defines the cloud scenario delete command for the Nextmv CLI.
+"""
+
+from typing import Annotated
+
+import typer
+from rich.prompt import Confirm
+
+from nextmv.cli.configuration.config import build_app
+from nextmv.cli.message import info, success
+from nextmv.cli.options import AppIDOption, ProfileOption, ScenarioTestIDOption
+
+# Set up subcommand application.
+app = typer.Typer()
+
+
+@app.command()
+def delete(
+    app_id: AppIDOption,
+    scenario_test_id: ScenarioTestIDOption,
+    yes: Annotated[
+        bool,
+        typer.Option(
+            "--yes",
+            "-y",
+            help="Agree to deletion confirmation prompt. Useful for non-interactive sessions.",
+        ),
+    ] = False,
+    profile: ProfileOption = None,
+) -> None:
+    """
+    Deletes a Nextmv Cloud scenario test.
+
+    This action is permanent and cannot be undone. The scenario test and all
+    associated data will be deleted. Use the [code]--yes[/code] flag to skip
+    the confirmation prompt.
+
+    [bold][underline]Examples[/underline][/bold]
+
+    - Delete the scenario test with the ID [magenta]hop-analysis[/magenta] from application
+      [magenta]hare-app[/magenta].
+        $ [green]nextmv cloud scenario delete --app-id hare-app --scenario-test-id hop-analysis[/green]
+
+    - Delete the scenario test without confirmation prompt.
+        $ [green]nextmv cloud scenario delete --app-id hare-app --scenario-test-id carrot-routes --yes[/green]
+    """
+
+    if not yes:
+        confirm = Confirm.ask(
+            f"Are you sure you want to delete scenario test [magenta]{scenario_test_id}[/magenta] "
+            f"from application [magenta]{app_id}[/magenta]? This action cannot be undone.",
+            default=False,
+        )
+
+        if not confirm:
+            info(
+                msg=f"Scenario test [magenta]{scenario_test_id}[/magenta] will not be deleted.",
+                emoji=":bulb:",
+            )
+            return
+
+    cloud_app = build_app(app_id=app_id, profile=profile)
+    cloud_app.delete_scenario_test(scenario_test_id=scenario_test_id)
+    success(msg=f"Scenario test [magenta]{scenario_test_id}[/magenta] deleted.")

--- a/nextmv/nextmv/cli/cloud/scenario/get.py
+++ b/nextmv/nextmv/cli/cloud/scenario/get.py
@@ -1,0 +1,102 @@
+"""
+This module defines the cloud scenario get command for the Nextmv CLI.
+"""
+
+import json
+from typing import Annotated
+
+import typer
+
+from nextmv.cli.configuration.config import build_app
+from nextmv.cli.message import in_progress, print_json, success
+from nextmv.cli.options import AppIDOption, ProfileOption, ScenarioTestIDOption
+from nextmv.polling import default_polling_options
+
+# Set up subcommand application.
+app = typer.Typer()
+
+
+@app.command()
+def get(
+    app_id: AppIDOption,
+    scenario_test_id: ScenarioTestIDOption,
+    output: Annotated[
+        str | None,
+        typer.Option(
+            "--output",
+            "-o",
+            help="Waits for the scenario test to complete and saves the results to this location.",
+            metavar="OUTPUT_PATH",
+        ),
+    ] = None,
+    timeout: Annotated[
+        int,
+        typer.Option(
+            help="The maximum time in seconds to wait for results when polling. Poll indefinitely if not set.",
+            metavar="TIMEOUT_SECONDS",
+        ),
+    ] = -1,
+    wait: Annotated[
+        bool,
+        typer.Option(
+            "--wait",
+            "-w",
+            help="Wait for the scenario test to complete. Results are printed to [magenta]stdout[/magenta]. "
+            "Specify output location with [code]--output[/code].",
+        ),
+    ] = False,
+    profile: ProfileOption = None,
+) -> None:
+    """
+    Get a Nextmv Cloud scenario test.
+
+    Use the [code]--wait[/code] flag to wait for the scenario test to
+    complete, polling for results. Using the [code]--output[/code] flag will
+    also activate waiting, and allows you to specify a destination file for the
+    results.
+
+    [bold][underline]Examples[/underline][/bold]
+
+    - Get the scenario test with ID [magenta]carrot-optimization[/magenta] from application
+      [magenta]hare-app[/magenta].
+        $ [green]nextmv cloud scenario get --app-id hare-app --scenario-test-id carrot-optimization[/green]
+
+    - Get the scenario test and wait for it to complete if necessary.
+        $ [green]nextmv cloud scenario get --app-id hare-app --scenario-test-id bunny-hop-test --wait[/green]
+
+    - Get the scenario test and save the results to a file.
+        $ [green]nextmv cloud scenario get --app-id hare-app --scenario-test-id warren-planning \\
+            --output results.json[/green]
+
+    - Get the scenario test using a specific profile.
+        $ [green]nextmv cloud scenario get --app-id hare-app --scenario-test-id lettuce-routes --profile prod[/green]
+    """
+    cloud_app = build_app(app_id=app_id, profile=profile)
+
+    # Build the polling options.
+    polling_options = default_polling_options()
+    polling_options.max_duration = timeout
+
+    # Determine if we should wait
+    should_wait = wait or (output is not None and output != "")
+
+    in_progress(msg="Getting scenario test...")
+    if should_wait:
+        scenario_test = cloud_app.scenario_test_with_polling(
+            scenario_test_id=scenario_test_id,
+            polling_options=polling_options,
+        )
+    else:
+        scenario_test = cloud_app.scenario_test(scenario_test_id=scenario_test_id)
+
+    scenario_test_dict = scenario_test.to_dict()
+
+    if output is not None:
+        with open(output, "w") as f:
+            json.dump(scenario_test_dict, f, indent=2)
+
+        success(msg=f"Scenario test results saved to [magenta]{output}[/magenta].")
+
+        return
+
+    print_json(scenario_test_dict)

--- a/nextmv/nextmv/cli/cloud/scenario/get.py
+++ b/nextmv/nextmv/cli/cloud/scenario/get.py
@@ -91,7 +91,7 @@ def get(
 
     scenario_test_dict = scenario_test.to_dict()
 
-    if output is not None:
+    if output is not None and output != "":
         with open(output, "w") as f:
             json.dump(scenario_test_dict, f, indent=2)
 

--- a/nextmv/nextmv/cli/cloud/scenario/list.py
+++ b/nextmv/nextmv/cli/cloud/scenario/list.py
@@ -1,0 +1,63 @@
+"""
+This module defines the cloud scenario list command for the Nextmv CLI.
+"""
+
+import json
+from typing import Annotated
+
+import typer
+
+from nextmv.cli.configuration.config import build_app
+from nextmv.cli.message import in_progress, print_json, success
+from nextmv.cli.options import AppIDOption, ProfileOption
+
+# Set up subcommand application.
+app = typer.Typer()
+
+
+@app.command()
+def list(
+    app_id: AppIDOption,
+    output: Annotated[
+        str | None,
+        typer.Option(
+            "--output",
+            "-o",
+            help="Saves the list of scenario tests to this location.",
+            metavar="OUTPUT_PATH",
+        ),
+    ] = None,
+    profile: ProfileOption = None,
+) -> None:
+    """
+    List all Nextmv Cloud scenario tests for an application.
+
+    This command retrieves all scenario tests associated with the specified
+    application.
+
+    [bold][underline]Examples[/underline][/bold]
+
+    - List all scenario tests for application [magenta]hare-app[/magenta].
+        $ [green]nextmv cloud scenario list --app-id hare-app[/green]
+
+    - List all scenario tests and save to a file.
+        $ [green]nextmv cloud scenario list --app-id hare-app --output scenario_tests.json[/green]
+
+    - List all scenario tests using a specific profile.
+        $ [green]nextmv cloud scenario list --app-id hare-app --profile prod[/green]
+    """
+
+    cloud_app = build_app(app_id=app_id, profile=profile)
+    in_progress(msg="Listing scenario tests...")
+    scenario_tests = cloud_app.list_scenario_tests()
+    scenario_tests_dict = [exp.to_dict() for exp in scenario_tests]
+
+    if output is not None:
+        with open(output, "w") as f:
+            json.dump(scenario_tests_dict, f, indent=2)
+
+        success(msg=f"Scenario tests list saved to [magenta]{output}[/magenta].")
+
+        return
+
+    print_json(scenario_tests_dict)

--- a/nextmv/nextmv/cli/cloud/scenario/list.py
+++ b/nextmv/nextmv/cli/cloud/scenario/list.py
@@ -52,7 +52,7 @@ def list(
     scenario_tests = cloud_app.list_scenario_tests()
     scenario_tests_dict = [exp.to_dict() for exp in scenario_tests]
 
-    if output is not None:
+    if output is not None and output != "":
         with open(output, "w") as f:
             json.dump(scenario_tests_dict, f, indent=2)
 

--- a/nextmv/nextmv/cli/cloud/scenario/metadata.py
+++ b/nextmv/nextmv/cli/cloud/scenario/metadata.py
@@ -56,7 +56,7 @@ def metadata(
     scenario_metadata = cloud_app.scenario_test_metadata(scenario_test_id=scenario_test_id)
     scenario_metadata_dict = scenario_metadata.to_dict()
 
-    if output is not None:
+    if output is not None and output != "":
         with open(output, "w") as f:
             json.dump(scenario_metadata_dict, f, indent=2)
 

--- a/nextmv/nextmv/cli/cloud/scenario/metadata.py
+++ b/nextmv/nextmv/cli/cloud/scenario/metadata.py
@@ -1,0 +1,67 @@
+"""
+This module defines the cloud scenario metadata command for the Nextmv CLI.
+"""
+
+import json
+from typing import Annotated
+
+import typer
+
+from nextmv.cli.configuration.config import build_app
+from nextmv.cli.message import in_progress, print_json, success
+from nextmv.cli.options import AppIDOption, ProfileOption, ScenarioTestIDOption
+
+# Set up subcommand application.
+app = typer.Typer()
+
+
+@app.command()
+def metadata(
+    app_id: AppIDOption,
+    scenario_test_id: ScenarioTestIDOption,
+    output: Annotated[
+        str | None,
+        typer.Option(
+            "--output",
+            "-o",
+            help="Saves the scenario test metadata to this location.",
+            metavar="OUTPUT_PATH",
+        ),
+    ] = None,
+    profile: ProfileOption = None,
+) -> None:
+    """
+    Get metadata for a Nextmv Cloud scenario test.
+
+    This command retrieves metadata for a specific scenario test, including
+    status, creation date, and other high-level information without the full
+    run details.
+
+    [bold][underline]Examples[/underline][/bold]
+
+    - Get metadata for scenario test [magenta]bunny-warren-optimization[/magenta] from application
+      [magenta]hare-app[/magenta].
+        $ [green]nextmv cloud scenario metadata --app-id hare-app --scenario-test-id bunny-warren-optimization[/green]
+
+    - Get metadata and save to a file.
+        $ [green]nextmv cloud scenario metadata --app-id hare-app --scenario-test-id lettuce-delivery \\
+            --output metadata.json[/green]
+
+    - Get metadata using a specific profile.
+        $ [green]nextmv cloud scenario metadata --app-id hare-app --scenario-test-id hop-schedule --profile prod[/green]
+    """
+
+    cloud_app = build_app(app_id=app_id, profile=profile)
+    in_progress(msg="Getting scenario test metadata...")
+    scenario_metadata = cloud_app.scenario_test_metadata(scenario_test_id=scenario_test_id)
+    scenario_metadata_dict = scenario_metadata.to_dict()
+
+    if output is not None:
+        with open(output, "w") as f:
+            json.dump(scenario_metadata_dict, f, indent=2)
+
+        success(msg=f"Scenario test metadata saved to [magenta]{output}[/magenta].")
+
+        return
+
+    print_json(scenario_metadata_dict)

--- a/nextmv/nextmv/cli/cloud/scenario/update.py
+++ b/nextmv/nextmv/cli/cloud/scenario/update.py
@@ -83,7 +83,7 @@ def update(
     )
     scenario_info_dict = scenario_info.to_dict()
 
-    if output is not None:
+    if output is not None and output != "":
         with open(output, "w") as f:
             json.dump(scenario_info_dict, f, indent=2)
 

--- a/nextmv/nextmv/cli/cloud/scenario/update.py
+++ b/nextmv/nextmv/cli/cloud/scenario/update.py
@@ -1,5 +1,5 @@
 """
-This module defines the cloud batch update command for the Nextmv CLI.
+This module defines the cloud scenario update command for the Nextmv CLI.
 """
 
 import json
@@ -9,7 +9,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_app
 from nextmv.cli.message import in_progress, print_json, success
-from nextmv.cli.options import AppIDOption, BatchExperimentIDOption, ProfileOption
+from nextmv.cli.options import AppIDOption, ProfileOption, ScenarioTestIDOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -18,13 +18,13 @@ app = typer.Typer()
 @app.command()
 def update(
     app_id: AppIDOption,
-    batch_experiment_id: BatchExperimentIDOption,
+    scenario_test_id: ScenarioTestIDOption,
     description: Annotated[
         str | None,
         typer.Option(
             "--description",
             "-d",
-            help="Updated description of the batch experiment.",
+            help="Updated description of the scenario test.",
             metavar="DESCRIPTION",
         ),
     ] = None,
@@ -33,7 +33,7 @@ def update(
         typer.Option(
             "--name",
             "-n",
-            help="Updated name of the batch experiment.",
+            help="Updated name of the scenario test.",
             metavar="NAME",
         ),
     ] = None,
@@ -42,54 +42,52 @@ def update(
         typer.Option(
             "--output",
             "-o",
-            help="Saves the updated batch experiment information to this location.",
+            help="Saves the updated scenario test information to this location.",
             metavar="OUTPUT_PATH",
         ),
     ] = None,
     profile: ProfileOption = None,
 ) -> None:
     """
-    Update a Nextmv Cloud batch experiment.
+    Update a Nextmv Cloud scenario test.
 
-    Update the name and/or description of a batch experiment. Any fields not
+    Update the name and/or description of a scenario test. Any fields not
     specified will remain unchanged.
 
     [bold][underline]Examples[/underline][/bold]
 
-    - Update the name of a batch experiment.
-        $ [green]nextmv cloud batch update --app-id hare-app --batch-experiment-id carrot-feast \\
+    - Update the name of a scenario test.
+        $ [green]nextmv cloud scenario update --app-id hare-app --scenario-test-id carrot-feast \\
             --name "Spring Carrot Harvest"[/green]
 
-    - Update the description of a batch experiment.
-        $ [green]nextmv cloud batch update --app-id hare-app --batch-experiment-id bunny-hop-routes \\
+    - Update the description of a scenario test.
+        $ [green]nextmv cloud scenario update --app-id hare-app --scenario-test-id bunny-hop-routes \\
             --description "Optimizing hop paths through the meadow"[/green]
 
     - Update both name and description and save the result.
-        $ [green]nextmv cloud batch update --app-id hare-app --batch-experiment-id lettuce-delivery \\
+        $ [green]nextmv cloud scenario update --app-id hare-app --scenario-test-id lettuce-delivery \\
             --name "Warren Lettuce Express" --description "Fast lettuce delivery to all burrows" \\
-            --output updated-batch.json[/green]
+            --output updated-scenario.json[/green]
     """
 
     cloud_app = build_app(app_id=app_id, profile=profile)
-
-    in_progress(msg="Updating batch experiment...")
-    batch_experiment = cloud_app.update_batch_experiment(
-        batch_experiment_id=batch_experiment_id,
+    in_progress(msg="Updating scenario test...")
+    scenario_info = cloud_app.update_scenario_test(
+        scenario_test_id=scenario_test_id,
         name=name,
         description=description,
     )
-
-    batch_experiment_dict = batch_experiment.to_dict()
     success(
-        f"Batch experiment [magenta]{batch_experiment_id}[/magenta] updated successfully "
+        f"Scenario test [magenta]{scenario_test_id}[/magenta] updated successfully "
         f"in application [magenta]{app_id}[/magenta]."
     )
+    scenario_info_dict = scenario_info.to_dict()
 
     if output is not None:
         with open(output, "w") as f:
-            json.dump(batch_experiment_dict, f, indent=2)
+            json.dump(scenario_info_dict, f, indent=2)
 
-        success(msg=f"Updated batch experiment information saved to [magenta]{output}[/magenta].")
+        success(msg=f"Scenario test information saved to [magenta]{output}[/magenta].")
         return
 
-    print_json(batch_experiment_dict)
+    print_json(scenario_info_dict)

--- a/nextmv/nextmv/cli/cloud/secrets/get.py
+++ b/nextmv/nextmv/cli/cloud/secrets/get.py
@@ -55,7 +55,7 @@ def get(
     collection = cloud_app.secrets_collection(secrets_collection_id=secrets_collection_id)
     collection_dict = collection.to_dict()
 
-    if output is not None:
+    if output is not None and output != "":
         with open(output, "w") as f:
             json.dump(collection_dict, f, indent=2)
 

--- a/nextmv/nextmv/cli/cloud/secrets/list.py
+++ b/nextmv/nextmv/cli/cloud/secrets/list.py
@@ -49,7 +49,7 @@ def list(
     collections = cloud_app.list_secrets_collections()
     collections_dicts = [collection.to_dict() for collection in collections]
 
-    if output is not None:
+    if output is not None and output != "":
         with open(output, "w") as f:
             json.dump(collections_dicts, f, indent=2)
 

--- a/nextmv/nextmv/cli/cloud/secrets/update.py
+++ b/nextmv/nextmv/cli/cloud/secrets/update.py
@@ -136,7 +136,7 @@ def update(
         f"in application [magenta]{app_id}[/magenta]."
     )
 
-    if output is not None:
+    if output is not None and output != "":
         with open(output, "w") as f:
             json.dump(collection.to_dict(), f, indent=2)
 

--- a/nextmv/nextmv/cli/cloud/version/get.py
+++ b/nextmv/nextmv/cli/cloud/version/get.py
@@ -51,7 +51,7 @@ def get(
     version = cloud_app.version(version_id=version_id)
     version_dict = version.to_dict()
 
-    if output is not None:
+    if output is not None and output != "":
         with open(output, "w") as f:
             json.dump(version_dict, f, indent=2)
 

--- a/nextmv/nextmv/cli/cloud/version/list.py
+++ b/nextmv/nextmv/cli/cloud/version/list.py
@@ -49,7 +49,7 @@ def list(
     versions = cloud_app.list_versions()
     versions_dicts = [version.to_dict() for version in versions]
 
-    if output is not None:
+    if output is not None and output != "":
         with open(output, "w") as f:
             json.dump(versions_dicts, f, indent=2)
 

--- a/nextmv/nextmv/cli/cloud/version/update.py
+++ b/nextmv/nextmv/cli/cloud/version/update.py
@@ -81,7 +81,7 @@ def update(
     success(f"Version [magenta]{version_id}[/magenta] updated successfully in application [magenta]{app_id}[/magenta].")
     updated_version_dict = updated_version.to_dict()
 
-    if output is not None:
+    if output is not None and output != "":
         with open(output, "w") as f:
             json.dump(updated_version_dict, f, indent=2)
 

--- a/nextmv/nextmv/cli/options.py
+++ b/nextmv/nextmv/cli/options.py
@@ -155,10 +155,24 @@ AcceptanceTestIDOption = Annotated[
 BatchExperimentIDOption = Annotated[
     str,
     typer.Option(
-        "--batch-id",
+        "--batch-experiment-id",
         "-b",
         help="The Nextmv Cloud batch experiment ID to use for this action.",
-        envvar="NEXTMV_BATCH_ID",
-        metavar="BATCH_ID",
+        envvar="NEXTMV_BATCH_EXPERIMENT_ID",
+        metavar="BATCH_EXPERIMENT_ID",
+    ),
+]
+
+# scenario_test_id option - can be used in any command that requires a scenario test ID.
+# Define it as follows in commands or callbacks, as necessary:
+# scenario_test_id: ScenarioTestIDOption
+ScenarioTestIDOption = Annotated[
+    str,
+    typer.Option(
+        "--scenario-test-id",
+        "-i",
+        help="The Nextmv Cloud scenario test ID to use for this action.",
+        envvar="NEXTMV_SCENARIO_TEST_ID",
+        metavar="SCENARIO_TEST_ID",
     ),
 ]

--- a/nextmv/nextmv/cloud/application/_batch_scenario.py
+++ b/nextmv/nextmv/cloud/application/_batch_scenario.py
@@ -414,9 +414,9 @@ class ApplicationBatchMixin:
 
     def new_scenario_test(
         self: "Application",
-        id: str,
-        name: str,
         scenarios: list[Scenario],
+        id: str | None = None,
+        name: str | None = None,
         description: str | None = None,
         repetitions: int | None = 0,
     ) -> str:
@@ -448,13 +448,13 @@ class ApplicationBatchMixin:
 
         Parameters
         ----------
-        id: str
-            ID of the scenario test.
-        name: str
-            Name of the scenario test.
         scenarios: list[Scenario]
             List of scenarios to use for the scenario test. At least one
             scenario should be provided.
+        id: Optional[str]
+            ID of the scenario test. Will be generated if not provided.
+        name: Optional[str]
+            Name of the scenario test. If not provided, the ID will be used as the name.
         description: Optional[str]
             Optional description of the scenario test.
         repetitions: Optional[int]
@@ -479,6 +479,14 @@ class ApplicationBatchMixin:
 
         if len(scenarios) < 1:
             raise ValueError("At least one scenario must be provided")
+
+        # Generate ID if not provided
+        if id is None:
+            id = safe_id("scenario")
+
+        # Use ID as name if name not provided
+        if name is None:
+            name = id
 
         scenarios_by_id = _scenarios_by_id(scenarios)
 
@@ -535,9 +543,9 @@ class ApplicationBatchMixin:
 
     def new_scenario_test_with_result(
         self: "Application",
-        id: str,
-        name: str,
         scenarios: list[Scenario],
+        id: str | None = None,
+        name: str | None = None,
         description: str | None = None,
         repetitions: int | None = 0,
         polling_options: PollingOptions = DEFAULT_POLLING_OPTIONS,
@@ -554,13 +562,13 @@ class ApplicationBatchMixin:
 
         Parameters
         ----------
-        id: str
-            ID of the scenario test.
-        name: str
-            Name of the scenario test.
         scenarios: list[Scenario]
             List of scenarios to use for the scenario test. At least one
             scenario should be provided.
+        id: Optional[str]
+            ID of the scenario test. Will be generated if not provided.
+        name: Optional[str]
+            Name of the scenario test. If not provided, the ID will be used as the name.
         description: Optional[str]
             Optional description of the scenario test.
         repetitions: Optional[int]
@@ -569,6 +577,8 @@ class ApplicationBatchMixin:
             repetition means that the test will be repeated once, i.e.: it
             will be executed twice. 2 repetitions equals 3 executions, so on,
             and so forth.
+        polling_options : PollingOptions, default=_DEFAULT_POLLING_OPTIONS
+            Options to use when polling for the scenario test result.
 
         Returns
         -------
@@ -584,9 +594,9 @@ class ApplicationBatchMixin:
         """
 
         test_id = self.new_scenario_test(
+            scenarios=scenarios,
             id=id,
             name=name,
-            scenarios=scenarios,
             description=description,
             repetitions=repetitions,
         )

--- a/nextmv/nextmv/cloud/application/_batch_scenario.py
+++ b/nextmv/nextmv/cloud/application/_batch_scenario.py
@@ -385,7 +385,7 @@ class ApplicationBatchMixin:
             Type of the batch experiment. This is used to determine the
             experiment type. The default value is "batch". If you want to
             create a scenario test, set this to "scenario".
-        polling_options : PollingOptions, default=_DEFAULT_POLLING_OPTIONS
+        polling_options : PollingOptions, default=DEFAULT_POLLING_OPTIONS
             Options to use when polling for the batch experiment result.
 
         Returns
@@ -577,7 +577,7 @@ class ApplicationBatchMixin:
             repetition means that the test will be repeated once, i.e.: it
             will be executed twice. 2 repetitions equals 3 executions, so on,
             and so forth.
-        polling_options : PollingOptions, default=_DEFAULT_POLLING_OPTIONS
+        polling_options : PollingOptions, default=DEFAULT_POLLING_OPTIONS
             Options to use when polling for the scenario test result.
 
         Returns
@@ -692,7 +692,7 @@ class ApplicationBatchMixin:
         ----------
         scenario_test_id : str
             ID of the scenario test to retrieve.
-        polling_options : PollingOptions, default=_DEFAULT_POLLING_OPTIONS
+        polling_options : PollingOptions, default=DEFAULT_POLLING_OPTIONS
             Options to use when polling for the scenario test result.
 
         Returns


### PR DESCRIPTION
# Description

Adds the `nextmv cloud scenario` command tree with the following subcommands:

- `create`
- `delete`
- `get`
- `metadata`
- `list`
- `update`

Aligns behavior of batch exp, acceptance tests and scenario tests when creating an entity: if `--output` is used, then waiting is enabled automatically.

Changes the name of some options to align everything into using full entity names, i.e.: `batch-experiment` instead of `batch`, `acceptance-test` instead of `acceptance`, etc.

Makes ID and name optional when creating a scenario test.