### PR TITLE
Adds shadow tests and switchback tests to the SDK and the CLI | Enables the CLI

### DIFF
--- a/docs/nextmv/cloud/reference/application.md
+++ b/docs/nextmv/cloud/reference/application.md
@@ -46,6 +46,14 @@ These mixins extend the `Application` class with specific capabilities.
 
 ::: nextmv.nextmv.cloud.application._secrets
 
+### Shadow Test Management
+
+::: nextmv.nextmv.cloud.application._shadow
+
+### Switchback Test Management
+
+::: nextmv.nextmv.cloud.application._switchback
+
 ### Version Management
 
 ::: nextmv.nextmv.cloud.application._version

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -70,6 +70,8 @@ nav:
               - integration.py: nextmv/cloud/reference/integration.md
               - scenario.py: nextmv/cloud/reference/scenario.md
               - secrets.py: nextmv/cloud/reference/secrets.md
+              - shadow.py: nextmv/cloud/reference/shadow.md
+              - switchback.py: nextmv/cloud/reference/switchback.md
               - url.py: nextmv/cloud/reference/url.md
               - version.py: nextmv/cloud/reference/version.md
   - nextmv-gurobipy:

--- a/nextmv/nextmv/__about__.py
+++ b/nextmv/nextmv/__about__.py
@@ -1,1 +1,1 @@
-__version__ = "v1.0.0.dev1"
+__version__ = "v1.0.0.dev2"

--- a/nextmv/nextmv/__about__.py
+++ b/nextmv/nextmv/__about__.py
@@ -1,1 +1,1 @@
-__version__ = "v1.0.0.dev0"
+__version__ = "v1.0.0.dev1"

--- a/nextmv/nextmv/__about__.py
+++ b/nextmv/nextmv/__about__.py
@@ -1,1 +1,1 @@
-__version__ = "v0.40.0"
+__version__ = "v1.0.0.dev0"

--- a/nextmv/nextmv/__about__.py
+++ b/nextmv/nextmv/__about__.py
@@ -1,1 +1,1 @@
-__version__ = "v1.0.0.dev2"
+__version__ = "v1.0.0.dev3"

--- a/nextmv/nextmv/cli/cloud/__init__.py
+++ b/nextmv/nextmv/cli/cloud/__init__.py
@@ -16,6 +16,7 @@ from nextmv.cli.cloud.managed_input import app as managed_input_app
 from nextmv.cli.cloud.run import app as run_app
 from nextmv.cli.cloud.scenario import app as scenario_app
 from nextmv.cli.cloud.secrets import app as secrets_app
+from nextmv.cli.cloud.shadow import app as shadow_app
 from nextmv.cli.cloud.upload import app as upload_app
 from nextmv.cli.cloud.version import app as version_app
 
@@ -33,6 +34,7 @@ app.add_typer(managed_input_app, name="managed-input")
 app.add_typer(run_app, name="run")
 app.add_typer(scenario_app, name="scenario")
 app.add_typer(secrets_app, name="secrets")
+app.add_typer(shadow_app, name="shadow")
 app.add_typer(upload_app, name="upload")
 app.add_typer(version_app, name="version")
 

--- a/nextmv/nextmv/cli/cloud/__init__.py
+++ b/nextmv/nextmv/cli/cloud/__init__.py
@@ -17,6 +17,7 @@ from nextmv.cli.cloud.run import app as run_app
 from nextmv.cli.cloud.scenario import app as scenario_app
 from nextmv.cli.cloud.secrets import app as secrets_app
 from nextmv.cli.cloud.shadow import app as shadow_app
+from nextmv.cli.cloud.switchback import app as switchback_app
 from nextmv.cli.cloud.upload import app as upload_app
 from nextmv.cli.cloud.version import app as version_app
 
@@ -35,6 +36,7 @@ app.add_typer(run_app, name="run")
 app.add_typer(scenario_app, name="scenario")
 app.add_typer(secrets_app, name="secrets")
 app.add_typer(shadow_app, name="shadow")
+app.add_typer(switchback_app, name="switchback")
 app.add_typer(upload_app, name="upload")
 app.add_typer(version_app, name="version")
 

--- a/nextmv/nextmv/cli/cloud/batch/get.py
+++ b/nextmv/nextmv/cli/cloud/batch/get.py
@@ -48,7 +48,7 @@ def get(
     profile: ProfileOption = None,
 ) -> None:
     """
-    Get a Nextmv Cloud batch experiment.
+    Get a Nextmv Cloud batch experiment, including its runs.
 
     Use the [code]--wait[/code] flag to wait for the batch experiment to
     complete, polling for results. Using the [code]--output[/code] flag will

--- a/nextmv/nextmv/cli/cloud/input_set/create.py
+++ b/nextmv/nextmv/cli/cloud/input_set/create.py
@@ -73,7 +73,7 @@ def create(
             "--start-time",
             formats=["%Y-%m-%dT%H:%M:%S%z"],
             help="Start time for filtering runs in [magenta]RFC 3339[/magenta] format. "
-            "Example: [magenta]'2024-01-01T00:00:00Z'[/magenta]",
+            "Object format: [green]'2024-01-01T00:00:00Z'[/green]",
             metavar="START_TIME",
         ),
     ] = None,
@@ -83,7 +83,7 @@ def create(
             "--end-time",
             formats=["%Y-%m-%dT%H:%M:%S%z"],
             help="End time for filtering runs in [magenta]RFC 3339[/magenta] format. "
-            "Example: [magenta]'2024-01-01T00:00:00Z'[/magenta]",
+            "Object format: [green]'2024-01-01T00:00:00Z'[/green]",
             metavar="END_TIME",
         ),
     ] = None,

--- a/nextmv/nextmv/cli/cloud/input_set/create.py
+++ b/nextmv/nextmv/cli/cloud/input_set/create.py
@@ -72,7 +72,8 @@ def create(
         typer.Option(
             "--start-time",
             formats=["%Y-%m-%dT%H:%M:%S%z"],
-            help="Start time for filtering runs. (example: [magenta]'2024-01-01T00:00:00Z'[/magenta])",
+            help="Start time for filtering runs in [magenta]RFC 3339[/magenta] format. "
+            "Example: [magenta]'2024-01-01T00:00:00Z'[/magenta]",
             metavar="START_TIME",
         ),
     ] = None,
@@ -81,7 +82,8 @@ def create(
         typer.Option(
             "--end-time",
             formats=["%Y-%m-%dT%H:%M:%S%z"],
-            help="End time for filtering runs. (example: [magenta]'2024-01-01T00:00:00Z'[/magenta])",
+            help="End time for filtering runs in [magenta]RFC 3339[/magenta] format. "
+            "Example: [magenta]'2024-01-01T00:00:00Z'[/magenta]",
             metavar="END_TIME",
         ),
     ] = None,
@@ -99,7 +101,7 @@ def create(
         typer.Option(
             "--inputs",
             help="Inputs for the input set. Data should be valid [magenta]json[/magenta]. Object "
-            "format: [magenta][{'id': 'id', 'name': 'name', 'description': 'description'}][/magenta].",
+            "format: [green][{'id': 'id', 'name': 'name', 'description': 'description'}][/green].",
             metavar="INPUTS",
         ),
     ] = None,

--- a/nextmv/nextmv/cli/cloud/input_set/update.py
+++ b/nextmv/nextmv/cli/cloud/input_set/update.py
@@ -43,7 +43,7 @@ def update(
         typer.Option(
             "--inputs",
             help="Inputs for the input set. Data should be valid [magenta]json[/magenta]. Object "
-            "format: [magenta][{'id': 'id', 'name': 'name', 'description': 'description'}][/magenta].",
+            "format: [green][{'id': 'id', 'name': 'name', 'description': 'description'}][/green].",
             metavar="INPUTS",
         ),
     ] = None,

--- a/nextmv/nextmv/cli/cloud/scenario/get.py
+++ b/nextmv/nextmv/cli/cloud/scenario/get.py
@@ -48,7 +48,7 @@ def get(
     profile: ProfileOption = None,
 ) -> None:
     """
-    Get a Nextmv Cloud scenario test.
+    Get a Nextmv Cloud scenario test, including its runs.
 
     Use the [code]--wait[/code] flag to wait for the scenario test to
     complete, polling for results. Using the [code]--output[/code] flag will

--- a/nextmv/nextmv/cli/cloud/secrets/update.py
+++ b/nextmv/nextmv/cli/cloud/secrets/update.py
@@ -57,7 +57,7 @@ def update(
             "Pass multiple secrets by repeating the flag, or providing a list of objects. "
             "Allowed values for [magenta]type[/magenta] are: "
             f"{enum_values(SecretType)}. "
-            "Object format: [magenta]{'type': type, 'location': location, 'value': value}[/magenta]. "
+            "Object format: [green]{'type': type, 'location': location, 'value': value}[/green]. "
             "This will replace all existing secrets in the collection.",
             metavar="SECRETS",
         ),

--- a/nextmv/nextmv/cli/cloud/shadow/__init__.py
+++ b/nextmv/nextmv/cli/cloud/shadow/__init__.py
@@ -1,5 +1,5 @@
 """
-This module defines the cloud batch command tree for the Nextmv CLI.
+This module defines the cloud shadow command tree for the Nextmv CLI.
 """
 
 import typer

--- a/nextmv/nextmv/cli/cloud/shadow/__init__.py
+++ b/nextmv/nextmv/cli/cloud/shadow/__init__.py
@@ -1,0 +1,33 @@
+"""
+This module defines the cloud batch command tree for the Nextmv CLI.
+"""
+
+import typer
+
+from nextmv.cli.cloud.shadow.create import app as create_app
+from nextmv.cli.cloud.shadow.delete import app as delete_app
+from nextmv.cli.cloud.shadow.get import app as get_app
+from nextmv.cli.cloud.shadow.list import app as list_app
+from nextmv.cli.cloud.shadow.metadata import app as metadata_app
+from nextmv.cli.cloud.shadow.start import app as start_app
+from nextmv.cli.cloud.shadow.stop import app as stop_app
+from nextmv.cli.cloud.shadow.update import app as update_app
+
+# Set up subcommand application.
+app = typer.Typer()
+app.add_typer(create_app)
+app.add_typer(delete_app)
+app.add_typer(get_app)
+app.add_typer(list_app)
+app.add_typer(metadata_app)
+app.add_typer(start_app)
+app.add_typer(stop_app)
+app.add_typer(update_app)
+
+
+@app.callback()
+def callback() -> None:
+    """
+    Create and manage Nextmv Cloud shadow tests.
+    """
+    pass

--- a/nextmv/nextmv/cli/cloud/shadow/create.py
+++ b/nextmv/nextmv/cli/cloud/shadow/create.py
@@ -115,7 +115,7 @@ def create(
     control over when the shadow test should terminate, after said number of
     runs. Alternatively, you may specify the [code]--termination-time[/code]
     option or use the [code]nextmv cloud shadow stop[/code] command to stop the
-    test
+    test.
 
     [bold][underline]Examples[/underline][/bold]
 
@@ -168,7 +168,7 @@ def create(
     except json.JSONDecodeError as e:
         error(f"Invalid comparisons format: [magenta]{comparisons}[/magenta]. Error: {e}")
 
-    in_progress(msg="Creating shadow test...")
+    in_progress(msg="Creating shadow test in draft mode...")
     shadow_test = cloud_app.new_shadow_test(
         comparisons=comparisons_dict,
         termination_events=TerminationEvents(

--- a/nextmv/nextmv/cli/cloud/shadow/create.py
+++ b/nextmv/nextmv/cli/cloud/shadow/create.py
@@ -36,8 +36,10 @@ def create(
         typer.Option(
             "--termination-maximum-runs",
             "-m",
-            help="Maximum number of runs for the shadow test termination condition. Must be at least 1.",
+            help="Maximum number of runs for the shadow test termination condition.",
             metavar="TERMINATION_MAXIMUM_RUNS",
+            min=1,
+            max=300,
         ),
     ],
     description: Annotated[
@@ -75,7 +77,7 @@ def create(
             "-r",
             formats=["%Y-%m-%dT%H:%M:%S%z"],
             help="Scheduled time for shadow test start in [magenta]RFC 3339[/magenta] format. "
-            "Example: [magenta]'2024-01-01T00:00:00Z'[/magenta]",
+            "Object format: [green]'2024-01-01T00:00:00Z'[/green]",
             metavar="START_TIME",
         ),
     ] = None,
@@ -85,7 +87,7 @@ def create(
             "--termination-time",
             "-t",
             help="Scheduled time for shadow test end in [magenta]RFC 3339[/magenta] format. "
-            "Example: [magenta]'2024-01-01T00:00:00Z'[/magenta]",
+            "Object format: [green]'2024-01-01T00:00:00Z'[/green]",
             formats=["%Y-%m-%dT%H:%M:%S%z"],
             metavar="TERMINATION_TIME",
         ),

--- a/nextmv/nextmv/cli/cloud/shadow/create.py
+++ b/nextmv/nextmv/cli/cloud/shadow/create.py
@@ -1,0 +1,184 @@
+"""
+This module defines the cloud shadow create command for the Nextmv CLI.
+"""
+
+import json
+from datetime import datetime
+from typing import Annotated
+
+import typer
+
+from nextmv.cli.configuration.config import build_app
+from nextmv.cli.message import error, in_progress, print_json
+from nextmv.cli.options import AppIDOption, ProfileOption
+from nextmv.cloud.shadow import StartEvents, TerminationEvents
+
+# Set up subcommand application.
+app = typer.Typer()
+
+
+@app.command()
+def create(
+    app_id: AppIDOption,
+    comparisons: Annotated[
+        str,
+        typer.Option(
+            "--comparisons",
+            "-c",
+            help="Object mapping baseline instance IDs to a list of comparison instance IDs. "
+            "Data should be valid [magenta]json[/magenta]. "
+            "Object format: [green]{'baseline_id1': ['comparison_id1', 'comparison_id2'], 'baseline_id2': ...}[/green]",
+            metavar="COMPARISONS",
+        ),
+    ],
+    termination_maximum_runs: Annotated[
+        int,
+        typer.Option(
+            "--termination-maximum-runs",
+            "-m",
+            help="Maximum number of runs for the shadow test termination condition. Must be at least 1.",
+            metavar="TERMINATION_MAXIMUM_RUNS",
+        ),
+    ],
+    description: Annotated[
+        str | None,
+        typer.Option(
+            "--description",
+            "-d",
+            help="Description of the shadow test.",
+            metavar="DESCRIPTION",
+        ),
+    ] = None,
+    name: Annotated[
+        str | None,
+        typer.Option(
+            "--name",
+            "-n",
+            help="Name of the shadow test. If not provided, the ID will be used as the name.",
+            metavar="NAME",
+        ),
+    ] = None,
+    shadow_test_id: Annotated[
+        str | None,
+        typer.Option(
+            "--shadow-test-id",
+            "-s",
+            help="ID for the shadow test. Will be generated if not provided.",
+            envvar="NEXTMV_SHADOW_TEST_ID",
+            metavar="SHADOW_TEST_ID",
+        ),
+    ] = None,
+    start_time: Annotated[
+        datetime | None,
+        typer.Option(
+            "--start-time",
+            "-r",
+            formats=["%Y-%m-%dT%H:%M:%S%z"],
+            help="Scheduled time for shadow test start in [magenta]RFC 3339[/magenta] format. "
+            "Example: [magenta]'2024-01-01T00:00:00Z'[/magenta]",
+            metavar="START_TIME",
+        ),
+    ] = None,
+    termination_time: Annotated[
+        datetime | None,
+        typer.Option(
+            "--termination-time",
+            "-t",
+            help="Scheduled time for shadow test end in [magenta]RFC 3339[/magenta] format. "
+            "Example: [magenta]'2024-01-01T00:00:00Z'[/magenta]",
+            formats=["%Y-%m-%dT%H:%M:%S%z"],
+            metavar="TERMINATION_TIME",
+        ),
+    ] = None,
+    profile: ProfileOption = None,
+) -> None:
+    """
+    Create a new Nextmv Cloud shadow test in draft mode.
+
+    Use the [code]--comparisons[/code] option to define how to set up instance
+    comparisons. The value should be valid [magenta]json[/magenta]. The keys of
+    the comparisons object are the baseline instance IDs, and the values
+    are the candidate lists of instance IDs to compare against the respective
+    baseline.
+
+    Here is an example comparisons object:
+    [green]{
+        "baseline-instance-1": ["candidate-instance-1", "candidate-instance-2"],
+        "baseline-instance-2": ["candidate-instance-3"]
+    }[/green]
+
+    You may specify the [code]--start-time[/code] option to make the shadow
+    test start at a specific time. Alternatively, you may use the
+    [code]nextmv cloud shadow start[/code] command to start the test.
+
+    The [code]--termination-maximum-runs[/code] option is required and provides
+    control over when the shadow test should terminate, after said number of
+    runs. Alternatively, you may specify the [code]--termination-time[/code]
+    option or use the [code]nextmv cloud shadow stop[/code] command to stop the
+    test
+
+    [bold][underline]Examples[/underline][/bold]
+
+    - Create a shadow test with a baseline and two candidate instances:
+        $ [green]COMPARISONS='{
+            "fluffy-bunny-baseline": [
+                "hopping-candidate-ears",
+                "speedy-cottontail"
+            ]
+        }'
+        nextmv cloud shadow create --app-id hare-app --shadow-test-id bunny-hop-shadow --name "Bunny Hop Showdown" \\
+            --comparisons "$COMPARISONS" --termination-maximum-runs 100[/green]
+
+    - Create a shadow test with multiple baselines and candidates:
+        $ [green]COMPARISONS='{
+            "fluffy-bunny-baseline": [
+                "hopping-candidate-ears"
+            ],
+            "wise-old-rabbit": [
+                "burrow-master"
+            ]
+        }'
+        nextmv cloud shadow create --app-id hare-app --shadow-test-id warren-race --name "Warren Race Test" \\
+            --comparisons "$COMPARISONS" --termination-maximum-runs 50[/green]
+
+    - Create a shadow test with a scheduled start and termination time:
+        $ [green]COMPARISONS='{
+            "fluffy-bunny-baseline": [
+                "hopping-candidate-ears"
+            ]
+        }'
+        nextmv cloud shadow create --app-id hare-app --shadow-test-id sunrise-hop --name "Sunrise Hop Test" \\
+            --comparisons "$COMPARISONS" --start-time '2026-01-23T10:00:00Z' \\
+            --termination-time '2026-01-23T18:00:00Z' --termination-maximum-runs 20[/green]
+
+    - Create a shadow test with a description:
+        $ [green]COMPARISONS='{
+            "fluffy-bunny-baseline": [
+                "hopping-candidate-ears"
+            ]
+        }'
+        nextmv cloud shadow create --app-id hare-app --shadow-test-id carrot-compare --name "Carrot Comparison" \\
+            --description "Testing cool bunnies" --comparisons "$COMPARISONS" --termination-maximum-runs 10[/green]
+    """
+
+    cloud_app = build_app(app_id=app_id, profile=profile)
+
+    try:
+        comparisons_dict = json.loads(comparisons)
+    except json.JSONDecodeError as e:
+        error(f"Invalid comparisons format: [magenta]{comparisons}[/magenta]. Error: {e}")
+
+    in_progress(msg="Creating shadow test...")
+    shadow_test = cloud_app.new_shadow_test(
+        comparisons=comparisons_dict,
+        termination_events=TerminationEvents(
+            maximum_runs=termination_maximum_runs,
+            time=termination_time,
+        ),
+        shadow_test_id=shadow_test_id,
+        name=name,
+        description=description,
+        start_events=StartEvents(time=start_time) if start_time is not None else None,
+    )
+
+    print_json(shadow_test.to_dict())

--- a/nextmv/nextmv/cli/cloud/shadow/delete.py
+++ b/nextmv/nextmv/cli/cloud/shadow/delete.py
@@ -1,0 +1,68 @@
+"""
+This module defines the cloud shadow delete command for the Nextmv CLI.
+"""
+
+from typing import Annotated
+
+import typer
+from rich.prompt import Confirm
+
+from nextmv.cli.configuration.config import build_app
+from nextmv.cli.message import info, success
+from nextmv.cli.options import AppIDOption, ProfileOption, ShadowTestIDOption
+
+# Set up subcommand application.
+app = typer.Typer()
+
+
+@app.command()
+def delete(
+    app_id: AppIDOption,
+    shadow_test_id: ShadowTestIDOption,
+    yes: Annotated[
+        bool,
+        typer.Option(
+            "--yes",
+            "-y",
+            help="Agree to deletion confirmation prompt. Useful for non-interactive sessions.",
+        ),
+    ] = False,
+    profile: ProfileOption = None,
+) -> None:
+    """
+    Deletes a Nextmv Cloud shadow test.
+
+    This action is permanent and cannot be undone. The shadow test and all
+    associated data, including runs, will be deleted. Use the [code]--yes[/code]
+    flag to skip the confirmation prompt.
+
+    [bold][underline]Examples[/underline][/bold]
+
+    - Delete the shadow test with the ID [magenta]hop-analysis[/magenta] from application
+      [magenta]hare-app[/magenta].
+        $ [green]nextmv cloud shadow delete --app-id hare-app --shadow-test-id hop-analysis[/green]
+
+    - Delete the shadow test without confirmation prompt.
+        $ [green]nextmv cloud shadow delete --app-id hare-app --shadow-test-id carrot-routes --yes[/green]
+    """
+
+    if not yes:
+        confirm = Confirm.ask(
+            f"Are you sure you want to delete shadow test [magenta]{shadow_test_id}[/magenta] "
+            f"from application [magenta]{app_id}[/magenta]? This action cannot be undone.",
+            default=False,
+        )
+
+        if not confirm:
+            info(
+                msg=f"Shadow test [magenta]{shadow_test_id}[/magenta] will not be deleted.",
+                emoji=":bulb:",
+            )
+            return
+
+    cloud_app = build_app(app_id=app_id, profile=profile)
+    cloud_app.delete_shadow_test(shadow_test_id=shadow_test_id)
+    success(
+        f"Shadow test [magenta]{shadow_test_id}[/magenta] deleted successfully "
+        f"from application [magenta]{app_id}[/magenta]."
+    )

--- a/nextmv/nextmv/cli/cloud/shadow/get.py
+++ b/nextmv/nextmv/cli/cloud/shadow/get.py
@@ -1,0 +1,61 @@
+"""
+This module defines the cloud shadow get command for the Nextmv CLI.
+"""
+
+import json
+from typing import Annotated
+
+import typer
+
+from nextmv.cli.configuration.config import build_app
+from nextmv.cli.message import in_progress, print_json, success
+from nextmv.cli.options import AppIDOption, ProfileOption, ShadowTestIDOption
+
+# Set up subcommand application.
+app = typer.Typer()
+
+
+@app.command()
+def get(
+    app_id: AppIDOption,
+    shadow_test_id: ShadowTestIDOption,
+    output: Annotated[
+        str | None,
+        typer.Option(
+            "--output",
+            "-o",
+            help="Saves the results to this location.",
+            metavar="OUTPUT_PATH",
+        ),
+    ] = None,
+    profile: ProfileOption = None,
+) -> None:
+    """
+    Get a Nextmv Cloud shadow test, including its runs.
+
+    [bold][underline]Examples[/underline][/bold]
+
+    - Get the shadow test with ID [magenta]carrot-optimization[/magenta] from application
+      [magenta]hare-app[/magenta].
+        $ [green]nextmv cloud shadow get --app-id hare-app --shadow-test-id carrot-optimization[/green]
+
+    - Get the shadow test using a specific profile.
+        $ [green]nextmv cloud shadow get --app-id hare-app --shadow-test-id lettuce-routes --profile prod[/green]
+    """
+
+    cloud_app = build_app(app_id=app_id, profile=profile)
+    in_progress(msg="Getting shadow test...")
+    shadow_test = cloud_app.shadow_test(shadow_test_id=shadow_test_id)
+
+    shadow_test_dict = shadow_test.to_dict()
+
+    # Handle output
+    if output is not None and output != "":
+        with open(output, "w") as f:
+            json.dump(shadow_test_dict, f, indent=2)
+
+        success(msg=f"Shadow test output saved to [magenta]{output}[/magenta].")
+
+        return
+
+    print_json(shadow_test_dict)

--- a/nextmv/nextmv/cli/cloud/shadow/list.py
+++ b/nextmv/nextmv/cli/cloud/shadow/list.py
@@ -1,0 +1,63 @@
+"""
+This module defines the cloud shadow list command for the Nextmv CLI.
+"""
+
+import json
+from typing import Annotated
+
+import typer
+
+from nextmv.cli.configuration.config import build_app
+from nextmv.cli.message import in_progress, print_json, success
+from nextmv.cli.options import AppIDOption, ProfileOption
+
+# Set up subcommand application.
+app = typer.Typer()
+
+
+@app.command()
+def list(
+    app_id: AppIDOption,
+    output: Annotated[
+        str | None,
+        typer.Option(
+            "--output",
+            "-o",
+            help="Saves the list of shadow tests to this location.",
+            metavar="OUTPUT_PATH",
+        ),
+    ] = None,
+    profile: ProfileOption = None,
+) -> None:
+    """
+    List all Nextmv Cloud shadow tests for an application.
+
+    This command retrieves all shadow tests associated with the specified
+    application.
+
+    [bold][underline]Examples[/underline][/bold]
+
+    - List all shadow tests for application [magenta]hare-app[/magenta].
+        $ [green]nextmv cloud shadow list --app-id hare-app[/green]
+
+    - List all shadow tests and save to a file.
+        $ [green]nextmv cloud shadow list --app-id hare-app --output tests.json[/green]
+
+    - List all shadow tests using a specific profile.
+        $ [green]nextmv cloud shadow list --app-id hare-app --profile prod[/green]
+    """
+
+    cloud_app = build_app(app_id=app_id, profile=profile)
+    in_progress(msg="Listing shadow tests...")
+    shadow_tests = cloud_app.list_shadow_tests()
+    shadow_tests_dict = [test.to_dict() for test in shadow_tests]
+
+    if output is not None and output != "":
+        with open(output, "w") as f:
+            json.dump(shadow_tests_dict, f, indent=2)
+
+        success(msg=f"Shadow tests list saved to [magenta]{output}[/magenta].")
+
+        return
+
+    print_json(shadow_tests_dict)

--- a/nextmv/nextmv/cli/cloud/shadow/metadata.py
+++ b/nextmv/nextmv/cli/cloud/shadow/metadata.py
@@ -1,0 +1,66 @@
+"""
+This module defines the cloud shadow metadata command for the Nextmv CLI.
+"""
+
+import json
+from typing import Annotated
+
+import typer
+
+from nextmv.cli.configuration.config import build_app
+from nextmv.cli.message import in_progress, print_json, success
+from nextmv.cli.options import AppIDOption, ProfileOption, ShadowTestIDOption
+
+# Set up subcommand application.
+app = typer.Typer()
+
+
+@app.command()
+def metadata(
+    app_id: AppIDOption,
+    shadow_test_id: ShadowTestIDOption,
+    output: Annotated[
+        str | None,
+        typer.Option(
+            "--output",
+            "-o",
+            help="Saves the shadow test metadata to this location.",
+            metavar="OUTPUT_PATH",
+        ),
+    ] = None,
+    profile: ProfileOption = None,
+) -> None:
+    """
+    Get metadata for a Nextmv Cloud shadow test.
+
+    This command retrieves metadata for a specific shadow test, including
+    status, creation date, and other high-level information without the full
+    run details.
+
+    [bold][underline]Examples[/underline][/bold]
+
+    - Get metadata for shadow test [magenta]bunny-warren-optimization[/magenta] from application
+      [magenta]hare-app[/magenta].
+        $ [green]nextmv cloud shadow metadata --app-id hare-app --shadow-test-id bunny-warren-optimization[/green]
+
+    - Get metadata and save to a file.
+        $ [green]nextmv cloud shadow metadata --app-id hare-app --shadow-test-id lettuce-delivery \\
+            --output metadata.json[/green]
+
+    - Get metadata using a specific profile.
+        $ [green]nextmv cloud shadow metadata --app-id hare-app --shadow-test-id hop-schedule --profile prod[/green]
+    """
+
+    cloud_app = build_app(app_id=app_id, profile=profile)
+    in_progress(msg="Getting shadow test metadata...")
+    shadow_metadata = cloud_app.shadow_test_metadata(shadow_test_id=shadow_test_id)
+    shadow_metadata_dict = shadow_metadata.to_dict()
+
+    if output is not None and output != "":
+        with open(output, "w") as f:
+            json.dump(shadow_metadata_dict, f, indent=2)
+
+        success(msg=f"Shadow test metadata saved to [magenta]{output}[/magenta].")
+        return
+
+    print_json(shadow_metadata_dict)

--- a/nextmv/nextmv/cli/cloud/shadow/start.py
+++ b/nextmv/nextmv/cli/cloud/shadow/start.py
@@ -1,0 +1,43 @@
+"""
+This module defines the cloud shadow start command for the Nextmv CLI.
+"""
+
+import typer
+
+from nextmv.cli.configuration.config import build_app
+from nextmv.cli.message import in_progress, success
+from nextmv.cli.options import AppIDOption, ProfileOption, ShadowTestIDOption
+
+# Set up subcommand application.
+app = typer.Typer()
+
+
+@app.command()
+def start(
+    app_id: AppIDOption,
+    shadow_test_id: ShadowTestIDOption,
+    profile: ProfileOption = None,
+) -> None:
+    """
+    Starts a Nextmv Cloud shadow test.
+
+    Before starting a shadow test, it must be created in draft state. You may
+    use the [code]nextmv cloud shadow create[/code] command to create a new
+    shadow test. Alternatively, define a [code]--start-time[/code] when using
+    the [code]nextmv cloud shadow create[/code] command to have the shadow test
+    start automatically at a specific time.
+
+    [bold][underline]Examples[/underline][/bold]
+
+    - Start the shadow test with the ID [magenta]hop-analysis[/magenta] from application
+      [magenta]hare-app[/magenta].
+        $ [green]nextmv cloud shadow start --app-id hare-app --shadow-test-id hop-analysis[/green]
+    """
+
+    in_progress(msg="Starting shadow test...")
+    cloud_app = build_app(app_id=app_id, profile=profile)
+    cloud_app.start_shadow_test(shadow_test_id=shadow_test_id)
+    success(
+        f"Shadow test [magenta]{shadow_test_id}[/magenta] started successfully "
+        f"in application [magenta]{app_id}[/magenta]."
+    )

--- a/nextmv/nextmv/cli/cloud/shadow/stop.py
+++ b/nextmv/nextmv/cli/cloud/shadow/stop.py
@@ -29,15 +29,15 @@ def stop(
 
     [bold][underline]Examples[/underline][/bold]
 
-    - Start the shadow test with the ID [magenta]hop-analysis[/magenta] from application
+    - Stop the shadow test with the ID [magenta]hop-analysis[/magenta] from application
       [magenta]hare-app[/magenta].
-        $ [green]nextmv cloud shadow start --app-id hare-app --shadow-test-id hop-analysis[/green]
+        $ [green]nextmv cloud shadow stop --app-id hare-app --shadow-test-id hop-analysis[/green]
     """
 
-    in_progress(msg="Starting shadow test...")
+    in_progress(msg="Stopping shadow test...")
     cloud_app = build_app(app_id=app_id, profile=profile)
-    cloud_app.start_shadow_test(shadow_test_id=shadow_test_id)
+    cloud_app.stop_shadow_test(shadow_test_id=shadow_test_id)
     success(
-        f"Shadow test [magenta]{shadow_test_id}[/magenta] started successfully "
+        f"Shadow test [magenta]{shadow_test_id}[/magenta] stopped successfully "
         f"in application [magenta]{app_id}[/magenta]."
     )

--- a/nextmv/nextmv/cli/cloud/shadow/stop.py
+++ b/nextmv/nextmv/cli/cloud/shadow/stop.py
@@ -21,11 +21,9 @@ def stop(
     """
     Stops a Nextmv Cloud shadow test.
 
-    Before stopping a shadow test, it must be in a started state. You may
-    use the [code]nextmv cloud shadow start[/code] command to start
-    a shadow test. Alternatively, define a [code]--start-time[/code] when using
-    the [code]nextmv cloud shadow create[/code] command to have the shadow test
-    start automatically at a specific time.
+    Before stopping a shadow test, it must be in a started state. Experiments
+    in a [magenta]draft[/magenta] state, that haven't started, can be deleted
+    with the [code]nextmv cloud shadow delete[/code] command.
 
     [bold][underline]Examples[/underline][/bold]
 

--- a/nextmv/nextmv/cli/cloud/shadow/stop.py
+++ b/nextmv/nextmv/cli/cloud/shadow/stop.py
@@ -1,0 +1,43 @@
+"""
+This module defines the cloud shadow stop command for the Nextmv CLI.
+"""
+
+import typer
+
+from nextmv.cli.configuration.config import build_app
+from nextmv.cli.message import in_progress, success
+from nextmv.cli.options import AppIDOption, ProfileOption, ShadowTestIDOption
+
+# Set up subcommand application.
+app = typer.Typer()
+
+
+@app.command()
+def stop(
+    app_id: AppIDOption,
+    shadow_test_id: ShadowTestIDOption,
+    profile: ProfileOption = None,
+) -> None:
+    """
+    Stops a Nextmv Cloud shadow test.
+
+    Before stopping a shadow test, it must be in a started state. You may
+    use the [code]nextmv cloud shadow start[/code] command to start
+    a shadow test. Alternatively, define a [code]--start-time[/code] when using
+    the [code]nextmv cloud shadow create[/code] command to have the shadow test
+    start automatically at a specific time.
+
+    [bold][underline]Examples[/underline][/bold]
+
+    - Start the shadow test with the ID [magenta]hop-analysis[/magenta] from application
+      [magenta]hare-app[/magenta].
+        $ [green]nextmv cloud shadow start --app-id hare-app --shadow-test-id hop-analysis[/green]
+    """
+
+    in_progress(msg="Starting shadow test...")
+    cloud_app = build_app(app_id=app_id, profile=profile)
+    cloud_app.start_shadow_test(shadow_test_id=shadow_test_id)
+    success(
+        f"Shadow test [magenta]{shadow_test_id}[/magenta] started successfully "
+        f"in application [magenta]{app_id}[/magenta]."
+    )

--- a/nextmv/nextmv/cli/cloud/shadow/update.py
+++ b/nextmv/nextmv/cli/cloud/shadow/update.py
@@ -1,0 +1,95 @@
+"""
+This module defines the cloud shadow update command for the Nextmv CLI.
+"""
+
+import json
+from typing import Annotated
+
+import typer
+
+from nextmv.cli.configuration.config import build_app
+from nextmv.cli.message import in_progress, print_json, success
+from nextmv.cli.options import AppIDOption, ProfileOption, ShadowTestIDOption
+
+# Set up subcommand application.
+app = typer.Typer()
+
+
+@app.command()
+def update(
+    app_id: AppIDOption,
+    shadow_test_id: ShadowTestIDOption,
+    description: Annotated[
+        str | None,
+        typer.Option(
+            "--description",
+            "-d",
+            help="Updated description of the shadow test.",
+            metavar="DESCRIPTION",
+        ),
+    ] = None,
+    name: Annotated[
+        str | None,
+        typer.Option(
+            "--name",
+            "-n",
+            help="Updated name of the shadow test.",
+            metavar="NAME",
+        ),
+    ] = None,
+    output: Annotated[
+        str | None,
+        typer.Option(
+            "--output",
+            "-o",
+            help="Saves the updated shadow test information to this location.",
+            metavar="OUTPUT_PATH",
+        ),
+    ] = None,
+    profile: ProfileOption = None,
+) -> None:
+    """
+    Update a Nextmv Cloud shadow test.
+
+    Update the name and/or description of a shadow test. Any fields not
+    specified will remain unchanged.
+
+    [bold][underline]Examples[/underline][/bold]
+
+    - Update the name of a shadow test.
+        $ [green]nextmv cloud shadow update --app-id hare-app --shadow-test-id carrot-feast \\
+            --name "Spring Carrot Harvest"[/green]
+
+    - Update the description of a shadow test.
+        $ [green]nextmv cloud shadow update --app-id hare-app --shadow-test-id bunny-hop-routes \\
+            --description "Optimizing hop paths through the meadow"[/green]
+
+    - Update both name and description and save the result.
+        $ [green]nextmv cloud shadow update --app-id hare-app --shadow-test-id lettuce-delivery \\
+            --name "Warren Lettuce Express" --description "Fast lettuce delivery to all burrows" \\
+            --output updated-shadow-test.json[/green]
+    """
+
+    cloud_app = build_app(app_id=app_id, profile=profile)
+
+    in_progress(msg="Updating shadow test...")
+    shadow_test = cloud_app.update_shadow_test(
+        shadow_test_id=shadow_test_id,
+        name=name,
+        description=description,
+    )
+
+    shadow_test_dict = shadow_test.to_dict()
+    success(
+        f"Shadow test [magenta]{shadow_test_id}[/magenta] updated successfully "
+        f"in application [magenta]{app_id}[/magenta]."
+    )
+
+    if output is not None and output != "":
+        with open(output, "w") as f:
+            json.dump(shadow_test_dict, f, indent=2)
+
+        success(msg=f"Updated shadow test information saved to [magenta]{output}[/magenta].")
+        return
+
+    print_json(shadow_test_dict)

--- a/nextmv/nextmv/cli/cloud/switchback/__init__.py
+++ b/nextmv/nextmv/cli/cloud/switchback/__init__.py
@@ -1,0 +1,33 @@
+"""
+This module defines the cloud switchback command tree for the Nextmv CLI.
+"""
+
+import typer
+
+from nextmv.cli.cloud.switchback.create import app as create_app
+from nextmv.cli.cloud.switchback.delete import app as delete_app
+from nextmv.cli.cloud.switchback.get import app as get_app
+from nextmv.cli.cloud.switchback.list import app as list_app
+from nextmv.cli.cloud.switchback.metadata import app as metadata_app
+from nextmv.cli.cloud.switchback.start import app as start_app
+from nextmv.cli.cloud.switchback.stop import app as stop_app
+from nextmv.cli.cloud.switchback.update import app as update_app
+
+# Set up subcommand application.
+app = typer.Typer()
+app.add_typer(create_app)
+app.add_typer(delete_app)
+app.add_typer(get_app)
+app.add_typer(list_app)
+app.add_typer(metadata_app)
+app.add_typer(start_app)
+app.add_typer(stop_app)
+app.add_typer(update_app)
+
+
+@app.callback()
+def callback() -> None:
+    """
+    Create and manage Nextmv Cloud switchback tests.
+    """
+    pass

--- a/nextmv/nextmv/cli/cloud/switchback/create.py
+++ b/nextmv/nextmv/cli/cloud/switchback/create.py
@@ -1,0 +1,147 @@
+"""
+This module defines the cloud switchback create command for the Nextmv CLI.
+"""
+
+from datetime import datetime
+from typing import Annotated
+
+import typer
+
+from nextmv.cli.configuration.config import build_app
+from nextmv.cli.message import in_progress, print_json
+from nextmv.cli.options import AppIDOption, ProfileOption
+from nextmv.cloud.switchback import TestComparisonSingle
+
+# Set up subcommand application.
+app = typer.Typer()
+
+
+@app.command()
+def create(
+    app_id: AppIDOption,
+    baseline_instance_id: Annotated[
+        str,
+        typer.Option(
+            "--baseline-instance-id",
+            "-b",
+            help="ID of the baseline instance for the switchback test.",
+            metavar="BASELINE_INSTANCE_ID",
+        ),
+    ],
+    candidate_instance_id: Annotated[
+        str,
+        typer.Option(
+            "--candidate-instance-id",
+            "-c",
+            help="ID of the candidate instance for the switchback test.",
+            metavar="CANDIDATE_INSTANCE_ID",
+        ),
+    ],
+    unit_duration_minutes: Annotated[
+        float,
+        typer.Option(
+            "--unit-duration-minutes",
+            "-u",
+            help="Duration of each interval in minutes.",
+            metavar="UNIT_DURATION_MINUTES",
+        ),
+    ],
+    units: Annotated[
+        int,
+        typer.Option(
+            "--units",
+            "-t",
+            help="Total number of intervals in the switchback test.",
+            metavar="UNITS",
+        ),
+    ],
+    description: Annotated[
+        str | None,
+        typer.Option(
+            "--description",
+            "-d",
+            help="Description of the switchback test.",
+            metavar="DESCRIPTION",
+        ),
+    ] = None,
+    name: Annotated[
+        str | None,
+        typer.Option(
+            "--name",
+            "-n",
+            help="Name of the switchback test. If not provided, the ID will be used as the name.",
+            metavar="NAME",
+        ),
+    ] = None,
+    switchback_test_id: Annotated[
+        str | None,
+        typer.Option(
+            "--switchback-test-id",
+            "-s",
+            help="ID for the switchback test. Will be generated if not provided.",
+            envvar="NEXTMV_SWITCHBACK_TEST_ID",
+            metavar="SWITCHBACK_TEST_ID",
+        ),
+    ] = None,
+    start: Annotated[
+        datetime | None,
+        typer.Option(
+            "--start",
+            "-r",
+            formats=["%Y-%m-%dT%H:%M:%S%z"],
+            help="Scheduled time for switchback test start in [magenta]RFC 3339[/magenta] format. "
+            "Example: [magenta]'2024-01-01T00:00:00Z'[/magenta]",
+            metavar="START",
+        ),
+    ] = None,
+    profile: ProfileOption = None,
+) -> None:
+    """
+    Create a new Nextmv Cloud switchback test in draft mode.
+
+    The test will alternate between the [code]--baseline-instance-id[/code] and
+    [code]--candidate-instance-id[/code] over specified time intervals.
+
+    You may specify the [code]--start[/code] option to make the switchback
+    test start at a specific time. Alternatively, you may use the
+    [code]nextmv cloud switchback start[/code] command to start the test.
+
+    Use the [code]nextmv cloud switchback stop[/code] command to stop the test.
+
+    [bold][underline]Examples[/underline][/bold]
+
+    - Create a switchback test alternating between two bunny instances:
+        $ [green]nextmv cloud switchback create --app-id hare-app --switchback-test-id bunny-switch-hop \\
+            --name "Bunny Switch Hop" --baseline-instance-id fluffy-bunny-baseline \\
+            --candidate-instance-id speedy-cottontail --unit-duration-minutes 15 --units 10[/green]
+
+    - Create a switchback test with a scheduled start time:
+        $ [green]nextmv cloud switchback create --app-id hare-app --switchback-test-id sunrise-switch \\
+            --name "Sunrise Switch Test" --baseline-instance-id wise-old-rabbit \\
+            --candidate-instance-id burrow-master --unit-duration-minutes 30 --units 8 \\
+            --start '2026-01-23T10:00:00Z'[/green]
+
+    - Create a switchback test with a description:
+        $ [green]nextmv cloud switchback create --app-id hare-app --switchback-test-id carrot-switch \\
+            --name "Carrot Switch" --baseline-instance-id fluffy-bunny-baseline \\
+            --candidate-instance-id hopping-candidate-ears --unit-duration-minutes 20 --units 12 \\
+            --description "Which bunny hops best for carrots?"[/green]
+    """
+
+    cloud_app = build_app(app_id=app_id, profile=profile)
+
+    in_progress(msg="Creating switchback test in draft mode...")
+    switchback_test = cloud_app.new_switchback_test(
+        comparison=TestComparisonSingle(
+            baseline_instance_id=baseline_instance_id,
+            candidate_instance_id=candidate_instance_id,
+        ),
+        unit_duration_minutes=unit_duration_minutes,
+        units=units,
+        switchback_test_id=switchback_test_id,
+        name=name,
+        description=description,
+        start=start,
+    )
+
+    print_json(switchback_test.to_dict())

--- a/nextmv/nextmv/cli/cloud/switchback/create.py
+++ b/nextmv/nextmv/cli/cloud/switchback/create.py
@@ -44,6 +44,8 @@ def create(
             "-u",
             help="Duration of each interval in minutes.",
             metavar="UNIT_DURATION_MINUTES",
+            min=1,
+            max=10080,
         ),
     ],
     units: Annotated[
@@ -53,6 +55,8 @@ def create(
             "-t",
             help="Total number of intervals in the switchback test.",
             metavar="UNITS",
+            min=1,
+            max=1000,
         ),
     ],
     description: Annotated[
@@ -90,7 +94,7 @@ def create(
             "-r",
             formats=["%Y-%m-%dT%H:%M:%S%z"],
             help="Scheduled time for switchback test start in [magenta]RFC 3339[/magenta] format. "
-            "Example: [magenta]'2024-01-01T00:00:00Z'[/magenta]",
+            "Object format: [green]'2024-01-01T00:00:00Z'[/green]",
             metavar="START",
         ),
     ] = None,

--- a/nextmv/nextmv/cli/cloud/switchback/delete.py
+++ b/nextmv/nextmv/cli/cloud/switchback/delete.py
@@ -1,0 +1,68 @@
+"""
+This module defines the cloud switchback delete command for the Nextmv CLI.
+"""
+
+from typing import Annotated
+
+import typer
+from rich.prompt import Confirm
+
+from nextmv.cli.configuration.config import build_app
+from nextmv.cli.message import info, success
+from nextmv.cli.options import AppIDOption, ProfileOption, SwitchbackTestIDOption
+
+# Set up subcommand application.
+app = typer.Typer()
+
+
+@app.command()
+def delete(
+    app_id: AppIDOption,
+    switchback_test_id: SwitchbackTestIDOption,
+    yes: Annotated[
+        bool,
+        typer.Option(
+            "--yes",
+            "-y",
+            help="Agree to deletion confirmation prompt. Useful for non-interactive sessions.",
+        ),
+    ] = False,
+    profile: ProfileOption = None,
+) -> None:
+    """
+    Deletes a Nextmv Cloud switchback test.
+
+    This action is permanent and cannot be undone. The switchback test and all
+    associated data, including runs, will be deleted. Use the [code]--yes[/code]
+    flag to skip the confirmation prompt.
+
+    [bold][underline]Examples[/underline][/bold]
+
+    - Delete the switchback test with the ID [magenta]hop-analysis[/magenta] from application
+      [magenta]hare-app[/magenta].
+        $ [green]nextmv cloud switchback delete --app-id hare-app --switchback-test-id hop-analysis[/green]
+
+    - Delete the switchback test without confirmation prompt.
+        $ [green]nextmv cloud switchback delete --app-id hare-app --switchback-test-id carrot-routes --yes[/green]
+    """
+
+    if not yes:
+        confirm = Confirm.ask(
+            f"Are you sure you want to delete switchback test [magenta]{switchback_test_id}[/magenta] "
+            f"from application [magenta]{app_id}[/magenta]? This action cannot be undone.",
+            default=False,
+        )
+
+        if not confirm:
+            info(
+                msg=f"Switchback test [magenta]{switchback_test_id}[/magenta] will not be deleted.",
+                emoji=":bulb:",
+            )
+            return
+
+    cloud_app = build_app(app_id=app_id, profile=profile)
+    cloud_app.delete_switchback_test(switchback_test_id=switchback_test_id)
+    success(
+        f"Switchback test [magenta]{switchback_test_id}[/magenta] deleted successfully "
+        f"from application [magenta]{app_id}[/magenta]."
+    )

--- a/nextmv/nextmv/cli/cloud/switchback/get.py
+++ b/nextmv/nextmv/cli/cloud/switchback/get.py
@@ -1,0 +1,62 @@
+"""
+This module defines the cloud switchback get command for the Nextmv CLI.
+"""
+
+import json
+from typing import Annotated
+
+import typer
+
+from nextmv.cli.configuration.config import build_app
+from nextmv.cli.message import in_progress, print_json, success
+from nextmv.cli.options import AppIDOption, ProfileOption, SwitchbackTestIDOption
+
+# Set up subcommand application.
+app = typer.Typer()
+
+
+@app.command()
+def get(
+    app_id: AppIDOption,
+    switchback_test_id: SwitchbackTestIDOption,
+    output: Annotated[
+        str | None,
+        typer.Option(
+            "--output",
+            "-o",
+            help="Saves the results to this location.",
+            metavar="OUTPUT_PATH",
+        ),
+    ] = None,
+    profile: ProfileOption = None,
+) -> None:
+    """
+    Get a Nextmv Cloud switchback test, including its runs.
+
+    [bold][underline]Examples[/underline][/bold]
+
+    - Get the switchback test with ID [magenta]carrot-optimization[/magenta] from application
+      [magenta]hare-app[/magenta].
+        $ [green]nextmv cloud switchback get --app-id hare-app --switchback-test-id carrot-optimization[/green]
+
+    - Get the switchback test using a specific profile.
+        $ [green]nextmv cloud switchback get --app-id hare-app --switchback-test-id lettuce-routes \\
+            --profile prod[/green]
+    """
+
+    cloud_app = build_app(app_id=app_id, profile=profile)
+    in_progress(msg="Getting switchback test...")
+    switchback_test = cloud_app.switchback_test(switchback_test_id=switchback_test_id)
+
+    switchback_test_dict = switchback_test.to_dict()
+
+    # Handle output
+    if output is not None and output != "":
+        with open(output, "w") as f:
+            json.dump(switchback_test_dict, f, indent=2)
+
+        success(msg=f"Switchback test output saved to [magenta]{output}[/magenta].")
+
+        return
+
+    print_json(switchback_test_dict)

--- a/nextmv/nextmv/cli/cloud/switchback/list.py
+++ b/nextmv/nextmv/cli/cloud/switchback/list.py
@@ -1,0 +1,63 @@
+"""
+This module defines the cloud switchback list command for the Nextmv CLI.
+"""
+
+import json
+from typing import Annotated
+
+import typer
+
+from nextmv.cli.configuration.config import build_app
+from nextmv.cli.message import in_progress, print_json, success
+from nextmv.cli.options import AppIDOption, ProfileOption
+
+# Set up subcommand application.
+app = typer.Typer()
+
+
+@app.command()
+def list(
+    app_id: AppIDOption,
+    output: Annotated[
+        str | None,
+        typer.Option(
+            "--output",
+            "-o",
+            help="Saves the list of switchback tests to this location.",
+            metavar="OUTPUT_PATH",
+        ),
+    ] = None,
+    profile: ProfileOption = None,
+) -> None:
+    """
+    List all Nextmv Cloud switchback tests for an application.
+
+    This command retrieves all switchback tests associated with the specified
+    application.
+
+    [bold][underline]Examples[/underline][/bold]
+
+    - List all switchback tests for application [magenta]hare-app[/magenta].
+        $ [green]nextmv cloud switchback list --app-id hare-app[/green]
+
+    - List all switchback tests and save to a file.
+        $ [green]nextmv cloud switchback list --app-id hare-app --output tests.json[/green]
+
+    - List all switchback tests using a specific profile.
+        $ [green]nextmv cloud switchback list --app-id hare-app --profile prod[/green]
+    """
+
+    cloud_app = build_app(app_id=app_id, profile=profile)
+    in_progress(msg="Listing switchback tests...")
+    switchback_tests = cloud_app.list_switchback_tests()
+    switchback_tests_dict = [test.to_dict() for test in switchback_tests]
+
+    if output is not None and output != "":
+        with open(output, "w") as f:
+            json.dump(switchback_tests_dict, f, indent=2)
+
+        success(msg=f"Switchback tests list saved to [magenta]{output}[/magenta].")
+
+        return
+
+    print_json(switchback_tests_dict)

--- a/nextmv/nextmv/cli/cloud/switchback/metadata.py
+++ b/nextmv/nextmv/cli/cloud/switchback/metadata.py
@@ -1,0 +1,68 @@
+"""
+This module defines the cloud switchback metadata command for the Nextmv CLI.
+"""
+
+import json
+from typing import Annotated
+
+import typer
+
+from nextmv.cli.configuration.config import build_app
+from nextmv.cli.message import in_progress, print_json, success
+from nextmv.cli.options import AppIDOption, ProfileOption, SwitchbackTestIDOption
+
+# Set up subcommand application.
+app = typer.Typer()
+
+
+@app.command()
+def metadata(
+    app_id: AppIDOption,
+    switchback_test_id: SwitchbackTestIDOption,
+    output: Annotated[
+        str | None,
+        typer.Option(
+            "--output",
+            "-o",
+            help="Saves the switchback test metadata to this location.",
+            metavar="OUTPUT_PATH",
+        ),
+    ] = None,
+    profile: ProfileOption = None,
+) -> None:
+    """
+    Get metadata for a Nextmv Cloud switchback test.
+
+    This command retrieves metadata for a specific switchback test, including
+    status, creation date, and other high-level information without the full
+    run details.
+
+    [bold][underline]Examples[/underline][/bold]
+
+    - Get metadata for switchback test [magenta]bunny-warren-optimization[/magenta] from application
+      [magenta]hare-app[/magenta].
+        $ [green]nextmv cloud switchback metadata --app-id hare-app \\
+            --switchback-test-id bunny-warren-optimization[/green]
+
+    - Get metadata and save to a file.
+        $ [green]nextmv cloud switchback metadata --app-id hare-app --switchback-test-id lettuce-delivery \\
+            --output metadata.json[/green]
+
+    - Get metadata using a specific profile.
+        $ [green]nextmv cloud switchback metadata --app-id hare-app --switchback-test-id hop-schedule \\
+            --profile prod[/green]
+    """
+
+    cloud_app = build_app(app_id=app_id, profile=profile)
+    in_progress(msg="Getting switchback test metadata...")
+    switchback_metadata = cloud_app.switchback_test_metadata(switchback_test_id=switchback_test_id)
+    switchback_metadata_dict = switchback_metadata.to_dict()
+
+    if output is not None and output != "":
+        with open(output, "w") as f:
+            json.dump(switchback_metadata_dict, f, indent=2)
+
+        success(msg=f"Switchback test metadata saved to [magenta]{output}[/magenta].")
+        return
+
+    print_json(switchback_metadata_dict)

--- a/nextmv/nextmv/cli/cloud/switchback/start.py
+++ b/nextmv/nextmv/cli/cloud/switchback/start.py
@@ -1,0 +1,43 @@
+"""
+This module defines the cloud switchback start command for the Nextmv CLI.
+"""
+
+import typer
+
+from nextmv.cli.configuration.config import build_app
+from nextmv.cli.message import in_progress, success
+from nextmv.cli.options import AppIDOption, ProfileOption, SwitchbackTestIDOption
+
+# Set up subcommand application.
+app = typer.Typer()
+
+
+@app.command()
+def start(
+    app_id: AppIDOption,
+    switchback_test_id: SwitchbackTestIDOption,
+    profile: ProfileOption = None,
+) -> None:
+    """
+    Starts a Nextmv Cloud switchback test.
+
+    Before starting a switchback test, it must be created in draft state. You
+    may use the [code]nextmv cloud switchback create[/code] command to create a
+    new switchback test. Alternatively, define a [code]--start[/code] when
+    using the [code]nextmv cloud switchback create[/code] command to have the
+    switchback test start automatically at a specific time.
+
+    [bold][underline]Examples[/underline][/bold]
+
+    - Start the switchback test with the ID [magenta]hop-analysis[/magenta] from application
+      [magenta]hare-app[/magenta].
+        $ [green]nextmv cloud switchback start --app-id hare-app --switchback-test-id hop-analysis[/green]
+    """
+
+    in_progress(msg="Starting switchback test...")
+    cloud_app = build_app(app_id=app_id, profile=profile)
+    cloud_app.start_switchback_test(switchback_test_id=switchback_test_id)
+    success(
+        f"Switchback test [magenta]{switchback_test_id}[/magenta] started successfully "
+        f"in application [magenta]{app_id}[/magenta]."
+    )

--- a/nextmv/nextmv/cli/cloud/switchback/stop.py
+++ b/nextmv/nextmv/cli/cloud/switchback/stop.py
@@ -1,0 +1,43 @@
+"""
+This module defines the cloud switchback stop command for the Nextmv CLI.
+"""
+
+import typer
+
+from nextmv.cli.configuration.config import build_app
+from nextmv.cli.message import in_progress, success
+from nextmv.cli.options import AppIDOption, ProfileOption, SwitchbackTestIDOption
+
+# Set up subcommand application.
+app = typer.Typer()
+
+
+@app.command()
+def stop(
+    app_id: AppIDOption,
+    switchback_test_id: SwitchbackTestIDOption,
+    profile: ProfileOption = None,
+) -> None:
+    """
+    Stops a Nextmv Cloud switchback test.
+
+    Before stopping a switchback test, it must be in a started state. You may
+    use the [code]nextmv cloud switchback start[/code] command to start a
+    switchback test. Alternatively, define a [code]--start[/code] when using
+    the [code]nextmv cloud switchback create[/code] command to have the
+    switchback test start automatically at a specific time.
+
+    [bold][underline]Examples[/underline][/bold]
+
+    - Stop the switchback test with the ID [magenta]hop-analysis[/magenta] from application
+      [magenta]hare-app[/magenta].
+        $ [green]nextmv cloud switchback stop --app-id hare-app --switchback-test-id hop-analysis[/green]
+    """
+
+    in_progress(msg="Stopping switchback test...")
+    cloud_app = build_app(app_id=app_id, profile=profile)
+    cloud_app.stop_switchback_test(switchback_test_id=switchback_test_id)
+    success(
+        f"Switchback test [magenta]{switchback_test_id}[/magenta] stopped successfully "
+        f"in application [magenta]{app_id}[/magenta]."
+    )

--- a/nextmv/nextmv/cli/cloud/switchback/stop.py
+++ b/nextmv/nextmv/cli/cloud/switchback/stop.py
@@ -21,11 +21,9 @@ def stop(
     """
     Stops a Nextmv Cloud switchback test.
 
-    Before stopping a switchback test, it must be in a started state. You may
-    use the [code]nextmv cloud switchback start[/code] command to start a
-    switchback test. Alternatively, define a [code]--start[/code] when using
-    the [code]nextmv cloud switchback create[/code] command to have the
-    switchback test start automatically at a specific time.
+    Before stopping a switchback test, it must be in a started state. Experiments
+    in a [magenta]draft[/magenta] state, that haven't started, can be deleted
+    with the [code]nextmv cloud switchback delete[/code] command.
 
     [bold][underline]Examples[/underline][/bold]
 

--- a/nextmv/nextmv/cli/cloud/switchback/update.py
+++ b/nextmv/nextmv/cli/cloud/switchback/update.py
@@ -1,5 +1,5 @@
 """
-This module defines the cloud shadow update command for the Nextmv CLI.
+This module defines the cloud switchback update command for the Nextmv CLI.
 """
 
 import json
@@ -9,7 +9,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_app
 from nextmv.cli.message import in_progress, print_json, success
-from nextmv.cli.options import AppIDOption, ProfileOption, ShadowTestIDOption
+from nextmv.cli.options import AppIDOption, ProfileOption, SwitchbackTestIDOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -18,13 +18,13 @@ app = typer.Typer()
 @app.command()
 def update(
     app_id: AppIDOption,
-    shadow_test_id: ShadowTestIDOption,
+    switchback_test_id: SwitchbackTestIDOption,
     description: Annotated[
         str | None,
         typer.Option(
             "--description",
             "-d",
-            help="Updated description of the shadow test.",
+            help="Updated description of the switchback test.",
             metavar="DESCRIPTION",
         ),
     ] = None,
@@ -33,7 +33,7 @@ def update(
         typer.Option(
             "--name",
             "-n",
-            help="Updated name of the shadow test.",
+            help="Updated name of the switchback test.",
             metavar="NAME",
         ),
     ] = None,
@@ -42,55 +42,55 @@ def update(
         typer.Option(
             "--output",
             "-o",
-            help="Saves the updated shadow test information to this location.",
+            help="Saves the updated switchback test information to this location.",
             metavar="OUTPUT_PATH",
         ),
     ] = None,
     profile: ProfileOption = None,
 ) -> None:
     """
-    Update a Nextmv Cloud shadow test.
+    Update a Nextmv Cloud switchback test.
 
-    Update the name and/or description of a shadow test. Any fields not
+    Update the name and/or description of a switchback test. Any fields not
     specified will remain unchanged.
 
     [bold][underline]Examples[/underline][/bold]
 
-    - Update the name of a shadow test.
-        $ [green]nextmv cloud shadow update --app-id hare-app --shadow-test-id carrot-feast \\
+    - Update the name of a switchback test.
+        $ [green]nextmv cloud switchback update --app-id hare-app --switchback-test-id carrot-feast \\
             --name "Spring Carrot Harvest"[/green]
 
-    - Update the description of a shadow test.
-        $ [green]nextmv cloud shadow update --app-id hare-app --shadow-test-id bunny-hop-routes \\
+    - Update the description of a switchback test.
+        $ [green]nextmv cloud switchback update --app-id hare-app --switchback-test-id bunny-hop-routes \\
             --description "Optimizing hop paths through the meadow"[/green]
 
     - Update both name and description and save the result.
-        $ [green]nextmv cloud shadow update --app-id hare-app --shadow-test-id lettuce-delivery \\
+        $ [green]nextmv cloud switchback update --app-id hare-app --switchback-test-id lettuce-delivery \\
             --name "Warren Lettuce Express" --description "Fast lettuce delivery to all burrows" \\
-            --output updated-shadow-test.json[/green]
+            --output updated-switchback-test.json[/green]
     """
 
     cloud_app = build_app(app_id=app_id, profile=profile)
 
-    in_progress(msg="Updating shadow test...")
-    shadow_test = cloud_app.update_shadow_test(
-        shadow_test_id=shadow_test_id,
+    in_progress(msg="Updating switchback test...")
+    switchback_test = cloud_app.update_switchback_test(
+        switchback_test_id=switchback_test_id,
         name=name,
         description=description,
     )
 
-    shadow_test_dict = shadow_test.to_dict()
+    switchback_test_dict = switchback_test.to_dict()
     success(
-        f"Shadow test [magenta]{shadow_test_id}[/magenta] updated successfully "
+        f"Switchback test [magenta]{switchback_test_id}[/magenta] updated successfully "
         f"in application [magenta]{app_id}[/magenta]."
     )
 
     if output is not None and output != "":
         with open(output, "w") as f:
-            json.dump(shadow_test_dict, f, indent=2)
+            json.dump(switchback_test_dict, f, indent=2)
 
-        success(msg=f"Updated shadow test information saved to [magenta]{output}[/magenta].")
+        success(msg=f"Updated switchback test information saved to [magenta]{output}[/magenta].")
 
         return
 
-    print_json(shadow_test_dict)
+    print_json(switchback_test_dict)

--- a/nextmv/nextmv/cli/options.py
+++ b/nextmv/nextmv/cli/options.py
@@ -190,3 +190,17 @@ SecretsCollectionIDOption = Annotated[
         metavar="SECRETS_COLLECTION_ID",
     ),
 ]
+
+# shadow_test_id option - can be used in any command that requires a shadow test ID.
+# Define it as follows in commands or callbacks, as necessary:
+# shadow_test_id: ShadowTestIDOption
+ShadowTestIDOption = Annotated[
+    str,
+    typer.Option(
+        "--shadow-test-id",
+        "-s",
+        help="The Nextmv Cloud shadow test ID to use for this action.",
+        envvar="NEXTMV_SHADOW_TEST_ID",
+        metavar="SHADOW_TEST_ID",
+    ),
+]

--- a/nextmv/nextmv/cli/options.py
+++ b/nextmv/nextmv/cli/options.py
@@ -204,3 +204,17 @@ ShadowTestIDOption = Annotated[
         metavar="SHADOW_TEST_ID",
     ),
 ]
+
+# switchback_test_id option - can be used in any command that requires a switchback test ID.
+# Define it as follows in commands or callbacks, as necessary:
+# switchback_test_id: SwitchbackTestIDOption
+SwitchbackTestIDOption = Annotated[
+    str,
+    typer.Option(
+        "--switchback-test-id",
+        "-s",
+        help="The Nextmv Cloud switchback test ID to use for this action.",
+        envvar="NEXTMV_SWITCHBACK_TEST_ID",
+        metavar="SWITCHBACK_TEST_ID",
+    ),
+]

--- a/nextmv/nextmv/cloud/__init__.py
+++ b/nextmv/nextmv/cloud/__init__.py
@@ -90,6 +90,11 @@ from .secrets import Secret as Secret
 from .secrets import SecretsCollection as SecretsCollection
 from .secrets import SecretsCollectionSummary as SecretsCollectionSummary
 from .secrets import SecretType as SecretType
+from .shadow import ShadowTest as ShadowTest
+from .shadow import ShadowTestMetadata as ShadowTestMetadata
+from .shadow import StartEvents as StartEvents
+from .shadow import TerminationEvents as TerminationEvents
+from .shadow import TestComparison as TestComparison
 from .url import DownloadURL as DownloadURL
 from .url import UploadURL as UploadURL
 from .version import Version as Version

--- a/nextmv/nextmv/cloud/__init__.py
+++ b/nextmv/nextmv/cloud/__init__.py
@@ -95,6 +95,11 @@ from .shadow import ShadowTestMetadata as ShadowTestMetadata
 from .shadow import StartEvents as StartEvents
 from .shadow import TerminationEvents as TerminationEvents
 from .shadow import TestComparison as TestComparison
+from .switchback import SwitchbackPlan as SwitchbackPlan
+from .switchback import SwitchbackPlanUnit as SwitchbackPlanUnit
+from .switchback import SwitchbackTest as SwitchbackTest
+from .switchback import SwitchbackTestMetadata as SwitchbackTestMetadata
+from .switchback import TestComparisonSingle as TestComparisonSingle
 from .url import DownloadURL as DownloadURL
 from .url import UploadURL as UploadURL
 from .version import Version as Version

--- a/nextmv/nextmv/cloud/application/__init__.py
+++ b/nextmv/nextmv/cloud/application/__init__.py
@@ -41,6 +41,7 @@ from nextmv.cloud.application._instance import ApplicationInstanceMixin
 from nextmv.cloud.application._managed_input import ApplicationManagedInputMixin
 from nextmv.cloud.application._run import ApplicationRunMixin
 from nextmv.cloud.application._secrets import ApplicationSecretsMixin
+from nextmv.cloud.application._shadow import ApplicationShadowMixin
 from nextmv.cloud.application._utils import _is_not_exist_error
 from nextmv.cloud.application._version import ApplicationVersionMixin
 from nextmv.cloud.client import Client
@@ -100,6 +101,7 @@ class Application(
     ApplicationVersionMixin,
     ApplicationInputSetMixin,
     ApplicationManagedInputMixin,
+    ApplicationShadowMixin,
 ):
     """
     A published decision model that can be executed.

--- a/nextmv/nextmv/cloud/application/__init__.py
+++ b/nextmv/nextmv/cloud/application/__init__.py
@@ -42,6 +42,7 @@ from nextmv.cloud.application._managed_input import ApplicationManagedInputMixin
 from nextmv.cloud.application._run import ApplicationRunMixin
 from nextmv.cloud.application._secrets import ApplicationSecretsMixin
 from nextmv.cloud.application._shadow import ApplicationShadowMixin
+from nextmv.cloud.application._switchback import ApplicationSwitchbackMixin
 from nextmv.cloud.application._utils import _is_not_exist_error
 from nextmv.cloud.application._version import ApplicationVersionMixin
 from nextmv.cloud.client import Client
@@ -102,6 +103,7 @@ class Application(
     ApplicationInputSetMixin,
     ApplicationManagedInputMixin,
     ApplicationShadowMixin,
+    ApplicationSwitchbackMixin,
 ):
     """
     A published decision model that can be executed.

--- a/nextmv/nextmv/cloud/application/_shadow.py
+++ b/nextmv/nextmv/cloud/application/_shadow.py
@@ -208,7 +208,7 @@ class ApplicationShadowMixin:
             name = shadow_test_id
 
         payload = {
-            "id": id,
+            "id": shadow_test_id,
             "name": name,
             "comparisons": comparisons,
             "termination_events": termination_events.to_dict(),

--- a/nextmv/nextmv/cloud/application/_shadow.py
+++ b/nextmv/nextmv/cloud/application/_shadow.py
@@ -1,0 +1,314 @@
+"""
+Application mixin for managing shadow tests.
+"""
+
+from typing import TYPE_CHECKING
+
+from nextmv.cloud.shadow import ShadowTest, ShadowTestMetadata, StartEvents, TerminationEvents
+from nextmv.run import Run
+from nextmv.safe import safe_id
+
+if TYPE_CHECKING:
+    from . import Application
+
+
+class ApplicationShadowMixin:
+    """
+    Mixin class for managing shadow tests within an application.
+    """
+
+    def shadow_test(self: "Application", shadow_test_id: str) -> ShadowTest:
+        """
+        Get a shadow test. This method also returns the runs of the shadow
+        test under the `.runs` attribute.
+
+        Parameters
+        ----------
+        shadow_test_id : str
+            ID of the shadow test.
+
+        Returns
+        -------
+        ShadowTest
+            The requested shadow test details.
+
+        Raises
+        ------
+        requests.HTTPError
+            If the response status code is not 2xx.
+
+        Examples
+        --------
+        >>> shadow_test = app.shadow_test("shadow-123")
+        >>> print(shadow_test.name)
+        'My Shadow Test'
+        """
+
+        response = self.client.request(
+            method="GET",
+            endpoint=f"{self.experiments_endpoint}/shadow/{shadow_test_id}",
+        )
+
+        exp = ShadowTest.from_dict(response.json())
+
+        runs_response = self.client.request(
+            method="GET",
+            endpoint=f"{self.experiments_endpoint}/shadow/{shadow_test_id}/runs",
+        )
+
+        runs = [Run.from_dict(run) for run in runs_response.json().get("runs", [])]
+        exp.runs = runs
+
+        return exp
+
+    def shadow_test_metadata(self: "Application", shadow_test_id: str) -> ShadowTestMetadata:
+        """
+        Get metadata for a shadow test.
+
+        Parameters
+        ----------
+        shadow_test_id : str
+            ID of the shadow test.
+
+        Returns
+        -------
+        ShadowTestMetadata
+            The requested shadow test metadata.
+
+        Raises
+        ------
+        requests.HTTPError
+            If the response status code is not 2xx.
+
+        Examples
+        --------
+        >>> metadata = app.shadow_test_metadata("shadow-123")
+        >>> print(metadata.name)
+        'My Shadow Test'
+        """
+
+        response = self.client.request(
+            method="GET",
+            endpoint=f"{self.experiments_endpoint}/shadow/{shadow_test_id}/metadata",
+        )
+
+        return ShadowTestMetadata.from_dict(response.json())
+
+    def delete_shadow_test(self: "Application", shadow_test_id: str) -> None:
+        """
+        Delete a shadow test.
+
+        Deletes a shadow test along with all the associated information,
+        such as its runs.
+
+        Parameters
+        ----------
+        shadow_test_id : str
+            ID of the shadow test to delete.
+
+        Raises
+        ------
+        requests.HTTPError
+            If the response status code is not 2xx.
+
+        Examples
+        --------
+        >>> app.delete_shadow_test("shadow-123")
+        """
+
+        _ = self.client.request(
+            method="DELETE",
+            endpoint=f"{self.experiments_endpoint}/shadow/{shadow_test_id}",
+        )
+
+    def list_shadow_tests(self: "Application") -> list[ShadowTest]:
+        """
+        List all shadow tests.
+
+        Returns
+        -------
+        list[ShadowTest]
+            List of shadow tests.
+
+        Raises
+        ------
+        requests.HTTPError
+            If the response status code is not 2xx.
+        """
+
+        response = self.client.request(
+            method="GET",
+            endpoint=f"{self.experiments_endpoint}/shadow",
+        )
+
+        return [ShadowTest.from_dict(shadow_test) for shadow_test in response.json()]
+
+    def new_shadow_test(
+        self: "Application",
+        comparisons: dict[str, list[str]],
+        termination_events: TerminationEvents,
+        shadow_test_id: str | None = None,
+        name: str | None = None,
+        description: str | None = None,
+        start_events: StartEvents | None = None,
+    ) -> ShadowTest:
+        """
+        Create a new shadow test in draft mode. Shadow tests are experiments
+        that run instances in parallel to compare their results.
+
+        Use the `comparisons` parameter to define how to set up instance
+        comparisons. The keys of the `comparisons` dictionary are the baseline
+        instance IDs, and the values are the candidate lists of instance IDs to
+        compare against the respective baseline.
+
+        You may specify `start_events` to make the shadow test start at a
+        specific time. Alternatively, you may use the `start_shadow_test`
+        method to start the test.
+
+        The `termination_events` parameter is required and provides control
+        over when the shadow test should terminate. Alternatively, you may use
+        the `stop_shadow_test` method to stop the test.
+
+        Parameters
+        ----------
+        comparisons : dict[str, list[str]]
+            Dictionary defining the baseline and candidate instance IDs for
+            comparison. The keys are baseline instance IDs, and the values are
+            lists of candidate instance IDs to compare against the respective
+            baseline.
+        termination_events : TerminationEvents
+            Termination events for the shadow test.
+        shadow_test_id : Optional[str]
+            ID of the shadow test. Will be generated if not provided.
+        name : Optional[str]
+            Name of the shadow test. If not provided, the ID will be used as
+            the name.
+        description : Optional[str]
+            Optional description of the shadow test.
+        start_events : Optional[StartEvents]
+            Start events for the shadow test.
+
+        Returns
+        -------
+        ShadowTest
+            The created shadow test.
+
+        Raises
+        ------
+        requests.HTTPError
+            If the response status code is not 2xx.
+        """
+
+        # Generate ID if not provided
+        if shadow_test_id is None:
+            shadow_test_id = safe_id("shadow")
+
+        # Use ID as name if name not provided
+        if name is None:
+            name = shadow_test_id
+
+        payload = {
+            "id": id,
+            "name": name,
+            "comparisons": comparisons,
+            "termination_events": termination_events.to_dict(),
+        }
+
+        if description is not None:
+            payload["description"] = description
+        if start_events is not None:
+            payload["start_events"] = start_events.to_dict()
+
+        response = self.client.request(
+            method="POST",
+            endpoint=f"{self.experiments_endpoint}/shadow",
+            payload=payload,
+        )
+
+        return ShadowTest.from_dict(response.json())
+
+    def start_shadow_test(self: "Application", shadow_test_id: str) -> None:
+        """
+        Start a shadow test. Create a shadow test in draft mode using the
+        `new_shadow_test` method, then use this method to start the test.
+
+        Parameters
+        ----------
+        shadow_test_id : str
+            ID of the shadow test to start.
+
+        Raises
+        ------
+        requests.HTTPError
+            If the response status code is not 2xx.
+        """
+
+        _ = self.client.request(
+            method="PUT",
+            endpoint=f"{self.experiments_endpoint}/shadow/{shadow_test_id}/start",
+        )
+
+    def stop_shadow_test(self: "Application", shadow_test_id: str) -> None:
+        """
+        Stop a shadow test. The test should already have started before using
+        this method.
+
+        Parameters
+        ----------
+        shadow_test_id : str
+            ID of the shadow test to stop.
+
+        Raises
+        ------
+        requests.HTTPError
+            If the response status code is not 2xx.
+        """
+
+        _ = self.client.request(
+            method="PUT",
+            endpoint=f"{self.experiments_endpoint}/shadow/{shadow_test_id}/stop",
+        )
+
+    def update_shadow_test(
+        self: "Application",
+        shadow_test_id: str,
+        name: str | None = None,
+        description: str | None = None,
+    ) -> ShadowTest:
+        """
+        Update a shadow test.
+
+        Parameters
+        ----------
+        shadow_test_id : str
+            ID of the shadow test to update.
+        name : Optional[str], default=None
+            Optional name of the shadow test.
+        description : Optional[str], default=None
+            Optional description of the shadow test.
+
+        Returns
+        -------
+        ShadowTest
+            The information with the updated shadow test.
+
+        Raises
+        ------
+        requests.HTTPError
+            If the response status code is not 2xx.
+        """
+
+        payload = {}
+
+        if name is not None:
+            payload["name"] = name
+        if description is not None:
+            payload["description"] = description
+
+        response = self.client.request(
+            method="PATCH",
+            endpoint=f"{self.experiments_endpoint}/shadow/{shadow_test_id}",
+            payload=payload,
+        )
+
+        return ShadowTest.from_dict(response.json())

--- a/nextmv/nextmv/cloud/application/_switchback.py
+++ b/nextmv/nextmv/cloud/application/_switchback.py
@@ -172,9 +172,11 @@ class ApplicationSwitchbackMixin:
         comparison : TestComparisonSingle
             Comparison defining the baseline and candidate instances.
         unit_duration_minutes : float
-            Duration of each interval in minutes.
+            Duration of each interval in minutes. The value must be between 1
+            and 10080.
         units : int
-            Total number of intervals in the switchback test.
+            Total number of intervals in the switchback test. The value must be
+            between 1 and 1000.
         switchback_test_id : Optional[str], default=None
             Optional ID for the switchback test. Will be generated if not
             provided.
@@ -197,6 +199,12 @@ class ApplicationSwitchbackMixin:
             If the response status code is not 2xx.
         """
 
+        if unit_duration_minutes < 1 or unit_duration_minutes > 10080:
+            raise ValueError("unit_duration_minutes must be between 1 and 10080")
+
+        if units < 1 or units > 1000:
+            raise ValueError("units must be between 1 and 1000")
+
         # Generate ID if not provided
         if switchback_test_id is None:
             switchback_test_id = safe_id("switchback")
@@ -206,7 +214,7 @@ class ApplicationSwitchbackMixin:
             name = switchback_test_id
 
         payload = {
-            "id": id,
+            "id": switchback_test_id,
             "name": name,
             "comparison": comparison,
             "generate_random_plan": {

--- a/nextmv/nextmv/cloud/application/_switchback.py
+++ b/nextmv/nextmv/cloud/application/_switchback.py
@@ -147,7 +147,7 @@ class ApplicationSwitchbackMixin:
     def new_switchback_test(
         self: "Application",
         comparison: TestComparisonSingle,
-        unit_duration_minuites: float,
+        unit_duration_minutes: float,
         units: int,
         switchback_test_id: str | None = None,
         name: str | None = None,
@@ -171,7 +171,7 @@ class ApplicationSwitchbackMixin:
         ----------
         comparison : TestComparisonSingle
             Comparison defining the baseline and candidate instances.
-        unit_duration_minuites : float
+        unit_duration_minutes : float
             Duration of each interval in minutes.
         units : int
             Total number of intervals in the switchback test.
@@ -209,7 +209,10 @@ class ApplicationSwitchbackMixin:
             "id": id,
             "name": name,
             "comparison": comparison,
-            "generate_random_plan": {"unit_duration_minutes": unit_duration_minuites, "units": units},
+            "generate_random_plan": {
+                "unit_duration_minutes": unit_duration_minutes,
+                "units": units,
+            },
         }
 
         if description is not None:

--- a/nextmv/nextmv/cloud/application/_switchback.py
+++ b/nextmv/nextmv/cloud/application/_switchback.py
@@ -1,0 +1,312 @@
+"""
+Application mixin for managing switchback tests.
+"""
+
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from nextmv.cloud.switchback import SwitchbackTest, SwitchbackTestMetadata, TestComparisonSingle
+from nextmv.run import Run
+from nextmv.safe import safe_id
+
+if TYPE_CHECKING:
+    from . import Application
+
+
+class ApplicationSwitchbackMixin:
+    """
+    Mixin class for managing switchback tests within an application.
+    """
+
+    def switchback_test(self: "Application", switchback_test_id: str) -> SwitchbackTest:
+        """
+        Get a switchback test. This method also returns the runs of the switchback
+        test under the `.runs` attribute.
+
+        Parameters
+        ----------
+        switchback_test_id : str
+            ID of the switchback test.
+
+        Returns
+        -------
+        SwitchbackTest
+            The requested switchback test details.
+
+        Raises
+        ------
+        requests.HTTPError
+            If the response status code is not 2xx.
+
+        Examples
+        --------
+        >>> switchback_test = app.switchback_test("switchback-123")
+        >>> print(switchback_test.name)
+        'My Switchback Test'
+        """
+
+        response = self.client.request(
+            method="GET",
+            endpoint=f"{self.experiments_endpoint}/switchback/{switchback_test_id}",
+        )
+
+        exp = SwitchbackTest.from_dict(response.json())
+
+        runs_response = self.client.request(
+            method="GET",
+            endpoint=f"{self.experiments_endpoint}/switchback/{switchback_test_id}/runs",
+        )
+
+        runs = [Run.from_dict(run) for run in runs_response.json().get("runs", [])]
+        exp.runs = runs
+
+        return exp
+
+    def switchback_test_metadata(self: "Application", switchback_test_id: str) -> SwitchbackTestMetadata:
+        """
+        Get metadata for a switchback test.
+
+        Parameters
+        ----------
+        switchback_test_id : str
+            ID of the switchback test.
+
+        Returns
+        -------
+        SwitchbackTestMetadata
+            The requested switchback test metadata.
+
+        Raises
+        ------
+        requests.HTTPError
+            If the response status code is not 2xx.
+
+        Examples
+        --------
+        >>> metadata = app.switchback_test_metadata("switchback-123")
+        >>> print(metadata.name)
+        'My Switchback Test'
+        """
+
+        response = self.client.request(
+            method="GET",
+            endpoint=f"{self.experiments_endpoint}/switchback/{switchback_test_id}/metadata",
+        )
+
+        return SwitchbackTestMetadata.from_dict(response.json())
+
+    def delete_switchback_test(self: "Application", switchback_test_id: str) -> None:
+        """
+        Delete a switchback test.
+
+        Deletes a switchback test along with all the associated information,
+        such as its runs.
+
+        Parameters
+        ----------
+        switchback_test_id : str
+            ID of the switchback test to delete.
+
+        Raises
+        ------
+        requests.HTTPError
+            If the response status code is not 2xx.
+
+        Examples
+        --------
+        >>> app.delete_switchback_test("switchback-123")
+        """
+
+        _ = self.client.request(
+            method="DELETE",
+            endpoint=f"{self.experiments_endpoint}/switchback/{switchback_test_id}",
+        )
+
+    def list_switchback_tests(self: "Application") -> list[SwitchbackTest]:
+        """
+        List all switchback tests.
+
+        Returns
+        -------
+        list[SwitchbackTest]
+            List of switchback tests.
+
+        Raises
+        ------
+        requests.HTTPError
+            If the response status code is not 2xx.
+        """
+
+        response = self.client.request(
+            method="GET",
+            endpoint=f"{self.experiments_endpoint}/switchback",
+        )
+
+        return [SwitchbackTest.from_dict(switchback_test) for switchback_test in response.json().get("items", [])]
+
+    def new_switchback_test(
+        self: "Application",
+        comparison: TestComparisonSingle,
+        unit_duration_minuites: float,
+        units: int,
+        switchback_test_id: str | None = None,
+        name: str | None = None,
+        description: str | None = None,
+        start: datetime | None = None,
+    ) -> SwitchbackTest:
+        """
+        Create a new switchback test in draft mode. Switchback tests are
+        experiments that alternate between different instances over specified
+        time intervals.
+
+        Use the `comparison` parameter to define how to set up the instance
+        comparison. The test will alternate between the baseline and candidate
+        instances defined in the comparison.
+
+        You may specify `start` to make the switchback test start at a
+        specific time. Alternatively, you may use the `start_switchback_test`
+        method to start the test.
+
+        Parameters
+        ----------
+        comparison : TestComparisonSingle
+            Comparison defining the baseline and candidate instances.
+        unit_duration_minuites : float
+            Duration of each interval in minutes.
+        units : int
+            Total number of intervals in the switchback test.
+        switchback_test_id : Optional[str], default=None
+            Optional ID for the switchback test. Will be generated if not
+            provided.
+        name : Optional[str], default=None
+            Optional name of the switchback test. If not provided, the ID will
+            be used as the name.
+        description : Optional[str], default=None
+            Optional description of the switchback test.
+        start : Optional[datetime], default=None
+            Optional scheduled start time for the switchback test.
+
+        Returns
+        -------
+        SwitchbackTest
+            The created switchback test.
+
+        Raises
+        ------
+        requests.HTTPError
+            If the response status code is not 2xx.
+        """
+
+        # Generate ID if not provided
+        if switchback_test_id is None:
+            switchback_test_id = safe_id("switchback")
+
+        # Use ID as name if name not provided
+        if name is None:
+            name = switchback_test_id
+
+        payload = {
+            "id": id,
+            "name": name,
+            "comparison": comparison,
+            "generate_random_plan": {"unit_duration_minutes": unit_duration_minuites, "units": units},
+        }
+
+        if description is not None:
+            payload["description"] = description
+        if start is not None:
+            payload["generate_random_plan"]["start"] = start.isoformat()
+
+        response = self.client.request(
+            method="POST",
+            endpoint=f"{self.experiments_endpoint}/switchback",
+            payload=payload,
+        )
+
+        return SwitchbackTest.from_dict(response.json())
+
+    def start_switchback_test(self: "Application", switchback_test_id: str) -> None:
+        """
+        Start a switchback test. Create a switchback test in draft mode using the
+        `new_switchback_test` method, then use this method to start the test.
+
+        Parameters
+        ----------
+        switchback_test_id : str
+            ID of the switchback test to start.
+
+        Raises
+        ------
+        requests.HTTPError
+            If the response status code is not 2xx.
+        """
+
+        _ = self.client.request(
+            method="PUT",
+            endpoint=f"{self.experiments_endpoint}/switchback/{switchback_test_id}/start",
+        )
+
+    def stop_switchback_test(self: "Application", switchback_test_id: str) -> None:
+        """
+        Stop a switchback test. The test should already have started before using
+        this method.
+
+        Parameters
+        ----------
+        switchback_test_id : str
+            ID of the switchback test to stop.
+
+        Raises
+        ------
+        requests.HTTPError
+            If the response status code is not 2xx.
+        """
+
+        _ = self.client.request(
+            method="PUT",
+            endpoint=f"{self.experiments_endpoint}/switchback/{switchback_test_id}/stop",
+        )
+
+    def update_switchback_test(
+        self: "Application",
+        switchback_test_id: str,
+        name: str | None = None,
+        description: str | None = None,
+    ) -> SwitchbackTest:
+        """
+        Update a switchback test.
+
+        Parameters
+        ----------
+        switchback_test_id : str
+            ID of the switchback test to update.
+        name : Optional[str], default=None
+            Optional name of the switchback test.
+        description : Optional[str], default=None
+            Optional description of the switchback test.
+
+        Returns
+        -------
+        SwitchbackTest
+            The information with the updated switchback test.
+
+        Raises
+        ------
+        requests.HTTPError
+            If the response status code is not 2xx.
+        """
+
+        payload = {}
+
+        if name is not None:
+            payload["name"] = name
+        if description is not None:
+            payload["description"] = description
+
+        response = self.client.request(
+            method="PATCH",
+            endpoint=f"{self.experiments_endpoint}/switchback/{switchback_test_id}",
+            payload=payload,
+        )
+
+        return SwitchbackTest.from_dict(response.json())

--- a/nextmv/nextmv/cloud/shadow.py
+++ b/nextmv/nextmv/cloud/shadow.py
@@ -90,7 +90,7 @@ class TerminationEvents(BaseModel):
 
     maximum_runs: int
     """
-    Maximum number of runs for the test. Min should be 1, max should be 300.
+    Maximum number of runs for the test. Value must be between 1 and 300.
     """
     time: datetime | None = None
     """
@@ -99,8 +99,8 @@ class TerminationEvents(BaseModel):
     """
 
     def model_post_init(self, __context):
-        if self.maximum_runs < 1:
-            raise ValueError("maximum_runs must be at least 1")
+        if self.maximum_runs < 1 or self.maximum_runs > 300:
+            raise ValueError("maximum_runs must be between 1 and 300")
 
 
 class ShadowTestMetadata(BaseModel):
@@ -151,7 +151,10 @@ class ShadowTestMetadata(BaseModel):
     """The current status of the shadow test."""
 
 
-class ShadowTest(ShadowTestMetadata):
+# This class uses some fields defined in ShadowTestMetadata. We are not
+# using inheritance to help the user understand the full structure when using
+# tools like intellisense.
+class ShadowTest(BaseModel):
     """
     A Nextmv Cloud shadow test definition.
 
@@ -166,6 +169,20 @@ class ShadowTest(ShadowTestMetadata):
 
     Parameters
     ----------
+    shadow_test_id : str, optional
+        The unique identifier of the shadow test.
+    name : str, optional
+        Name of the shadow test.
+    description : str, optional
+        Description of the shadow test.
+    app_id : str, optional
+        ID of the application to which the shadow test belongs.
+    created_at : datetime, optional
+        Creation date of the shadow test.
+    updated_at : datetime, optional
+        Last update date of the shadow test.
+    status : ExperimentStatus, optional
+        The current status of the shadow test.
     completed_at : datetime, optional
         Completion date of the shadow test, if applicable.
     comparisons : list[TestComparison], optional
@@ -174,8 +191,30 @@ class ShadowTest(ShadowTestMetadata):
         Start events for the shadow test.
     termination_events : TerminationEvents, optional
         Termination events for the shadow test.
+    grouped_distributional_summaries : list[dict[str, Any]], optional
+        Grouped distributional summaries of the shadow test.
+    runs : list[Run], optional
+        List of runs in the shadow test.
     """
 
+    shadow_test_id: str | None = Field(
+        serialization_alias="id",
+        validation_alias=AliasChoices("id", "shadow_test_id"),
+        default=None,
+    )
+    """The unique identifier of the shadow test."""
+    name: str | None = None
+    """Name of the shadow test."""
+    description: str | None = None
+    """Description of the shadow test."""
+    app_id: str | None = None
+    """ID of the application to which the shadow test belongs."""
+    created_at: datetime | None = None
+    """Creation date of the shadow test."""
+    updated_at: datetime | None = None
+    """Last update date of the shadow test."""
+    status: ExperimentStatus | None = None
+    """The current status of the shadow test."""
     completed_at: datetime | None = None
     """Completion date of the shadow test, if applicable."""
     comparisons: list[TestComparison] | None = None

--- a/nextmv/nextmv/cloud/shadow.py
+++ b/nextmv/nextmv/cloud/shadow.py
@@ -1,0 +1,186 @@
+"""
+Classes for working with Nextmv Cloud shadow tests.
+
+This module provides classes for interacting with shadow tests in Nextmv Cloud.
+It details the core data structures for these types of experiments.
+
+Classes
+-------
+TestComparison
+    A structure to define comparison parameters for tests.
+StartEvents
+    A structure to define start events for tests.
+TerminationEvents
+    A structure to define termination events for tests.
+ShadowTestMetadata
+    Metadata for a Nextmv Cloud shadow test.
+ShadowTest
+    A Nextmv Cloud shadow test definition.
+"""
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import AliasChoices, Field
+
+from nextmv.base_model import BaseModel
+from nextmv.cloud.batch_experiment import ExperimentStatus
+from nextmv.run import Run
+
+
+class TestComparison(BaseModel):
+    """
+    A structure to define comparison parameters for tests.
+
+    You can import the `TestComparison` class directly from `cloud`:
+
+    ```python
+    from nextmv.cloud import TestComparison
+    ```
+
+    Parameters
+    ----------
+    baseline_instance_id : str
+        ID of the baseline instance for comparison.
+    candidate_instance_ids : list[str]
+        List of candidate instance IDs to compare against the baseline.
+    """
+
+    baseline_instance_id: str
+    """ID of the baseline instance for comparison."""
+    candidate_instance_ids: list[str]
+    """List of candidate instance IDs to compare against the baseline."""
+
+
+class StartEvents(BaseModel):
+    """
+    A structure to define start events for tests.
+
+    You can import the `StartEvents` class directly from `cloud`:
+
+    ```python
+    from nextmv.cloud import StartEvents
+    ```
+
+    Parameters
+    ----------
+    time : datetime, optional
+        Scheduled time for the test to start.
+    """
+
+    time: datetime | None = None
+    """Scheduled time for the test to start."""
+
+
+class TerminationEvents(BaseModel):
+    """
+    A structure to define termination events for tests.
+
+    You can import the `TerminationEvents` class directly from `cloud`:
+
+    ```python
+    from nextmv.cloud import TerminationEvents
+    ```
+
+    Parameters
+    ----------
+    time : datetime, optional
+        Scheduled time for the test to terminate.
+    """
+
+    time: datetime | None = None
+    """
+    Scheduled time for the test to terminate. A zero value means no
+    limit.
+    """
+    maximum_runs: int | None = None
+    """
+    Maximum number of runs for the test. Min should be 1, max should be 300.
+    """
+
+
+class ShadowTestMetadata(BaseModel):
+    """
+    Metadata for a Nextmv Cloud shadow test.
+
+    You can import the `ShadowTestMetadata` class directly from `cloud`:
+
+    ```python
+    from nextmv.cloud import ShadowTestMetadata
+    ```
+
+    Parameters
+    ----------
+    shadow_test_id : str, optional
+        The unique identifier of the shadow test.
+    name : str, optional
+        Name of the shadow test.
+    description : str, optional
+        Description of the shadow test.
+    app_id : str, optional
+        ID of the application to which the shadow test belongs.
+    created_at : datetime, optional
+        Creation date of the shadow test.
+    updated_at : datetime, optional
+        Last update date of the shadow test.
+    status : ExperimentStatus, optional
+        The current status of the shadow test.
+    """
+
+    shadow_test_id: str | None = Field(
+        serialization_alias="id",
+        validation_alias=AliasChoices("id", "shadow_test_id"),
+        default=None,
+    )
+    """The unique identifier of the shadow test."""
+    name: str | None = None
+    """Name of the shadow test."""
+    description: str | None = None
+    """Description of the shadow test."""
+    app_id: str | None = None
+    """ID of the application to which the shadow test belongs."""
+    created_at: datetime | None = None
+    """Creation date of the shadow test."""
+    updated_at: datetime | None = None
+    """Last update date of the shadow test."""
+    status: ExperimentStatus | None = None
+    """The current status of the shadow test."""
+
+
+class ShadowTest(ShadowTestMetadata):
+    """
+    A Nextmv Cloud shadow test definition.
+
+    A shadow test is a type of experiment where runs are executed in parallel
+    to compare different instances.
+
+    You can import the `ShadowTest` class directly from `cloud`:
+
+    ```python
+    from nextmv.cloud import ShadowTest
+    ```
+
+    Parameters
+    ----------
+    completed_at : datetime, optional
+        Completion date of the shadow test, if applicable.
+    comparisons : list[TestComparison], optional
+        List of test comparisons defined in the shadow test.
+    start_events : StartEvents, optional
+        Start events for the shadow test.
+    termination_events : TerminationEvents, optional
+        Termination events for the shadow test.
+    """
+
+    completed_at: datetime | None = None
+    """Completion date of the shadow test, if applicable."""
+    comparisons: list[TestComparison] | None = None
+    """List of test comparisons defined in the shadow test."""
+    start_events: StartEvents | None = None
+    """Start events for the shadow test."""
+    termination_events: TerminationEvents | None = None
+    """Termination events for the shadow test."""
+    grouped_distributional_summaries: list[dict[str, Any]] | None = None
+    """Grouped distributional summaries of the shadow test."""
+    runs: list[Run] | None = None
+    """List of runs in the shadow test."""

--- a/nextmv/nextmv/cloud/shadow.py
+++ b/nextmv/nextmv/cloud/shadow.py
@@ -88,15 +88,19 @@ class TerminationEvents(BaseModel):
         Scheduled time for the test to terminate.
     """
 
+    maximum_runs: int
+    """
+    Maximum number of runs for the test. Min should be 1, max should be 300.
+    """
     time: datetime | None = None
     """
     Scheduled time for the test to terminate. A zero value means no
     limit.
     """
-    maximum_runs: int | None = None
-    """
-    Maximum number of runs for the test. Min should be 1, max should be 300.
-    """
+
+    def model_post_init(self, __context):
+        if self.maximum_runs < 1:
+            raise ValueError("maximum_runs must be at least 1")
 
 
 class ShadowTestMetadata(BaseModel):

--- a/nextmv/nextmv/cloud/switchback.py
+++ b/nextmv/nextmv/cloud/switchback.py
@@ -1,0 +1,189 @@
+"""
+Classes for working with Nextmv Cloud switchback tests.
+
+This module provides classes for interacting with switchback tests in Nextmv Cloud.
+It details the core data structures for these types of experiments.
+
+Classes
+-------
+TestComparisonSingle
+    A structure to define a single comparison for tests.
+SwitchbackPlanUnit
+    A structure to define a single unit in the switchback plan.
+SwitchbackPlan
+    A structure to define the switchback plan for tests.
+SwitchbackTestMetadata
+    Metadata for a Nextmv Cloud switchback test.
+SwitchbackTest
+    A Nextmv Cloud switchback test definition.
+"""
+
+from datetime import datetime
+
+from pydantic import AliasChoices, Field
+
+from nextmv.base_model import BaseModel
+from nextmv.cloud.batch_experiment import ExperimentStatus
+from nextmv.run import Run
+
+
+class TestComparisonSingle(BaseModel):
+    """
+    A structure to define a single comparison for tests.
+
+    You can import the `TestComparisonSingle` class directly from `cloud`:
+
+    ```python
+    from nextmv.cloud import TestComparisonSingle
+    ```
+
+    Parameters
+    ----------
+    baseline_instance_id : str
+        ID of the baseline instance for comparison.
+    candidate_instance_id : str
+        ID of the candidate instance for comparison.
+    """
+
+    baseline_instance_id: str
+    """ID of the baseline instance for comparison."""
+    candidate_instance_id: str
+    """ID of the candidate instance for comparison."""
+
+
+class SwitchbackPlanUnit(BaseModel):
+    """
+    A structure to define a single unit in the switchback plan.
+
+    You can import the `SwitchbackPlanUnit` class directly from `cloud`:
+
+    ```python
+    from nextmv.cloud import SwitchbackPlanUnit
+    ```
+
+    Parameters
+    ----------
+    duration_minutes : float
+        Duration of this interval in minutes.
+    instance_id : str
+        ID of the instance to run during this unit.
+    index : int
+        Index of this unit in the switchback plan.
+    """
+
+    duration_minutes: float
+    """Duration of this interval in minutes."""
+    instance_id: str
+    """ID of the instance to run during this unit."""
+    index: int
+    """Index of this unit in the switchback plan."""
+
+
+class SwitchbackPlan(BaseModel):
+    """
+    A structure to define the switchback plan for tests.
+
+    You can import the `SwitchbackPlan` class directly from `cloud`:
+
+    ```python
+    from nextmv.cloud import SwitchbackPlan
+    ```
+
+    Parameters
+    ----------
+    interval_duration_seconds : int
+        Duration of each interval in seconds.
+    total_intervals : int
+        Total number of intervals in the switchback test.
+    """
+
+    start: datetime | None = None
+    """Start time of the switchback test."""
+    units: list[SwitchbackPlanUnit] | None = None
+    """List of switchback plan units."""
+
+
+class SwitchbackTestMetadata(BaseModel):
+    """
+    Metadata for a Nextmv Cloud switchback test.
+
+    You can import the `SwitchbackTestMetadata` class directly from `cloud`:
+
+    ```python
+    from nextmv.cloud import SwitchbackTestMetadata
+    ```
+
+    Parameters
+    ----------
+    switchback_test_id : str, optional
+        The unique identifier of the switchback test.
+    name : str, optional
+        Name of the switchback test.
+    description : str, optional
+        Description of the switchback test.
+    app_id : str, optional
+        ID of the application to which the switchback test belongs.
+    created_at : datetime, optional
+        Creation date of the switchback test.
+    updated_at : datetime, optional
+        Last update date of the switchback test.
+    status : ExperimentStatus, optional
+        The current status of the switchback test.
+    """
+
+    switchback_test_id: str | None = Field(
+        serialization_alias="id",
+        validation_alias=AliasChoices("id", "switchback_test_id"),
+        default=None,
+    )
+    """The unique identifier of the switchback test."""
+    name: str | None = None
+    """Name of the switchback test."""
+    description: str | None = None
+    """Description of the switchback test."""
+    app_id: str | None = None
+    """ID of the application to which the switchback test belongs."""
+    created_at: datetime | None = None
+    """Creation date of the switchback test."""
+    updated_at: datetime | None = None
+    """Last update date of the switchback test."""
+    status: ExperimentStatus | None = None
+    """The current status of the switchback test."""
+
+
+class SwitchbackTest(SwitchbackTestMetadata):
+    """
+    A Nextmv Cloud switchback test definition.
+
+    A switchback test is a type of experiment where runs are executed in
+    sequential intervals, alternating between different instances to compare
+    their performance.
+
+    You can import the `SwitchbackTest` class directly from `cloud`:
+
+    ```python
+    from nextmv.cloud import SwitchbackTest
+    ```
+
+    Parameters
+    ----------
+    completed_at : datetime, optional
+        Completion date of the switchback test, if applicable.
+    comparison : TestComparisonSingle, optional
+        Test comparison defined in the switchback test.
+    start_events : StartEvents, optional
+        Start events for the switchback test.
+    termination_events : TerminationEvents, optional
+        Termination events for the switchback test.
+    """
+
+    started_at: datetime | None = None
+    """Start date of the switchback test, if applicable."""
+    completed_at: datetime | None = None
+    """Completion date of the switchback test, if applicable."""
+    comparison: TestComparisonSingle | None = None
+    """Test comparison defined in the switchback test."""
+    plan: SwitchbackPlan | None = None
+    """Switchback plan defining the intervals and instance switching."""
+    runs: list[Run] | None = None
+    """List of runs in the switchback test."""

--- a/nextmv/nextmv/cloud/switchback.py
+++ b/nextmv/nextmv/cloud/switchback.py
@@ -91,10 +91,10 @@ class SwitchbackPlan(BaseModel):
 
     Parameters
     ----------
-    interval_duration_seconds : int
-        Duration of each interval in seconds.
-    total_intervals : int
-        Total number of intervals in the switchback test.
+    start : datetime, optional
+        Start time of the switchback test.
+    units : list[SwitchbackPlanUnit], optional
+        List of switchback plan units.
     """
 
     start: datetime | None = None
@@ -151,7 +151,10 @@ class SwitchbackTestMetadata(BaseModel):
     """The current status of the switchback test."""
 
 
-class SwitchbackTest(SwitchbackTestMetadata):
+# This class uses some fields defined in SwitchbackTestMetadata. We are not
+# using inheritance to help the user understand the full structure when using
+# tools like intellisense.
+class SwitchbackTest(BaseModel):
     """
     A Nextmv Cloud switchback test definition.
 
@@ -167,16 +170,50 @@ class SwitchbackTest(SwitchbackTestMetadata):
 
     Parameters
     ----------
+    switchback_test_id : str, optional
+        The unique identifier of the switchback test.
+    name : str, optional
+        Name of the switchback test.
+    description : str, optional
+        Description of the switchback test.
+    app_id : str, optional
+        ID of the application to which the switchback test belongs.
+    created_at : datetime, optional
+        Creation date of the switchback test.
+    updated_at : datetime, optional
+        Last update date of the switchback test.
+    status : ExperimentStatus, optional
+        The current status of the switchback test.
+    started_at : datetime, optional
+        Start date of the switchback test, if applicable.
     completed_at : datetime, optional
         Completion date of the switchback test, if applicable.
     comparison : TestComparisonSingle, optional
         Test comparison defined in the switchback test.
-    start_events : StartEvents, optional
-        Start events for the switchback test.
-    termination_events : TerminationEvents, optional
-        Termination events for the switchback test.
+    plan : SwitchbackPlan, optional
+        Switchback plan defining the intervals and instance switching.
+    runs : list[Run], optional
+        List of runs in the switchback test.
     """
 
+    switchback_test_id: str | None = Field(
+        serialization_alias="id",
+        validation_alias=AliasChoices("id", "switchback_test_id"),
+        default=None,
+    )
+    """The unique identifier of the switchback test."""
+    name: str | None = None
+    """Name of the switchback test."""
+    description: str | None = None
+    """Description of the switchback test."""
+    app_id: str | None = None
+    """ID of the application to which the switchback test belongs."""
+    created_at: datetime | None = None
+    """Creation date of the switchback test."""
+    updated_at: datetime | None = None
+    """Last update date of the switchback test."""
+    status: ExperimentStatus | None = None
+    """The current status of the switchback test."""
     started_at: datetime | None = None
     """Start date of the switchback test, if applicable."""
     completed_at: datetime | None = None

--- a/nextmv/pyproject.toml
+++ b/nextmv/pyproject.toml
@@ -51,8 +51,8 @@ Documentation = "https://nextmv-py.docs.nextmv.io/en/latest/nextmv/"
 Repository = "https://github.com/nextmv-io/nextmv-py"
 
 # TODO: Uncomment when CLI is ready for general rollout.
-# [project.scripts]
-# nextmv = "nextmv.cli.main:main"
+[project.scripts]
+nextmv = "nextmv.cli.main:main"
 
 [project.optional-dependencies]
 all = [


### PR DESCRIPTION
# Description

My apologies, as this is a massive PR. It is the home stretch before bug bashing though 😅 .

- Enables the CLI when the library is installed, again.
- Adds methods for wrangling shadow tests to the `cloud.Application` class.
- Adds methods for wrangling switchback tests to the `cloud.Application` class.
- Adds the `nextmv cloud shadow` command tree with the following subcommands:
  - `create`
  - `delete`
  - `get`
  - `list`
  - `metadata`
  - `start`
  - `stop`
  - `update`
- Adds the `nextmv cloud switchback` command tree with the following subcommands:
  - `create`
  - `delete`
  - `get`
  - `list`
  - `metadata`
  - `start`
  - `stop`
  - `update` 