### PR TITLE
Improves contrast and styling for the CLI

### DIFF
--- a/nextmv/nextmv/cli/CONTRIBUTING.md
+++ b/nextmv/nextmv/cli/CONTRIBUTING.md
@@ -204,7 +204,7 @@ Use these Rich markup guidelines when formatting help text and messages.
 - When talking about a command, or a command option, use the `[code]` `[/code]`
   tags. Take this example from the help menu of the `cloud/app/delete.py` file.
   In the command help, when referring to the `--yes` option, we use
-  `[code]--yes[/code]` to format it as code.
+  `--yes` to format it as code.
 
   ```python
   @app.command()
@@ -223,7 +223,7 @@ Use these Rich markup guidelines when formatting help text and messages.
       """
       Deletes a Nextmv Cloud application.
 
-      This action is permanent and cannot be undone. Use the [code]--yes[/code]
+      This action is permanent and cannot be undone. Use the --yes
       flag to skip the confirmation prompt.
 
       [bold][underline]Examples[/underline][/bold]

--- a/nextmv/nextmv/cli/CONTRIBUTING.md
+++ b/nextmv/nextmv/cli/CONTRIBUTING.md
@@ -197,14 +197,63 @@ if not yes:
         return
 ```
 
-## Formatting
+## Formatting, colors, and styles
 
-Use these Rich markup guidelines when formatting help text and messages.
+Use these Rich markup colors/styles when formatting help text and messages.
+These are the main colors/styles that can be used for highlighting/contrast (we
+limit colors to keep coloring consistent):
 
-- When talking about a command, or a command option, use the `[code]` `[/code]`
-  tags. Take this example from the help menu of the `cloud/app/delete.py` file.
-  In the command help, when referring to the `--yes` option, we use
-  `--yes` to format it as code.
+- `[code]`: commands. CLI related variables. - technical things that are CLI
+  commands.
+- `[magenta]`: variable names, values, literals, etc. - mainly short technical things.
+- `[dim]`: examples. - longer technical things.
+- `[yellow]`: emphasis, highlight of special items, type contrast to
+  `[magenta]`. Use sparingly only.
+
+In any case, the best advice is to follow existing examples in the codebase to
+maintain consistency.
+
+Here are some guidelines for when to use each formatting style.
+
+- When talking about a command use the `[code]` `[/code]` tags. Consider the
+  help message of the `cloud/shadow/stop.py` file. We tell the user they can
+  delete an experiment with the `nextmv cloud shadow delete` command. The
+  formatting of that command is done using the `[code]` `[/code]` tags:
+
+  ```python
+  @app.command()
+  def stop(
+      app_id: AppIDOption,
+      shadow_test_id: ShadowTestIDOption,
+      profile: ProfileOption = None,
+  ) -> None:
+      """
+      Stops a Nextmv Cloud shadow test.
+
+      Before stopping a shadow test, it must be in a started state. Experiments
+      in a [magenta]draft[/magenta] state, that haven't started, can be deleted
+      with the [code]nextmv cloud shadow delete[/code] command.
+
+      [bold][underline]Examples[/underline][/bold]
+
+      - Stop the shadow test with the ID [magenta]hop-analysis[/magenta] from application
+        [magenta]hare-app[/magenta].
+          $ [dim]nextmv cloud shadow stop --app-id hare-app --shadow-test-id hop-analysis[/dim]
+      """
+
+      in_progress(msg="Stopping shadow test...")
+      cloud_app = build_app(app_id=app_id, profile=profile)
+      cloud_app.stop_shadow_test(shadow_test_id=shadow_test_id)
+      success(
+          f"Shadow test [magenta]{shadow_test_id}[/magenta] stopped successfully "
+          f"in application [magenta]{app_id}[/magenta]."
+      )
+  ```
+
+- When talking about a command option, there is no formatting needed. Typer
+  automatically adds coloring to options in the help menu. Take this example
+  from the help menu of the `cloud/app/delete.py` file. In the command help,
+  when referring to the `--yes` option:
 
   ```python
   @app.command()
@@ -229,10 +278,10 @@ Use these Rich markup guidelines when formatting help text and messages.
       [bold][underline]Examples[/underline][/bold]
 
       - Delete the application with the ID [magenta]hare-app[/magenta].
-          $ [green]nextmv cloud app delete --app-id hare-app[/green]
+          $ [dim]nextmv cloud app delete --app-id hare-app[/dim]
 
       - Delete the application with the ID [magenta]hare-app[/magenta] without confirmation prompt.
-          $ [green]nextmv cloud app delete --app-id hare-app --yes[/green]
+          $ [dim]nextmv cloud app delete --app-id hare-app --yes[/dim]
       """
   ```
 
@@ -245,6 +294,12 @@ Use these Rich markup guidelines when formatting help text and messages.
   ```python
   error(f"Input path [magenta]{input}[/magenta] does not exist.")
   ```
+
+- When talking about longer technical things, like examples for a command
+  usage, or examples of a JSON object, use the `[dim]` `[/dim]` tags. Consider
+  the examples section of the `cloud/app/delete.py` file above. The example
+  commands are formatted using the `[dim]` `[/dim]` tags. The `[dim]` tag is
+  discussed in more detail in the command documentation section below.
 
 - Links to URLs should be formatted using the `[link=URL_LINK][bold]
   [/bold][/link]` tags. Consider the main help message of the `nextmv
@@ -264,11 +319,6 @@ Use these Rich markup guidelines when formatting help text and messages.
 
   The link provided is <https://github.com/nextmv-io/community-apps>, and it will
   be applied to the text `nextmv-io/community-apps`.
-
-- Colors that can be used for highlighting (we limit colors to keep coloring consistent):
-  - `[magenta]`: variable, literals, etc. - mainly short technical things (see above).
-  - `[green]`: commands, etc. - longer technical things, or, as a type-contrast to magenta.
-  - `[yellow]`: emphasis, highlight of special items, etc. (use sparingly only).
 
 ## Command documentation
 
@@ -316,11 +366,11 @@ to use it.
       [bold][underline]Examples[/underline][/bold]
 
       - Get the application with the ID [magenta]hare-app[/magenta].
-          $ [green]nextmv cloud app get --app-id hare-app[/green]
+          $ [dim]nextmv cloud app get --app-id hare-app[/dim]
 
       - Get the application with the ID [magenta]hare-app[/magenta] and save the information to an
         [magenta]app.json[/magenta] file.
-          $ [green]nextmv cloud app get --app-id hare-app --output app.json[/green]
+          $ [dim]nextmv cloud app get --app-id hare-app --output app.json[/dim]
       """
 
       client = build_client(profile)
@@ -353,11 +403,10 @@ to use it.
 
   - The examples section is fenced with the `[bold][underline]
     [/underline][/bold]` tags.
-
   - Each example is listed as a bullet, using a hyphen (`-`).
   - Each example has a short description, followed by the command itself in a
     new line, with 4 spaces of indentation in comparison to where the hyphen is.
-  - The command itself should be formatted using the `[green]` `[/green]` tags.
+  - The command itself should be formatted using the `[dim]` `[/dim]` tags.
   - The command should start with a dollar sign (`$`), followed by a space, and
     then the actual command.
   - When an example command is too long, use a double backslash (`\\`) for line
@@ -366,8 +415,8 @@ to use it.
 
     ```text
     - Create an application with an ID and description.
-        $ [green]nextmv cloud app create --name "Hare App" --app-id hare-app \\
-            --description "An application for routing hares"[/green]
+        $ [dim]nextmv cloud app create --name "Hare App" --app-id hare-app \\
+            --description "An application for routing hares"[/dim]
     ```
 
 ## Command options

--- a/nextmv/nextmv/cli/cloud/acceptance/create.py
+++ b/nextmv/nextmv/cli/cloud/acceptance/create.py
@@ -55,7 +55,7 @@ app = typer.Typer()
     - [magenta]statistic[/magenta]: Statistical method. Allowed values: {enum_values(StatisticType)}.
 
     Object format:
-    [green]{{
+    [dim]{{
         "field": "field",
         "metric_type": "type",
         "params": {{
@@ -66,12 +66,12 @@ app = typer.Typer()
             }}
         }},
         "statistic": "statistic"
-    }}[/green]
+    }}[/dim]
 
     [bold][underline]Examples[/underline][/bold]
 
     - Create an acceptance test with a single metric.
-        $ [green]METRIC='{{
+        $ [dim]METRIC='{{
             "field": "solution.objective",
             "metric_type": "direct-comparison",
             "params": {{
@@ -82,10 +82,10 @@ app = typer.Typer()
         }}'
         nextmv cloud acceptance create --app-id hare-app --acceptance-test-id test-123 \\
             --candidate-instance-id candidate-123 --baseline-instance-id baseline-456 \\
-            --metrics "$METRIC" --input-set-id input-set-123[/green]
+            --metrics "$METRIC" --input-set-id input-set-123[/dim]
 
     - Create with multiple metrics by repeating the flag.
-        $ [green]METRIC1='{{
+        $ [dim]METRIC1='{{
             "field": "solution.objective",
             "metric_type": "direct-comparison",
             "params": {{
@@ -105,10 +105,10 @@ app = typer.Typer()
         }}'
         nextmv cloud acceptance create --app-id hare-app --acceptance-test-id test-123 \\
             --candidate-instance-id candidate-123 --baseline-instance-id baseline-456 \\
-            --metrics "$METRIC1" --metrics "$METRIC2" --input-set-id input-set-123[/green]
+            --metrics "$METRIC1" --metrics "$METRIC2" --input-set-id input-set-123[/dim]
 
     - Create with multiple metrics in a single [magenta]json[/magenta] array.
-        $ [green]METRICS='[
+        $ [dim]METRICS='[
             {{
                 "field": "solution.objective",
                 "metric_type": "direct-comparison",
@@ -130,10 +130,10 @@ app = typer.Typer()
         ]'
         nextmv cloud acceptance create --app-id hare-app --acceptance-test-id test-123 \\
             --candidate-instance-id candidate-123 --baseline-instance-id baseline-456 \\
-            --metrics "$METRICS" --input-set-id input-set-123[/green]
+            --metrics "$METRICS" --input-set-id input-set-123[/dim]
 
     - Create an acceptance test and wait for it to complete.
-        $ [green]METRIC='{{
+        $ [dim]METRIC='{{
             "field": "solution.objective",
             "metric_type": "direct-comparison",
             "params": {{
@@ -144,10 +144,10 @@ app = typer.Typer()
         }}'
         nextmv cloud acceptance create --app-id hare-app --acceptance-test-id test-123 \\
             --candidate-instance-id candidate-123 --baseline-instance-id baseline-456 \\
-            --metrics "$METRIC" --input-set-id input-set-123 --wait[/green]
+            --metrics "$METRIC" --input-set-id input-set-123 --wait[/dim]
 
     - Create an acceptance test and save the results to a file, waiting for completion.
-        $ [green]METRIC='{{
+        $ [dim]METRIC='{{
             "field": "solution.objective",
             "metric_type": "direct-comparison",
             "params": {{
@@ -158,7 +158,7 @@ app = typer.Typer()
         }}'
         nextmv cloud acceptance create --app-id hare-app --acceptance-test-id test-123 \\
             --candidate-instance-id candidate-123 --baseline-instance-id baseline-456 \\
-            --metrics "$METRIC" --input-set-id input-set-123 --output results.json[/green]
+            --metrics "$METRIC" --input-set-id input-set-123 --output results.json[/dim]
     """
 )
 def create(

--- a/nextmv/nextmv/cli/cloud/acceptance/create.py
+++ b/nextmv/nextmv/cli/cloud/acceptance/create.py
@@ -27,24 +27,22 @@ app = typer.Typer()
 
     The acceptance test is based on a batch experiment. If the batch experiment
     with the same ID already exists, it will be reused. Otherwise, you must
-    provide the [code]--input-set-id[/code] option to create a new batch
-    experiment.
+    provide the --input-set-id option to create a new batch experiment.
 
-    Use the [code]--wait[/code] flag to wait for the acceptance test to
-    complete, polling for results. Using the [code]--output[/code] flag will
-    also activate waiting, and allows you to specify a destination file for the
-    results.
+    Use the --wait flag to wait for the acceptance test to complete, polling
+    for results. Using the --output flag will also activate waiting, and allows
+    you to specify a destination file for the results.
 
     [bold][underline]Metrics[/underline][/bold]
 
     Metrics are provided as [magenta]json[/magenta] objects using the
-    [code]--metrics[/code] flag. Each metric defines how to compare the
+    --metrics flag. Each metric defines how to compare the
     candidate and baseline instances.
 
     You can provide metrics in three ways:
     - A single metric as a [magenta]json[/magenta] object.
-    - Multiple metrics by repeating the [code]--metrics[/code] flag.
-    - Multiple metrics as a [magenta]json[/magenta] array in a single [code]--metrics[/code] flag.
+    - Multiple metrics by repeating the --metrics flag.
+    - Multiple metrics as a [magenta]json[/magenta] array in a single --metrics flag.
 
     Each metric must have the following fields:
     - [magenta]field[/magenta]: Field of the metric to measure (e.g., "solution.objective").
@@ -265,7 +263,7 @@ def create(
             "--wait",
             "-w",
             help="Wait for the acceptance test to complete. Results are printed to [magenta]stdout[/magenta]. "
-            "Specify output location with [code]--output[/code].",
+            "Specify output location with --output.",
             rich_help_panel="Output control",
         ),
     ] = False,

--- a/nextmv/nextmv/cli/cloud/acceptance/delete.py
+++ b/nextmv/nextmv/cli/cloud/acceptance/delete.py
@@ -32,9 +32,9 @@ def delete(
     """
     Deletes a Nextmv Cloud acceptance test.
 
-    This action is permanent and cannot be undone. The underlying batch experiment
-    and associated data will also be deleted. Use the [code]--yes[/code] flag to skip
-    the confirmation prompt.
+    This action is permanent and cannot be undone. The underlying batch
+    experiment and associated data will also be deleted. Use the --yes flag to
+    skip the confirmation prompt.
 
     [bold][underline]Examples[/underline][/bold]
 

--- a/nextmv/nextmv/cli/cloud/acceptance/delete.py
+++ b/nextmv/nextmv/cli/cloud/acceptance/delete.py
@@ -40,10 +40,10 @@ def delete(
 
     - Delete the acceptance test with the ID [magenta]test-cotton-tail[/magenta] from application
       [magenta]hare-app[/magenta].
-        $ [green]nextmv cloud acceptance delete --app-id hare-app --acceptance-test-id test-cotton-tail[/green]
+        $ [dim]nextmv cloud acceptance delete --app-id hare-app --acceptance-test-id test-cotton-tail[/dim]
 
     - Delete the acceptance test without confirmation prompt.
-        $ [green]nextmv cloud acceptance delete --app-id hare-app --acceptance-test-id test-cotton-tail --yes[/green]
+        $ [dim]nextmv cloud acceptance delete --app-id hare-app --acceptance-test-id test-cotton-tail --yes[/dim]
     """
 
     if not yes:

--- a/nextmv/nextmv/cli/cloud/acceptance/get.py
+++ b/nextmv/nextmv/cli/cloud/acceptance/get.py
@@ -42,7 +42,7 @@ def get(
             "--wait",
             "-w",
             help="Wait for the acceptance test to complete. Results are printed to [magenta]stdout[/magenta]. "
-            "Specify output location with [code]--output[/code].",
+            "Specify output location with --output.",
         ),
     ] = False,
     profile: ProfileOption = None,
@@ -50,10 +50,9 @@ def get(
     """
     Get a Nextmv Cloud acceptance test.
 
-    Use the [code]--wait[/code] flag to wait for the acceptance test to
-    complete, polling for results. Using the [code]--output[/code] flag will
-    also activate waiting, and allows you to specify a destination file for the
-    results.
+    Use the --wait flag to wait for the acceptance test to complete, polling
+    for results. Using the --output flag will also activate waiting, and allows
+    you to specify a destination file for the results.
 
     [bold][underline]Examples[/underline][/bold]
 

--- a/nextmv/nextmv/cli/cloud/acceptance/get.py
+++ b/nextmv/nextmv/cli/cloud/acceptance/get.py
@@ -58,17 +58,17 @@ def get(
 
     - Get the acceptance test with ID [magenta]test-123[/magenta] from application
       [magenta]hare-app[/magenta].
-        $ [green]nextmv cloud acceptance get --app-id hare-app --acceptance-test-id test-123[/green]
+        $ [dim]nextmv cloud acceptance get --app-id hare-app --acceptance-test-id test-123[/dim]
 
     - Get the acceptance test and wait for it to complete if necessary.
-        $ [green]nextmv cloud acceptance get --app-id hare-app --acceptance-test-id test-123 --wait[/green]
+        $ [dim]nextmv cloud acceptance get --app-id hare-app --acceptance-test-id test-123 --wait[/dim]
 
     - Get the acceptance test and save the results to a file.
-        $ [green]nextmv cloud acceptance get --app-id hare-app \\
-            --acceptance-test-id test-123 --output results.json[/green]
+        $ [dim]nextmv cloud acceptance get --app-id hare-app \\
+            --acceptance-test-id test-123 --output results.json[/dim]
 
     - Get the acceptance test using a specific profile.
-        $ [green]nextmv cloud acceptance get --app-id hare-app --acceptance-test-id test-123 --profile prod[/green]
+        $ [dim]nextmv cloud acceptance get --app-id hare-app --acceptance-test-id test-123 --profile prod[/dim]
     """
 
     cloud_app = build_app(app_id=app_id, profile=profile)

--- a/nextmv/nextmv/cli/cloud/acceptance/list.py
+++ b/nextmv/nextmv/cli/cloud/acceptance/list.py
@@ -38,13 +38,13 @@ def list(
     [bold][underline]Examples[/underline][/bold]
 
     - List all acceptance tests for application [magenta]hare-app[/magenta].
-        $ [green]nextmv cloud acceptance list --app-id hare-app[/green]
+        $ [dim]nextmv cloud acceptance list --app-id hare-app[/dim]
 
     - List all acceptance tests and save to a file.
-        $ [green]nextmv cloud acceptance list --app-id hare-app --output tests.json[/green]
+        $ [dim]nextmv cloud acceptance list --app-id hare-app --output tests.json[/dim]
 
     - List all acceptance tests using a specific profile.
-        $ [green]nextmv cloud acceptance list --app-id hare-app --profile prod[/green]
+        $ [dim]nextmv cloud acceptance list --app-id hare-app --profile prod[/dim]
     """
 
     cloud_app = build_app(app_id=app_id, profile=profile)

--- a/nextmv/nextmv/cli/cloud/acceptance/update.py
+++ b/nextmv/nextmv/cli/cloud/acceptance/update.py
@@ -57,17 +57,17 @@ def update(
     [bold][underline]Examples[/underline][/bold]
 
     - Update the name of an acceptance test.
-        $ [green]nextmv cloud acceptance update --app-id hare-app \\
-            --acceptance-test-id test-123 --name "Updated Test Name"[/green]
+        $ [dim]nextmv cloud acceptance update --app-id hare-app \\
+            --acceptance-test-id test-123 --name "Updated Test Name"[/dim]
 
     - Update the description of an acceptance test.
-        $ [green]nextmv cloud acceptance update --app-id hare-app \\
-            --acceptance-test-id test-123 --description "Updated description"[/green]
+        $ [dim]nextmv cloud acceptance update --app-id hare-app \\
+            --acceptance-test-id test-123 --description "Updated description"[/dim]
 
     - Update both name and description and save the result.
-        $ [green]nextmv cloud acceptance update --app-id hare-app \\
+        $ [dim]nextmv cloud acceptance update --app-id hare-app \\
             --acceptance-test-id test-123 --name "New Name" \\
-            --description "New description" --output updated-test.json[/green]
+            --description "New description" --output updated-test.json[/dim]
     """
 
     cloud_app = build_app(app_id=app_id, profile=profile)

--- a/nextmv/nextmv/cli/cloud/account/create.py
+++ b/nextmv/nextmv/cli/cloud/account/create.py
@@ -45,8 +45,8 @@ def create(
     Please contact [link=https://www.nextmv.io/contact][bold]Nextmv support[/bold][/link] for assistance.
 
     At least one administrator email address must be provided. Multiple
-    administrators can be specified by repeating the [code]--admins[/code] flag
-    or by separating email addresses with commas.
+    administrators can be specified by repeating the --admins flag or by
+    separating email addresses with commas.
 
     [bold][underline]Examples[/underline][/bold]
 

--- a/nextmv/nextmv/cli/cloud/account/create.py
+++ b/nextmv/nextmv/cli/cloud/account/create.py
@@ -51,20 +51,20 @@ def create(
     [bold][underline]Examples[/underline][/bold]
 
     - Create an account named [magenta]Bunny Logistics[/magenta] with a single administrator.
-        $ [green]nextmv cloud account create --name "Bunny Logistics" \\
-            --admins peter.rabbit@carrotexpress.com[/green]
+        $ [dim]nextmv cloud account create --name "Bunny Logistics" \\
+            --admins peter.rabbit@carrotexpress.com[/dim]
 
     - Create an account named [magenta]Hare Delivery Co[/magenta] with multiple administrators.
-        $ [green]nextmv cloud account create --name "Hare Delivery Co" \\
-            --admins bugs@acme.com --admins roger@toontown.com[/green]
+        $ [dim]nextmv cloud account create --name "Hare Delivery Co" \\
+            --admins bugs@acme.com --admins roger@toontown.com[/dim]
 
     - Create an account using the profile named [magenta]hare[/magenta].
-        $ [green]nextmv cloud account create --name "Cottontail Couriers" \\
-            --admins fluffy@hopmail.com --profile hare[/green]
+        $ [dim]nextmv cloud account create --name "Cottontail Couriers" \\
+            --admins fluffy@hopmail.com --profile hare[/dim]
 
     - Create an account with comma-separated administrators.
-        $ [green]nextmv cloud account create --name "Whiskers Warehouse" \\
-            --admins "thumper@forestmail.com,flopsy@warren.io"[/green]
+        $ [dim]nextmv cloud account create --name "Whiskers Warehouse" \\
+            --admins "thumper@forestmail.com,flopsy@warren.io"[/dim]
     """
 
     cloud_client = build_client(profile)

--- a/nextmv/nextmv/cli/cloud/account/delete.py
+++ b/nextmv/nextmv/cli/cloud/account/delete.py
@@ -33,7 +33,7 @@ def delete(
 
     You must have the [magenta]administrator[/magenta] role on that account in order to delete it.
 
-    This action is permanent and cannot be undone. Use the [code]--yes[/code]
+    This action is permanent and cannot be undone. Use the --yes
     flag to skip the confirmation prompt.
 
     [bold][underline]Examples[/underline][/bold]

--- a/nextmv/nextmv/cli/cloud/account/delete.py
+++ b/nextmv/nextmv/cli/cloud/account/delete.py
@@ -39,10 +39,10 @@ def delete(
     [bold][underline]Examples[/underline][/bold]
 
     - Delete the account with the ID [magenta]bunnies-account[/magenta].
-        $ [green]nextmv cloud account delete --account-id bunnies-account[/green]
+        $ [dim]nextmv cloud account delete --account-id bunnies-account[/dim]
 
     - Delete the account without confirmation prompt.
-        $ [green]nextmv cloud account delete --account-id bunnies-account --yes[/green]
+        $ [dim]nextmv cloud account delete --account-id bunnies-account --yes[/dim]
     """
 
     if not yes:

--- a/nextmv/nextmv/cli/cloud/account/get.py
+++ b/nextmv/nextmv/cli/cloud/account/get.py
@@ -39,11 +39,11 @@ def get(
     [bold][underline]Examples[/underline][/bold]
 
     - Get the account with the ID [magenta]bunny-logistics[/magenta].
-        $ [green]nextmv cloud account get --account-id bunny-logistics[/green]
+        $ [dim]nextmv cloud account get --account-id bunny-logistics[/dim]
 
     - Get the account with the ID [magenta]cottontail-couriers[/magenta] and save the information to an
       [magenta]account.json[/magenta] file.
-        $ [green]nextmv cloud account get --account-id cottontail-couriers --output account.json[/green]
+        $ [dim]nextmv cloud account get --account-id cottontail-couriers --output account.json[/dim]
     """
 
     client = build_client(profile)

--- a/nextmv/nextmv/cli/cloud/account/update.py
+++ b/nextmv/nextmv/cli/cloud/account/update.py
@@ -46,12 +46,12 @@ def update(
     [bold][underline]Examples[/underline][/bold]
 
     - Update the account named [magenta]hare-delivery[/magenta] to [magenta]Hare Delivery Co[/magenta].
-        $ [green]nextmv cloud account update --account-id hare-delivery \\
-            --name "Hare Delivery Co"[/green]
+        $ [dim]nextmv cloud account update --account-id hare-delivery \\
+            --name "Hare Delivery Co"[/dim]
 
     - Update an account and save the updated information to an [magenta]updated_account.json[/magenta] file.
-        $ [green]nextmv cloud account update --account-id cottontail-couriers \\
-            --name "Cottontail Express" --output updated_account.json[/green]
+        $ [dim]nextmv cloud account update --account-id cottontail-couriers \\
+            --name "Cottontail Express" --output updated_account.json[/dim]
     """
 
     cloud_account = build_account(account_id=account_id, profile=profile)

--- a/nextmv/nextmv/cli/cloud/app/create.py
+++ b/nextmv/nextmv/cli/cloud/app/create.py
@@ -84,14 +84,13 @@ def create(
     """
     Create a new Nextmv Cloud application.
 
-    Use the [code]--exist-ok[/code] flag to avoid errors when creating an
-    application with an ID that already exists. This is useful for scripts that
-    need to ensure an application exists without worrying about whether it was
-    created previously.
+    Use the --exist-ok flag to avoid errors when creating an application with
+    an ID that already exists. This is useful for scripts that need to ensure
+    an application exists without worrying about whether it was created
+    previously.
 
-    An application can be marked as a workflow using the
-    [code]--is-workflow[/code] flag. Workflows allow for more complex
-    decision-making processes by leveraging
+    An application can be marked as a workflow using the --is-workflow flag.
+    Workflows allow for more complex decision-making processes by leveraging
     [link=https://github.com/nextmv-io/nextpipe][bold]Nextpipe[/bold][/link] to
     orchestrate multiple decision models.
 

--- a/nextmv/nextmv/cli/cloud/app/create.py
+++ b/nextmv/nextmv/cli/cloud/app/create.py
@@ -97,28 +97,28 @@ def create(
     [bold][underline]Examples[/underline][/bold]
 
     - Create an application with the name [magenta]Hare App[/magenta]. A random ID will be generated.
-        $ [green]nextmv cloud app create --name "Hare App"[/green]
+        $ [dim]nextmv cloud app create --name "Hare App"[/dim]
 
     - Create an application with the specific ID [magenta]hare-app[/magenta].
-        $ [green]nextmv cloud app create --name "Hare App" --app-id hare-app[/green]
+        $ [dim]nextmv cloud app create --name "Hare App" --app-id hare-app[/dim]
 
     - Create an application with an ID and description.
-        $ [green]nextmv cloud app create --name "Hare App" --app-id hare-app \\
-            --description "An application for routing hares"[/green]
+        $ [dim]nextmv cloud app create --name "Hare App" --app-id hare-app \\
+            --description "An application for routing hares"[/dim]
 
     - Create an application, or get it if it already exists.
-        $ [green]nextmv cloud app create --name "Hare App" --app-id hare-app --exist-ok[/green]
+        $ [dim]nextmv cloud app create --name "Hare App" --app-id hare-app --exist-ok[/dim]
 
     - Create a workflow application.
-        $ [green]nextmv cloud app create --name "Hare Workflow" --app-id hare-workflow --is-workflow[/green]
+        $ [dim]nextmv cloud app create --name "Hare Workflow" --app-id hare-workflow --is-workflow[/dim]
 
     - Create an application with a default instance ID.
-        $ [green]nextmv cloud app create --name "Hare App" --app-id hare-app \\
-            --default-instance-id burrow[/green]
+        $ [dim]nextmv cloud app create --name "Hare App" --app-id hare-app \\
+            --default-instance-id burrow[/dim]
 
     - Create an application with a default experiment instance.
-        $ [green]nextmv cloud app create --name "Hare App" --app-id hare-app \\
-            --default-experiment-instance experiment-v1[/green]
+        $ [dim]nextmv cloud app create --name "Hare App" --app-id hare-app \\
+            --default-experiment-instance experiment-v1[/dim]
     """
 
     client = build_client(profile)

--- a/nextmv/nextmv/cli/cloud/app/delete.py
+++ b/nextmv/nextmv/cli/cloud/app/delete.py
@@ -31,7 +31,7 @@ def delete(
     """
     Deletes a Nextmv Cloud application.
 
-    This action is permanent and cannot be undone. Use the [code]--yes[/code]
+    This action is permanent and cannot be undone. Use the --yes
     flag to skip the confirmation prompt.
 
     [bold][underline]Examples[/underline][/bold]

--- a/nextmv/nextmv/cli/cloud/app/delete.py
+++ b/nextmv/nextmv/cli/cloud/app/delete.py
@@ -37,10 +37,10 @@ def delete(
     [bold][underline]Examples[/underline][/bold]
 
     - Delete the application with the ID [magenta]hare-app[/magenta].
-        $ [green]nextmv cloud app delete --app-id hare-app[/green]
+        $ [dim]nextmv cloud app delete --app-id hare-app[/dim]
 
     - Delete the application with the ID [magenta]hare-app[/magenta] without confirmation prompt.
-        $ [green]nextmv cloud app delete --app-id hare-app --yes[/green]
+        $ [dim]nextmv cloud app delete --app-id hare-app --yes[/dim]
     """
 
     if not yes:

--- a/nextmv/nextmv/cli/cloud/app/exists.py
+++ b/nextmv/nextmv/cli/cloud/app/exists.py
@@ -27,11 +27,11 @@ def exists(
     [bold][underline]Examples[/underline][/bold]
 
     - Check if the application with the ID [magenta]hare-app[/magenta] exists.
-        $ [green]nextmv cloud app exists --app-id hare-app[/green]
+        $ [dim]nextmv cloud app exists --app-id hare-app[/dim]
 
     - Check if the application with the ID [magenta]hare-app[/magenta] exists.
       Use the profile named [magenta]hare[/magenta].
-        $ [green]nextmv cloud app exists --app-id hare-app --profile hare[/green]
+        $ [dim]nextmv cloud app exists --app-id hare-app --profile hare[/dim]
     """
 
     client = build_client(profile)

--- a/nextmv/nextmv/cli/cloud/app/get.py
+++ b/nextmv/nextmv/cli/cloud/app/get.py
@@ -39,11 +39,11 @@ def get(
     [bold][underline]Examples[/underline][/bold]
 
     - Get the application with the ID [magenta]hare-app[/magenta].
-        $ [green]nextmv cloud app get --app-id hare-app[/green]
+        $ [dim]nextmv cloud app get --app-id hare-app[/dim]
 
     - Get the application with the ID [magenta]hare-app[/magenta] and save the information to an
       [magenta]app.json[/magenta] file.
-        $ [green]nextmv cloud app get --app-id hare-app --output app.json[/green]
+        $ [dim]nextmv cloud app get --app-id hare-app --output app.json[/dim]
     """
 
     client = build_client(profile)

--- a/nextmv/nextmv/cli/cloud/app/list.py
+++ b/nextmv/nextmv/cli/cloud/app/list.py
@@ -35,13 +35,13 @@ def list(
     [bold][underline]Examples[/underline][/bold]
 
     - List all applications.
-        $ [green]nextmv cloud app list[/green]
+        $ [dim]nextmv cloud app list[/dim]
 
     - List all applications using the profile named [magenta]hare[/magenta].
-        $ [green]nextmv cloud app list --profile hare[/green]
+        $ [dim]nextmv cloud app list --profile hare[/dim]
 
     - List all applications and save the information to an [magenta]apps.json[/magenta] file.
-        $ [green]nextmv cloud app list --output apps.json[/green]
+        $ [dim]nextmv cloud app list --output apps.json[/dim]
     """
 
     client = build_client(profile)

--- a/nextmv/nextmv/cli/cloud/app/push.py
+++ b/nextmv/nextmv/cli/cloud/app/push.py
@@ -97,29 +97,29 @@ def push(
     [bold][underline]Examples[/underline][/bold]
 
     - Push an application, with ID [magenta]hare-app[/magenta], from the current directory.
-        $ [green]nextmv cloud app push --app-id hare-app[/green]
+        $ [dim]nextmv cloud app push --app-id hare-app[/dim]
 
     - Push an application, with ID [magenta]hare-app[/magenta], from the [magenta]./my-app[/magenta] directory.
-        $ [green]nextmv cloud app push --app-id hare-app --app-dir ./my-app[/green]
+        $ [dim]nextmv cloud app push --app-id hare-app --app-dir ./my-app[/dim]
 
     - Push an application, with ID [magenta]hare-app[/magenta], using a custom manifest file.
-        $ [green]nextmv cloud app push --app-id hare-app --manifest ./custom-manifest.yaml[/green]
+        $ [dim]nextmv cloud app push --app-id hare-app --manifest ./custom-manifest.yaml[/dim]
 
     - Push an application, with ID [magenta]hare-app[/magenta], from a specific
       [magenta]./my-app[/magenta] directory with a custom manifest under [magenta]./custom-manifest.yaml[/magenta].
-        $ [green]nextmv cloud app push --app-id hare-app --app-dir ./my-app \\
-            --manifest ./custom-manifest.yaml[/green]
+        $ [dim]nextmv cloud app push --app-id hare-app --app-dir ./my-app \\
+            --manifest ./custom-manifest.yaml[/dim]
 
     - Push an application without creating a new version.
-        $ [green]nextmv cloud app push --app-id hare-app --no-version[/green]
+        $ [dim]nextmv cloud app push --app-id hare-app --no-version[/dim]
 
     - Push an application with a custom version ID.
-        $ [green]nextmv cloud app push --app-id hare-app --version-id v1.0.0[/green]
+        $ [dim]nextmv cloud app push --app-id hare-app --version-id v1.0.0[/dim]
 
     - Push an application with custom version ID, name, and description.
-        $ [green]nextmv cloud app push --app-id hare-app --version-id v1.0.0 \\
+        $ [dim]nextmv cloud app push --app-id hare-app --version-id v1.0.0 \\
             --version-name "Release 1.0.0" \\
-            --version-description "First stable release"[/green]
+            --version-description "First stable release"[/dim]
     """
 
     cloud_app = build_app(app_id=app_id, profile=profile)

--- a/nextmv/nextmv/cli/cloud/app/push.py
+++ b/nextmv/nextmv/cli/cloud/app/push.py
@@ -80,18 +80,17 @@ def push(
     """
     Push (deploy) a Nextmv application to Nextmv Cloud.
 
-    Use the [code]--app-dir[/code] option to specify the path to your
-    application's root directory. By default, the current working directory is
-    used.
+    Use the --app-dir option to specify the path to your application's root
+    directory. By default, the current working directory is used.
 
-    You can also provide a custom manifest file using the [code]--manifest[/code]
-    option. If not provided, the CLI will look for a file named [magenta]app.yaml[/magenta]
-    in the application's root.
+    You can also provide a custom manifest file using the --manifest option. If
+    not provided, the CLI will look for a file named
+    [magenta]app.yaml[/magenta] in the application's root.
 
     The default behavior of this command is to create a new application version
     [italic]after[/italic] the app has been pushed. You can use the
-    [code]--no-version[/code] option to skip this step. The
-    [code]--version-...[/code] options allow you to customize the attributes of
+    --no-version option to skip this step. The --version-id, --version-name,
+    and --version-description options allow you to customize the attributes of
     the version that is created. If any of these options are not provided,
     automatically generated values will be used.
 

--- a/nextmv/nextmv/cli/cloud/app/update.py
+++ b/nextmv/nextmv/cli/cloud/app/update.py
@@ -99,8 +99,8 @@ def update(
 
     if name is None and description is None and default_instance_id is None and default_experiment_instance is None:
         error(
-            "Provide at least one option to update: [code]--name[/code], [code]--description[/code], "
-            "[code]--default-instance-id[/code], or [code]--default-experiment-instance[/code]."
+            "Provide at least one option to update: --name, --description, "
+            "--default-instance-id, or --default-experiment-instance."
         )
 
     cloud_app = build_app(app_id=app_id, profile=profile)

--- a/nextmv/nextmv/cli/cloud/app/update.py
+++ b/nextmv/nextmv/cli/cloud/app/update.py
@@ -74,27 +74,27 @@ def update(
     [bold][underline]Examples[/underline][/bold]
 
     - Update an application's name.
-        $ [green]nextmv cloud app update --app-id hare-app --name "New Hare App"[/green]
+        $ [dim]nextmv cloud app update --app-id hare-app --name "New Hare App"[/dim]
 
     - Update an application's description.
-        $ [green]nextmv cloud app update --app-id hare-app --name "Hare App" \\
-            --description "An updated description for routing hares"[/green]
+        $ [dim]nextmv cloud app update --app-id hare-app --name "Hare App" \\
+            --description "An updated description for routing hares"[/dim]
 
     - Update an application's default instance ID.
-        $ [green]nextmv cloud app update --app-id hare-app --name "Hare App" \\
-            --default-instance-id burrow[/green]
+        $ [dim]nextmv cloud app update --app-id hare-app --name "Hare App" \\
+            --default-instance-id burrow[/dim]
 
     - Update an application's default experiment instance.
-        $ [green]nextmv cloud app update --app-id hare-app --name "Hare App" \\
-            --default-experiment-instance experiment-v1[/green]
+        $ [dim]nextmv cloud app update --app-id hare-app --name "Hare App" \\
+            --default-experiment-instance experiment-v1[/dim]
 
     - Update multiple application properties at once.
-        $ [green]nextmv cloud app update --app-id hare-app --name "Hare App" \\
+        $ [dim]nextmv cloud app update --app-id hare-app --name "Hare App" \\
             --description "Updated description" --default-instance-id burrow \\
-            --default-experiment-instance experiment-v1[/green]
+            --default-experiment-instance experiment-v1[/dim]
 
     - Update an application and save the updated information to an [magenta]updated_app.json[/magenta] file.
-        $ [green]nextmv cloud app update --app-id hare-app --name "New Hare App" --output updated_app.json[/green]
+        $ [dim]nextmv cloud app update --app-id hare-app --name "New Hare App" --output updated_app.json[/dim]
     """
 
     if name is None and description is None and default_instance_id is None and default_experiment_instance is None:

--- a/nextmv/nextmv/cli/cloud/batch/create.py
+++ b/nextmv/nextmv/cli/cloud/batch/create.py
@@ -109,7 +109,7 @@ def create(
             "--wait",
             "-w",
             help="Wait for the batch experiment to complete. Results are printed to [magenta]stdout[/magenta]. "
-            "Specify output location with [code]--output[/code].",
+            "Specify output location with --output.",
             rich_help_panel="Output control",
         ),
     ] = False,
@@ -122,21 +122,19 @@ def create(
     configurations. Each run is defined by a combination of input, instance or
     version, and optional configuration options.
 
-    Use the [code]--wait[/code] flag to wait for the batch experiment to
-    complete, polling for results. Using the [code]--output[/code] flag will
-    also activate waiting, and allows you to specify a destination file for the
-    results.
+    Use the --wait flag to wait for the batch experiment to complete, polling
+    for results. Using the --output flag will also activate waiting, and allows
+    you to specify a destination file for the results.
 
     [bold][underline]Runs[/underline][/bold]
 
-    Runs are provided as [magenta]json[/magenta] objects using the
-    [code]--runs[/code] flag. Each run defines what input, instance/version,
-    and configuration to use.
+    Runs are provided as [magenta]json[/magenta] objects using the --runs flag.
+    Each run defines what input, instance/version, and configuration to use.
 
     You can provide runs in three ways:
     - A single run as a [magenta]json[/magenta] object.
-    - Multiple runs by repeating the [code]--runs[/code] flag.
-    - Multiple runs as a [magenta]json[/magenta] array in a single [code]--runs[/code] flag.
+    - Multiple runs by repeating the --runs flag.
+    - Multiple runs as a [magenta]json[/magenta] array in a single --runs flag.
 
     Each run must have the following fields:
     - [magenta]input_id[/magenta]: ID of the input to use for this run
@@ -146,7 +144,7 @@ def create(
     - [magenta]instance_id[/magenta] OR [magenta]version_id[/magenta]: Either an instance ID or
       version ID must be provided (at least one required).
     - [magenta]option_set[/magenta]: ID of the option set to use (optional).
-      Make sure to define the option sets using the [code]--option-sets[/code] flag.
+      Make sure to define the option sets using the --option-sets flag.
     - [magenta]input_set_id[/magenta]: ID of the input set (optional).
     - [magenta]scenario_id[/magenta]: Scenario ID if part of a scenario test (optional).
     - [magenta]repetition[/magenta]: Repetition number (optional).
@@ -162,7 +160,7 @@ def create(
     [bold][underline]Option Sets[/underline][/bold]
 
     Option sets are provided as a [magenta]json[/magenta] object using the
-    [code]--option-sets[/code] flag. Option sets define named collections of
+    --option-sets flag. Option sets define named collections of
     runtime options that can be referenced by runs.
 
     The option sets object is a dictionary where keys are option set IDs and

--- a/nextmv/nextmv/cli/cloud/batch/create.py
+++ b/nextmv/nextmv/cli/cloud/batch/create.py
@@ -150,12 +150,12 @@ def create(
     - [magenta]repetition[/magenta]: Repetition number (optional).
 
     Object format:
-    [green]{
+    [dim]{
         "input_id": "meadow-input-a1",
         "instance_id": "bunny-hopper-v2",
         "option_set": "speed-optimized",
         "input_set_id": "spring-gardens"
-    }[/green]
+    }[/dim]
 
     [bold][underline]Option Sets[/underline][/bold]
 
@@ -167,23 +167,23 @@ def create(
     values are dictionaries of string key-value pairs representing the options.
 
     Object format:
-    [green]{
+    [dim]{
         "speed-optimized": {"timeout": "30", "algorithm": "fast"},
         "quality-focused": {"timeout": "300", "algorithm": "thorough"}
-    }[/green]
+    }[/dim]
 
     [bold][underline]Examples[/underline][/bold]
 
     - Create a batch experiment with a single run.
-        $ [green]RUN='{
+        $ [dim]RUN='{
             "input_id": "carrot-patch-a",
             "instance_id": "warren-planner-v1"
         }'
         nextmv cloud batch create --app-id hare-app --batch-experiment-id bunny-hop-test \\
-            --name "Spring Meadow Routes" --input-set-id spring-gardens --runs "$RUN"[/green]
+            --name "Spring Meadow Routes" --input-set-id spring-gardens --runs "$RUN"[/dim]
 
     - Create with multiple runs by repeating the flag.
-        $ [green]RUN1='{
+        $ [dim]RUN1='{
             "input_id": "lettuce-field-1",
             "instance_id": "hop-optimizer"
         }'
@@ -193,10 +193,10 @@ def create(
         }'
         nextmv cloud batch create --app-id hare-app --batch-experiment-id lettuce-routes \\
             --name "Lettuce Delivery Optimization" --input-set-id veggie-gardens \\
-            --runs "$RUN1" --runs "$RUN2"[/green]
+            --runs "$RUN1" --runs "$RUN2"[/dim]
 
     - Create with multiple runs in a single [magenta]json[/magenta] array.
-        $ [green]RUNS='[
+        $ [dim]RUNS='[
             {
                 "input_id": "warren-zone-a",
                 "instance_id": "burrow-builder"
@@ -207,28 +207,28 @@ def create(
             }
         ]'
         nextmv cloud batch create --app-id hare-app --batch-experiment-id warren-expansion \\
-            --name "Warren Construction Plans" --input-set-id burrow-sites --runs "$RUNS"[/green]
+            --name "Warren Construction Plans" --input-set-id burrow-sites --runs "$RUNS"[/dim]
 
     - Create a batch experiment and wait for it to complete.
-        $ [green]RUN='{
+        $ [dim]RUN='{
             "input_id": "carrot-harvest",
             "instance_id": "foraging-route"
         }'
         nextmv cloud batch create --app-id hare-app --batch-experiment-id harvest-time \\
             --name "Autumn Carrot Collection" --input-set-id harvest-season \\
-            --runs "$RUN" --wait[/green]
+            --runs "$RUN" --wait[/dim]
 
     - Create a batch experiment and save the results to a file, waiting for completion.
-        $ [green]RUN='{
+        $ [dim]RUN='{
             "input_id": "predator-zones",
             "instance_id": "safe-hopper"
         }'
         nextmv cloud batch create --app-id hare-app --batch-experiment-id safety-analysis \\
             --name "Fox Avoidance Routes" --input-set-id danger-zones \\
-            --runs "$RUN" --output bunny-safety-results.json[/green]
+            --runs "$RUN" --output bunny-safety-results.json[/dim]
 
     - Create a batch experiment with option sets.
-        $ [green]RUN1='{
+        $ [dim]RUN1='{
             "input_id": "garden-route-1",
             "instance_id": "hop-optimizer",
             "option_set": "fast-hops"
@@ -244,7 +244,7 @@ def create(
         }'
         nextmv cloud batch create --app-id hare-app --batch-experiment-id hop-comparison \\
             --name "Speed vs Safety Analysis" --input-set-id garden-paths \\
-            --runs "$RUN1" --runs "$RUN2" --option-sets "$OPTION_SETS"[/green]
+            --runs "$RUN1" --runs "$RUN2" --option-sets "$OPTION_SETS"[/dim]
     """
 
     cloud_app = build_app(app_id=app_id, profile=profile)

--- a/nextmv/nextmv/cli/cloud/batch/delete.py
+++ b/nextmv/nextmv/cli/cloud/batch/delete.py
@@ -40,10 +40,10 @@ def delete(
 
     - Delete the batch experiment with the ID [magenta]hop-analysis[/magenta] from application
       [magenta]hare-app[/magenta].
-        $ [green]nextmv cloud batch delete --app-id hare-app --batch-experiment-id hop-analysis[/green]
+        $ [dim]nextmv cloud batch delete --app-id hare-app --batch-experiment-id hop-analysis[/dim]
 
     - Delete the batch experiment without confirmation prompt.
-        $ [green]nextmv cloud batch delete --app-id hare-app --batch-experiment-id carrot-routes --yes[/green]
+        $ [dim]nextmv cloud batch delete --app-id hare-app --batch-experiment-id carrot-routes --yes[/dim]
     """
 
     if not yes:

--- a/nextmv/nextmv/cli/cloud/batch/delete.py
+++ b/nextmv/nextmv/cli/cloud/batch/delete.py
@@ -33,7 +33,7 @@ def delete(
     Deletes a Nextmv Cloud batch experiment.
 
     This action is permanent and cannot be undone. The batch experiment and all
-    associated data, including runs, will be deleted. Use the [code]--yes[/code]
+    associated data, including runs, will be deleted. Use the --yes
     flag to skip the confirmation prompt.
 
     [bold][underline]Examples[/underline][/bold]

--- a/nextmv/nextmv/cli/cloud/batch/get.py
+++ b/nextmv/nextmv/cli/cloud/batch/get.py
@@ -59,17 +59,17 @@ def get(
 
     - Get the batch experiment with ID [magenta]carrot-optimization[/magenta] from application
       [magenta]hare-app[/magenta].
-        $ [green]nextmv cloud batch get --app-id hare-app --batch-experiment-id carrot-optimization[/green]
+        $ [dim]nextmv cloud batch get --app-id hare-app --batch-experiment-id carrot-optimization[/dim]
 
     - Get the batch experiment and wait for it to complete if necessary.
-        $ [green]nextmv cloud batch get --app-id hare-app --batch-experiment-id bunny-hop-test --wait[/green]
+        $ [dim]nextmv cloud batch get --app-id hare-app --batch-experiment-id bunny-hop-test --wait[/dim]
 
     - Get the batch experiment and save the results to a file.
-        $ [green]nextmv cloud batch get --app-id hare-app --batch-experiment-id warren-planning \\
-            --output results.json[/green]
+        $ [dim]nextmv cloud batch get --app-id hare-app --batch-experiment-id warren-planning \\
+            --output results.json[/dim]
 
     - Get the batch experiment using a specific profile.
-        $ [green]nextmv cloud batch get --app-id hare-app --batch-experiment-id lettuce-routes --profile prod[/green]
+        $ [dim]nextmv cloud batch get --app-id hare-app --batch-experiment-id lettuce-routes --profile prod[/dim]
     """
 
     cloud_app = build_app(app_id=app_id, profile=profile)

--- a/nextmv/nextmv/cli/cloud/batch/get.py
+++ b/nextmv/nextmv/cli/cloud/batch/get.py
@@ -42,7 +42,7 @@ def get(
             "--wait",
             "-w",
             help="Wait for the batch experiment to complete. Results are printed to [magenta]stdout[/magenta]. "
-            "Specify output location with [code]--output[/code].",
+            "Specify output location with --output.",
         ),
     ] = False,
     profile: ProfileOption = None,
@@ -50,8 +50,8 @@ def get(
     """
     Get a Nextmv Cloud batch experiment, including its runs.
 
-    Use the [code]--wait[/code] flag to wait for the batch experiment to
-    complete, polling for results. Using the [code]--output[/code] flag will
+    Use the --wait flag to wait for the batch experiment to
+    complete, polling for results. Using the --output flag will
     also activate waiting, and allows you to specify a destination file for the
     results.
 

--- a/nextmv/nextmv/cli/cloud/batch/list.py
+++ b/nextmv/nextmv/cli/cloud/batch/list.py
@@ -38,13 +38,13 @@ def list(
     [bold][underline]Examples[/underline][/bold]
 
     - List all batch experiments for application [magenta]hare-app[/magenta].
-        $ [green]nextmv cloud batch list --app-id hare-app[/green]
+        $ [dim]nextmv cloud batch list --app-id hare-app[/dim]
 
     - List all batch experiments and save to a file.
-        $ [green]nextmv cloud batch list --app-id hare-app --output experiments.json[/green]
+        $ [dim]nextmv cloud batch list --app-id hare-app --output experiments.json[/dim]
 
     - List all batch experiments using a specific profile.
-        $ [green]nextmv cloud batch list --app-id hare-app --profile prod[/green]
+        $ [dim]nextmv cloud batch list --app-id hare-app --profile prod[/dim]
     """
 
     cloud_app = build_app(app_id=app_id, profile=profile)

--- a/nextmv/nextmv/cli/cloud/batch/metadata.py
+++ b/nextmv/nextmv/cli/cloud/batch/metadata.py
@@ -41,14 +41,14 @@ def metadata(
 
     - Get metadata for batch experiment [magenta]bunny-warren-optimization[/magenta] from application
       [magenta]hare-app[/magenta].
-        $ [green]nextmv cloud batch metadata --app-id hare-app --batch-experiment-id bunny-warren-optimization[/green]
+        $ [dim]nextmv cloud batch metadata --app-id hare-app --batch-experiment-id bunny-warren-optimization[/dim]
 
     - Get metadata and save to a file.
-        $ [green]nextmv cloud batch metadata --app-id hare-app --batch-experiment-id lettuce-delivery \\
-            --output metadata.json[/green]
+        $ [dim]nextmv cloud batch metadata --app-id hare-app --batch-experiment-id lettuce-delivery \\
+            --output metadata.json[/dim]
 
     - Get metadata using a specific profile.
-        $ [green]nextmv cloud batch metadata --app-id hare-app --batch-experiment-id hop-schedule --profile prod[/green]
+        $ [dim]nextmv cloud batch metadata --app-id hare-app --batch-experiment-id hop-schedule --profile prod[/dim]
     """
 
     cloud_app = build_app(app_id=app_id, profile=profile)

--- a/nextmv/nextmv/cli/cloud/batch/update.py
+++ b/nextmv/nextmv/cli/cloud/batch/update.py
@@ -57,17 +57,17 @@ def update(
     [bold][underline]Examples[/underline][/bold]
 
     - Update the name of a batch experiment.
-        $ [green]nextmv cloud batch update --app-id hare-app --batch-experiment-id carrot-feast \\
-            --name "Spring Carrot Harvest"[/green]
+        $ [dim]nextmv cloud batch update --app-id hare-app --batch-experiment-id carrot-feast \\
+            --name "Spring Carrot Harvest"[/dim]
 
     - Update the description of a batch experiment.
-        $ [green]nextmv cloud batch update --app-id hare-app --batch-experiment-id bunny-hop-routes \\
-            --description "Optimizing hop paths through the meadow"[/green]
+        $ [dim]nextmv cloud batch update --app-id hare-app --batch-experiment-id bunny-hop-routes \\
+            --description "Optimizing hop paths through the meadow"[/dim]
 
     - Update both name and description and save the result.
-        $ [green]nextmv cloud batch update --app-id hare-app --batch-experiment-id lettuce-delivery \\
+        $ [dim]nextmv cloud batch update --app-id hare-app --batch-experiment-id lettuce-delivery \\
             --name "Warren Lettuce Express" --description "Fast lettuce delivery to all burrows" \\
-            --output updated-batch.json[/green]
+            --output updated-batch.json[/dim]
     """
 
     cloud_app = build_app(app_id=app_id, profile=profile)

--- a/nextmv/nextmv/cli/cloud/data/upload.py
+++ b/nextmv/nextmv/cli/cloud/data/upload.py
@@ -52,14 +52,14 @@ def upload(
     is used for starting new runs, tracking runs, performing experiments, and
     more.
 
-    The [code]--upload-url[/code] flag is required to specify the pre-signed
+    The --upload-url flag is required to specify the pre-signed
     upload URL. It can be obtained using the [code]nextmv cloud upload
     create[/code] command. Use the [magenta].upload_url[/magenta] field from
     the command output.
 
     The data input should be given through [magenta]stdin[/magenta] or the
-    [code]--input[/code] flag. When using the [code]--input[/code] flag, the
-    value can be one of the following:
+    --input flag. When using the --input flag, the value can be one of the
+    following:
 
     - [green]<FILE_PATH>[/green]: path to a [magenta]file[/magenta] containing
       the data. Use with the [magenta]json[/magenta], and
@@ -98,7 +98,7 @@ def upload(
     # Validate that input is provided.
     stdin = sys.stdin.read().strip() if sys.stdin.isatty() is False else None
     if stdin is None and (input is None or input == ""):
-        error("Input data must be provided via the [code]--input[/code] flag or [magenta]stdin[/magenta].")
+        error("Input data must be provided via the --input flag or [magenta]stdin[/magenta].")
 
     cloud_app = build_app(app_id=app_id, profile=profile)
     data_kwarg = resolve_data_kwarg(

--- a/nextmv/nextmv/cli/cloud/data/upload.py
+++ b/nextmv/nextmv/cli/cloud/data/upload.py
@@ -61,13 +61,13 @@ def upload(
     --input flag. When using the --input flag, the value can be one of the
     following:
 
-    - [green]<FILE_PATH>[/green]: path to a [magenta]file[/magenta] containing
+    - [yellow]<FILE_PATH>[/yellow]: path to a [magenta]file[/magenta] containing
       the data. Use with the [magenta]json[/magenta], and
       [magenta]text[/magenta] content formats.
-    - [green]<DIR_PATH>[/green]: path to a [magenta]directory[/magenta]
+    - [yellow]<DIR_PATH>[/yellow]: path to a [magenta]directory[/magenta]
       containing data files. Use with the [magenta]multi-file[/magenta]
       content format.
-    - [green]<.tar.gz_PATH>[/green]: path to a [magenta].tar.gz[/magenta] file
+    - [yellow]<.tar.gz PATH>[/yellow]: path to a [magenta].tar.gz[/magenta] file
       containing tarred data files. Use with the [magenta]multi-file[/magenta]
       content format.
 
@@ -75,24 +75,24 @@ def upload(
 
     - Upload data from [magenta]stdin[/magenta] for application
       [magenta]hare-app[/magenta].
-        $ [green]echo '{"key": "value"}' | nextmv cloud data upload --app-id hare-app --upload-url <URL>[/green]
+        $ [dim]echo '{"key": "value"}' | nextmv cloud data upload --app-id hare-app --upload-url <URL>[/dim]
 
     - Upload data from a [magenta]JSON[/magenta] file.
-        $ [green]nextmv cloud data upload --app-id hare-app --upload-url <URL> --input data.json[/green]
+        $ [dim]nextmv cloud data upload --app-id hare-app --upload-url <URL> --input data.json[/dim]
 
     - Upload data from a [magenta]text[/magenta] file.
-        $ [green]nextmv cloud data upload --app-id hare-app --upload-url <URL> --input data.txt[/green]
+        $ [dim]nextmv cloud data upload --app-id hare-app --upload-url <URL> --input data.txt[/dim]
 
     - Upload [magenta]multi-file[/magenta] data from a directory.
-        $ [green]nextmv cloud data upload --app-id hare-app --upload-url <URL> --input ./data_directory[/green]
+        $ [dim]nextmv cloud data upload --app-id hare-app --upload-url <URL> --input ./data_directory[/dim]
 
     - Upload [magenta]multi-file[/magenta] data from a
       [magenta].tar.gz[/magenta] file.
-        $ [green]nextmv cloud data upload --app-id hare-app --upload-url <URL> --input data.tar.gz[/green]
+        $ [dim]nextmv cloud data upload --app-id hare-app --upload-url <URL> --input data.tar.gz[/dim]
 
     - Upload data using a specific profile.
-        $ [green]nextmv cloud data upload --app-id hare-app --upload-url <URL> --input data.json \\
-            --profile production[/green]
+        $ [dim]nextmv cloud data upload --app-id hare-app --upload-url <URL> --input data.json \\
+            --profile production[/dim]
     """
 
     # Validate that input is provided.

--- a/nextmv/nextmv/cli/cloud/ensemble/create.py
+++ b/nextmv/nextmv/cli/cloud/ensemble/create.py
@@ -45,12 +45,12 @@ app = typer.Typer()
     - [magenta]repetitions[/magenta]: Number of times to repeat the run (optional).
 
     Object format:
-    [green]{{
+    [dim]{{
         "id": "rg1",
         "instance_id": "inst-123",
         "options": {{"param": "value"}},
         "repetitions": 5
-    }}[/green]
+    }}[/dim]
 
     [bold][underline]Evaluation Rules[/underline][/bold]
 
@@ -74,18 +74,18 @@ app = typer.Typer()
     - [magenta]index[/magenta]: Evaluation order - lower indices evaluated first (required).
 
     Object format:
-    [green]{{
+    [dim]{{
         "id": "rule1",
         "statistics_path": "$.result.value",
         "objective": "minimize",
         "tolerance": {{"value": 0.1, "type": "relative"}},
         "index": 0
-    }}[/green]
+    }}[/dim]
 
     [bold][underline]Examples[/underline][/bold]
 
     - Create an ensemble definition with a single run group and rule.
-        $ [green]RUN_GROUP='{{
+        $ [dim]RUN_GROUP='{{
             "id": "rg1",
             "instance_id": "inst-123"
         }}'
@@ -96,10 +96,10 @@ app = typer.Typer()
             "tolerance": {{"value": 0.1, "type": "relative"}},
             "index": 0
         }}'
-        nextmv cloud ensemble create --app-id hare-app --run-groups "$RUN_GROUP" --rules "$RULE"[/green]
+        nextmv cloud ensemble create --app-id hare-app --run-groups "$RUN_GROUP" --rules "$RULE"[/dim]
 
     - Create with multiple run groups by repeating the flag.
-        $ [green]RUN_GROUP_1='{{
+        $ [dim]RUN_GROUP_1='{{
             "id": "rg1",
             "instance_id": "inst-123"
         }}'
@@ -116,10 +116,10 @@ app = typer.Typer()
             "index": 0
         }}'
         nextmv cloud ensemble create --app-id hare-app --run-groups "$RUN_GROUP_1" --run-groups "$RUN_GROUP_2" \\
-            --rules "$RULE"[/green]
+            --rules "$RULE"[/dim]
 
     - Create with multiple items in a single JSON array.
-        $ [green]RUN_GROUPS='[
+        $ [dim]RUN_GROUPS='[
             {{"id": "rg1", "instance_id": "inst-123"}},
             {{"id": "rg2", "instance_id": "inst-456"}}
         ]'
@@ -130,10 +130,10 @@ app = typer.Typer()
             "tolerance": {{"value": 0.1, "type": "relative"}},
             "index": 0
         }}]'
-        nextmv cloud ensemble create --app-id hare-app --run-groups "$RUN_GROUPS" --rules "$RULES"[/green]
+        nextmv cloud ensemble create --app-id hare-app --run-groups "$RUN_GROUPS" --rules "$RULES"[/dim]
 
     - Create with custom ID, name, and description.
-        $ [green]RUN_GROUP='{{
+        $ [dim]RUN_GROUP='{{
             "id": "rg1",
             "instance_id": "inst-123"
         }}'
@@ -147,10 +147,10 @@ app = typer.Typer()
         nextmv cloud ensemble create --app-id hare-app \\
             --ensemble-definition-id prod-ensemble --name "Production Ensemble" \\
             --description "Production ensemble with multiple solvers" \\
-            --run-groups "$RUN_GROUP" --rules "$RULE"[/green]
+            --run-groups "$RUN_GROUP" --rules "$RULE"[/dim]
 
     - Create with run group repetitions.
-        $ [green]RUN_GROUP='{{
+        $ [dim]RUN_GROUP='{{
             "id": "rg1",
             "instance_id": "inst-123",
             "repetitions": 5
@@ -162,7 +162,7 @@ app = typer.Typer()
             "tolerance": {{"value": 0.1, "type": "relative"}},
             "index": 0
         }}'
-        nextmv cloud ensemble create --app-id hare-app --run-groups "$RUN_GROUP" --rules "$RULE"[/green]
+        nextmv cloud ensemble create --app-id hare-app --run-groups "$RUN_GROUP" --rules "$RULE"[/dim]
     """
 )
 def create(

--- a/nextmv/nextmv/cli/cloud/ensemble/create.py
+++ b/nextmv/nextmv/cli/cloud/ensemble/create.py
@@ -30,13 +30,12 @@ app = typer.Typer()
     [bold][underline]Run Groups[/underline][/bold]
 
     Run groups are provided as [magenta]json[/magenta] objects using the
-    [code]--run-groups[/code] flag. Each run group specifies how child runs
-    are executed.
+    --run-groups flag. Each run group specifies how child runs are executed.
 
     You can provide run groups in three ways:
     - A single run group as a [magenta]json[/magenta] object.
-    - Multiple run groups by repeating the [code]--run-groups[/code] flag.
-    - Multiple run groups as a [magenta]json[/magenta] array in a single [code]--run-groups[/code] flag.
+    - Multiple run groups by repeating the --run-groups flag.
+    - Multiple run groups as a [magenta]json[/magenta] array in a single --run-groups flag.
 
     Each run group must have the following fields:
     - [magenta]id[/magenta]: Unique identifier for the run group (required).
@@ -56,13 +55,13 @@ app = typer.Typer()
     [bold][underline]Evaluation Rules[/underline][/bold]
 
     Evaluation rules are provided as [magenta]json[/magenta] objects using the
-    [code]--rules[/code] flag. Each rule determines how to evaluate and select
-    the best result from the child runs.
+    --rules flag. Each rule determines how to evaluate and select the best
+    result from the child runs.
 
     You can provide rules in three ways:
     - A single rule as a [magenta]json[/magenta] object.
-    - Multiple rules by repeating the [code]--rules[/code] flag.
-    - Multiple rules as a [magenta]json[/magenta] array in a single [code]--rules[/code] flag.
+    - Multiple rules by repeating the --rules flag.
+    - Multiple rules as a [magenta]json[/magenta] array in a single --rules flag.
 
     Each rule must have the following fields:
     - [magenta]id[/magenta]: Unique identifier for the rule (required).

--- a/nextmv/nextmv/cli/cloud/ensemble/delete.py
+++ b/nextmv/nextmv/cli/cloud/ensemble/delete.py
@@ -39,10 +39,10 @@ def delete(
 
     - Delete the ensemble definition with the ID [magenta]prod-ensemble[/magenta] from application
       [magenta]hare-app[/magenta].
-        $ [green]nextmv cloud ensemble delete --app-id hare-app --ensemble-definition-id prod-ensemble[/green]
+        $ [dim]nextmv cloud ensemble delete --app-id hare-app --ensemble-definition-id prod-ensemble[/dim]
 
     - Delete the ensemble definition without confirmation prompt.
-        $ [green]nextmv cloud ensemble delete --app-id hare-app --ensemble-definition-id prod-ensemble --yes[/green]
+        $ [dim]nextmv cloud ensemble delete --app-id hare-app --ensemble-definition-id prod-ensemble --yes[/dim]
     """
 
     if not yes:

--- a/nextmv/nextmv/cli/cloud/ensemble/delete.py
+++ b/nextmv/nextmv/cli/cloud/ensemble/delete.py
@@ -32,7 +32,7 @@ def delete(
     """
     Deletes a Nextmv Cloud ensemble definition.
 
-    This action is permanent and cannot be undone. Use the [code]--yes[/code]
+    This action is permanent and cannot be undone. Use the --yes
     flag to skip the confirmation prompt.
 
     [bold][underline]Examples[/underline][/bold]

--- a/nextmv/nextmv/cli/cloud/ensemble/get.py
+++ b/nextmv/nextmv/cli/cloud/ensemble/get.py
@@ -40,13 +40,13 @@ def get(
 
     - Get the ensemble definition with the ID [magenta]prod-ensemble[/magenta] from
       application [magenta]hare-app[/magenta].
-        $ [green]nextmv cloud ensemble get --app-id hare-app \\
-        --ensemble-definition-id prod-ensemble[/green]
+        $ [dim]nextmv cloud ensemble get --app-id hare-app \\
+        --ensemble-definition-id prod-ensemble[/dim]
 
     - Get the ensemble definition with the ID [magenta]prod-ensemble[/magenta] and
       save the information to an [magenta]ensemble.json[/magenta] file.
-        $ [green]nextmv cloud ensemble get --app-id hare-app \\
-            --ensemble-definition-id prod-ensemble --output ensemble.json[/green]
+        $ [dim]nextmv cloud ensemble get --app-id hare-app \\
+            --ensemble-definition-id prod-ensemble --output ensemble.json[/dim]
     """
 
     cloud_app = build_app(app_id=app_id, profile=profile)

--- a/nextmv/nextmv/cli/cloud/ensemble/update.py
+++ b/nextmv/nextmv/cli/cloud/ensemble/update.py
@@ -58,23 +58,23 @@ def update(
     [bold][underline]Examples[/underline][/bold]
 
     - Update the name of an ensemble definition.
-        $ [green]nextmv cloud ensemble update --app-id hare-app \\
-            --ensemble-definition-id prod-ensemble --name "Updated Production Ensemble"[/green]
+        $ [dim]nextmv cloud ensemble update --app-id hare-app \\
+            --ensemble-definition-id prod-ensemble --name "Updated Production Ensemble"[/dim]
 
     - Update the description of an ensemble definition.
-        $ [green]nextmv cloud ensemble update --app-id hare-app \\
+        $ [dim]nextmv cloud ensemble update --app-id hare-app \\
             --ensemble-definition-id prod-ensemble \\
-            --description "Updated ensemble for production workloads"[/green]
+            --description "Updated ensemble for production workloads"[/dim]
 
     - Update both name and description.
-        $ [green]nextmv cloud ensemble update --app-id hare-app \\
+        $ [dim]nextmv cloud ensemble update --app-id hare-app \\
             --ensemble-definition-id prod-ensemble --name "Production Ensemble v2" \\
-            --description "Enhanced ensemble configuration for production"[/green]
+            --description "Enhanced ensemble configuration for production"[/dim]
 
     - Update and save the result to a file.
-        $ [green]nextmv cloud ensemble update --app-id hare-app \\
+        $ [dim]nextmv cloud ensemble update --app-id hare-app \\
             --ensemble-definition-id prod-ensemble --name "New Name" \\
-            --description "New Description" --output updated.json[/green]
+            --description "New Description" --output updated.json[/dim]
     """
 
     if name is None and description is None:

--- a/nextmv/nextmv/cli/cloud/ensemble/update.py
+++ b/nextmv/nextmv/cli/cloud/ensemble/update.py
@@ -78,7 +78,7 @@ def update(
     """
 
     if name is None and description is None:
-        error("Provide at least one option to update: [code]--name[/code] or [code]--description[/code].")
+        error("Provide at least one option to update: --name or --description.")
 
     cloud_app = build_app(app_id=app_id, profile=profile)
 

--- a/nextmv/nextmv/cli/cloud/input_set/create.py
+++ b/nextmv/nextmv/cli/cloud/input_set/create.py
@@ -113,11 +113,9 @@ def create(
     An input set is a collection of inputs that can be reused across multiple
     experiments.
 
-    1. [code]--run-ids[/code]: Create from a list of existing run IDs.
-
-    2. [code]--inputs[/code]: Create from existing managed inputs in the application.
-
-    3. [code]--instance-id[/code] with [code]--start-time[/code] and [code]--end-time[/code]:
+    1. --run-ids: Create from a list of existing run IDs.
+    2. --inputs: Create from existing managed inputs in the application.
+    3. --instance-id with --start-time and --end-time:
        Create from instance runs matching the time range criteria.
 
     [bold][underline]Examples[/underline][/bold]

--- a/nextmv/nextmv/cli/cloud/input_set/create.py
+++ b/nextmv/nextmv/cli/cloud/input_set/create.py
@@ -73,7 +73,7 @@ def create(
             "--start-time",
             formats=["%Y-%m-%dT%H:%M:%S%z"],
             help="Start time for filtering runs in [magenta]RFC 3339[/magenta] format. "
-            "Object format: [green]'2024-01-01T00:00:00Z'[/green]",
+            "Object format: [dim]'2024-01-01T00:00:00Z'[/dim]",
             metavar="START_TIME",
         ),
     ] = None,
@@ -83,7 +83,7 @@ def create(
             "--end-time",
             formats=["%Y-%m-%dT%H:%M:%S%z"],
             help="End time for filtering runs in [magenta]RFC 3339[/magenta] format. "
-            "Object format: [green]'2024-01-01T00:00:00Z'[/green]",
+            "Object format: [dim]'2024-01-01T00:00:00Z'[/dim]",
             metavar="END_TIME",
         ),
     ] = None,
@@ -101,7 +101,7 @@ def create(
         typer.Option(
             "--inputs",
             help="Inputs for the input set. Data should be valid [magenta]json[/magenta]. Object "
-            "format: [green][{'id': 'id', 'name': 'name', 'description': 'description'}][/green].",
+            "format: [dim][{'id': 'id', 'name': 'name', 'description': 'description'}][/dim].",
             metavar="INPUTS",
         ),
     ] = None,
@@ -122,21 +122,21 @@ def create(
 
     - Create an input set for application [magenta]hare-app[/magenta] from runs.
       A random input set ID will be generated if one is not provided.
-        $ [green]nextmv cloud input-set create --app-id hare-app \\
-            --name "Hare Input Set" --run-ids run-1 --run-ids run-2 --run-ids run-3"[/green]
+        $ [dim]nextmv cloud input-set create --app-id hare-app \\
+            --name "Hare Input Set" --run-ids run-1 --run-ids run-2 --run-ids run-3"[/dim]
 
     - Create an input set with a specific ID.
-        $ [green]nextmv cloud input-set create --app-id hare-app --input-set-id hare-input-set \\
-            --name "Hare Input Set" --run-ids run-1 --run-ids run-2 --run-ids run-3"[/green]
+        $ [dim]nextmv cloud input-set create --app-id hare-app --input-set-id hare-input-set \\
+            --name "Hare Input Set" --run-ids run-1 --run-ids run-2 --run-ids run-3"[/dim]
 
     - Create an input set using existing managed inputs.
-        $ [green]nextmv cloud input-set create --app-id hare-app --name "Hare Input Set" \\
-            --inputs '[{"id": "hare-input-1", "name": "hare input", "description": "hare description"}]'[/green]
+        $ [dim]nextmv cloud input-set create --app-id hare-app --name "Hare Input Set" \\
+            --inputs '[{"id": "hare-input-1", "name": "hare input", "description": "hare description"}]'[/dim]
 
     - Create an input set from runs using a specific instance and time range.
-        $ [green]nextmv cloud input-set create --app-id hare-app --name "Hare Input Set" \\
+        $ [dim]nextmv cloud input-set create --app-id hare-app --name "Hare Input Set" \\
             --instance-id hare-instance --start-time "2024-01-01T00:00:00Z" \\
-            --end-time "2024-01-31T23:59:59Z"[/green]
+            --end-time "2024-01-31T23:59:59Z"[/dim]
     """
 
     cloud_app = build_app(app_id=app_id, profile=profile)

--- a/nextmv/nextmv/cli/cloud/input_set/get.py
+++ b/nextmv/nextmv/cli/cloud/input_set/get.py
@@ -39,12 +39,12 @@ def get(
     [bold][underline]Examples[/underline][/bold]
 
     - Get an input set with the ID [magenta]hare-input-set[/magenta].
-        $ [green]nextmv cloud input-set get --app-id hare-app --input-set-id hare-input-set[/green]
+        $ [dim]nextmv cloud input-set get --app-id hare-app --input-set-id hare-input-set[/dim]
 
     - Get an input set with the ID [magenta]hare-input-set[/magenta] and save
       the information to a [magenta]input-set.json[/magenta] file.
-        $ [green]nextmv cloud input-set get --app-id hare-app --input-set-id hare-input-set \\
-            --output input-set.json[/green]
+        $ [dim]nextmv cloud input-set get --app-id hare-app --input-set-id hare-input-set \\
+            --output input-set.json[/dim]
     """
 
     cloud_app = build_app(app_id=app_id, profile=profile)

--- a/nextmv/nextmv/cli/cloud/input_set/list.py
+++ b/nextmv/nextmv/cli/cloud/input_set/list.py
@@ -38,13 +38,13 @@ def list(
     [bold][underline]Examples[/underline][/bold]
 
     - List all input sets of application [magenta]hare-app[/magenta].
-        $ [green]nextmv cloud input-set list --app-id hare-app[/green]
+        $ [dim]nextmv cloud input-set list --app-id hare-app[/dim]
 
     - List all input sets using the profile named [magenta]hare[/magenta].
-        $ [green]nextmv cloud input-set list --app-id hare-app --profile hare[/green]
+        $ [dim]nextmv cloud input-set list --app-id hare-app --profile hare[/dim]
 
     - List all input sets and save the information to a [magenta]input-sets.json[/magenta] file.
-        $ [green]nextmv cloud input-set list --app-id hare-app --output input-sets.json[/green]
+        $ [dim]nextmv cloud input-set list --app-id hare-app --output input-sets.json[/dim]
     """
 
     cloud_app = build_app(app_id=app_id, profile=profile)

--- a/nextmv/nextmv/cli/cloud/input_set/update.py
+++ b/nextmv/nextmv/cli/cloud/input_set/update.py
@@ -88,7 +88,7 @@ def update(
     """
 
     if name is None and description is None and inputs is None:
-        error("Provide at least one option: [code]--name[/code], [code]--description[/code], or [code]--inputs[/code].")
+        error("Provide at least one option: --name, --description, or --inputs.")
 
     cloud_app = build_app(app_id=app_id, profile=profile)
     in_progress(msg="Updating input set...")

--- a/nextmv/nextmv/cli/cloud/input_set/update.py
+++ b/nextmv/nextmv/cli/cloud/input_set/update.py
@@ -43,7 +43,7 @@ def update(
         typer.Option(
             "--inputs",
             help="Inputs for the input set. Data should be valid [magenta]json[/magenta]. Object "
-            "format: [green][{'id': 'id', 'name': 'name', 'description': 'description'}][/green].",
+            "format: [dim][{'id': 'id', 'name': 'name', 'description': 'description'}][/dim].",
             metavar="INPUTS",
         ),
     ] = None,
@@ -67,24 +67,24 @@ def update(
     [bold][underline]Examples[/underline][/bold]
 
     - Update an input set's name.
-        $ [green]nextmv cloud input-set update --app-id hare-app \\
-            --input-set-id hare-input-set --name "New Name"[/green]
+        $ [dim]nextmv cloud input-set update --app-id hare-app \\
+            --input-set-id hare-input-set --name "New Name"[/dim]
 
     - Update an input set's description.
-        $ [green]nextmv cloud input-set update --app-id hare-app \\
-            --input-set-id hare-input-set --description "Updated description"[/green]
+        $ [dim]nextmv cloud input-set update --app-id hare-app \\
+            --input-set-id hare-input-set --description "Updated description"[/dim]
 
     - Update an input set's inputs.
-        $ [green]nextmv cloud input-set update --app-id hare-app --input-set-id hare-input-set \\
-            --inputs '[{"id": "hare-input-1", "name": "hare input", "description": "hare description"}]'[/green]
+        $ [dim]nextmv cloud input-set update --app-id hare-app --input-set-id hare-input-set \\
+            --inputs '[{"id": "hare-input-1", "name": "hare input", "description": "hare description"}]'[/dim]
 
     - Update both name and description.
-        $ [green]nextmv cloud input-set update --app-id hare-app --input-set-id hare-input-set \\
-            --name "New Name" --description "Updated description"[/green]
+        $ [dim]nextmv cloud input-set update --app-id hare-app --input-set-id hare-input-set \\
+            --name "New Name" --description "Updated description"[/dim]
 
     - Update and save to a file.
-        $ [green]nextmv cloud input-set update --app-id hare-app --input-set-id hare-input-set \\
-            --name "New Name" --output updated_input_set.json[/green]
+        $ [dim]nextmv cloud input-set update --app-id hare-app --input-set-id hare-input-set \\
+            --name "New Name" --output updated_input_set.json[/dim]
     """
 
     if name is None and description is None and inputs is None:

--- a/nextmv/nextmv/cli/cloud/instance/create.py
+++ b/nextmv/nextmv/cli/cloud/instance/create.py
@@ -138,28 +138,28 @@ def create(
     [bold][underline]Examples[/underline][/bold]
 
     - Create an instance for application [magenta]hare-app[/magenta] version [magenta]v1[/magenta].
-        $ [green]nextmv cloud instance create --app-id hare-app --version-id v1 --instance-id prod[/green]
+        $ [dim]nextmv cloud instance create --app-id hare-app --version-id v1 --instance-id prod[/dim]
 
     - Create an instance with a specific name.
-        $ [green]nextmv cloud instance create --app-id hare-app --version-id v1 \\
-            --instance-id prod --name "Production Instance"[/green]
+        $ [dim]nextmv cloud instance create --app-id hare-app --version-id v1 \\
+            --instance-id prod --name "Production Instance"[/dim]
 
     - Create an instance with a name and description.
-        $ [green]nextmv cloud instance create --app-id hare-app --version-id v1 \\
+        $ [dim]nextmv cloud instance create --app-id hare-app --version-id v1 \\
             --instance-id prod --name "Production Instance" \\
-            --description "Instance for production routing jobs"[/green]
+            --description "Instance for production routing jobs"[/dim]
 
     - Create an instance, or get it if it already exists.
-        $ [green]nextmv cloud instance create --app-id hare-app --version-id v1 \\
-            --instance-id prod --exist-ok[/green]
+        $ [dim]nextmv cloud instance create --app-id hare-app --version-id v1 \\
+            --instance-id prod --exist-ok[/dim]
 
     - Create an instance with configuration options.
-        $ [green]nextmv cloud instance create --app-id hare-app --version-id v1 \\
-            --instance-id prod --execution-class 6c9500mb870s --priority 1[/green]
+        $ [dim]nextmv cloud instance create --app-id hare-app --version-id v1 \\
+            --instance-id prod --execution-class 6c9500mb870s --priority 1[/dim]
 
     - Create an instance with runtime options.
-        $ [green]nextmv cloud instance create --app-id hare-app --version-id v1 \\
-            --instance-id prod --options max_duration=30 --options timeout=60[/green]
+        $ [dim]nextmv cloud instance create --app-id hare-app --version-id v1 \\
+            --instance-id prod --options max_duration=30 --options timeout=60[/dim]
     """
 
     cloud_app = build_app(app_id=app_id, profile=profile)

--- a/nextmv/nextmv/cli/cloud/instance/create.py
+++ b/nextmv/nextmv/cli/cloud/instance/create.py
@@ -131,10 +131,9 @@ def create(
     """
     Create a new Nextmv Cloud application instance.
 
-    Use the [code]--exist-ok[/code] flag to avoid errors when creating an
-    instance with an ID that already exists. This is useful for scripts that
-    need to ensure an instance exists without worrying about whether it was
-    created previously.
+    Use the --exist-ok flag to avoid errors when creating an instance with an
+    ID that already exists. This is useful for scripts that need to ensure an
+    instance exists without worrying about whether it was created previously.
 
     [bold][underline]Examples[/underline][/bold]
 

--- a/nextmv/nextmv/cli/cloud/instance/delete.py
+++ b/nextmv/nextmv/cli/cloud/instance/delete.py
@@ -32,7 +32,7 @@ def delete(
     """
     Deletes a Nextmv Cloud application instance.
 
-    This action is permanent and cannot be undone. Use the [code]--yes[/code]
+    This action is permanent and cannot be undone. Use the --yes
     flag to skip the confirmation prompt.
 
     [bold][underline]Examples[/underline][/bold]

--- a/nextmv/nextmv/cli/cloud/instance/delete.py
+++ b/nextmv/nextmv/cli/cloud/instance/delete.py
@@ -38,10 +38,10 @@ def delete(
     [bold][underline]Examples[/underline][/bold]
 
     - Delete the instance with the ID [magenta]prod[/magenta] from application [magenta]hare-app[/magenta].
-        $ [green]nextmv cloud instance delete --app-id hare-app --instance-id prod[/green]
+        $ [dim]nextmv cloud instance delete --app-id hare-app --instance-id prod[/dim]
 
     - Delete the instance without confirmation prompt.
-        $ [green]nextmv cloud instance delete --app-id hare-app --instance-id prod --yes[/green]
+        $ [dim]nextmv cloud instance delete --app-id hare-app --instance-id prod --yes[/dim]
     """
 
     if not yes:

--- a/nextmv/nextmv/cli/cloud/instance/exists.py
+++ b/nextmv/nextmv/cli/cloud/instance/exists.py
@@ -27,10 +27,10 @@ def exists(
     [bold][underline]Examples[/underline][/bold]
 
     - Check if the instance with the ID [magenta]prod[/magenta] exists in application [magenta]hare-app[/magenta].
-        $ [green]nextmv cloud instance exists --app-id hare-app --instance-id prod[/green]
+        $ [dim]nextmv cloud instance exists --app-id hare-app --instance-id prod[/dim]
 
     - Check if the instance exists using the profile named [magenta]hare[/magenta].
-        $ [green]nextmv cloud instance exists --app-id hare-app --instance-id prod --profile hare[/green]
+        $ [dim]nextmv cloud instance exists --app-id hare-app --instance-id prod --profile hare[/dim]
     """
 
     cloud_app = build_app(app_id=app_id, profile=profile)

--- a/nextmv/nextmv/cli/cloud/instance/get.py
+++ b/nextmv/nextmv/cli/cloud/instance/get.py
@@ -39,11 +39,11 @@ def get(
     [bold][underline]Examples[/underline][/bold]
 
     - Get the instance with the ID [magenta]prod[/magenta] from application [magenta]hare-app[/magenta].
-        $ [green]nextmv cloud instance get --app-id hare-app --instance-id prod[/green]
+        $ [dim]nextmv cloud instance get --app-id hare-app --instance-id prod[/dim]
 
     - Get the instance with the ID [magenta]prod[/magenta] and save the information to a
       [magenta]instance.json[/magenta] file.
-        $ [green]nextmv cloud instance get --app-id hare-app --instance-id prod --output instance.json[/green]
+        $ [dim]nextmv cloud instance get --app-id hare-app --instance-id prod --output instance.json[/dim]
     """
 
     cloud_app = build_app(app_id=app_id, profile=profile)

--- a/nextmv/nextmv/cli/cloud/instance/list.py
+++ b/nextmv/nextmv/cli/cloud/instance/list.py
@@ -35,13 +35,13 @@ def list(
     [bold][underline]Examples[/underline][/bold]
 
     - List all instances of application [magenta]hare-app[/magenta].
-        $ [green]nextmv cloud instance list --app-id hare-app[/green]
+        $ [dim]nextmv cloud instance list --app-id hare-app[/dim]
 
     - List all instances using the profile named [magenta]hare[/magenta].
-        $ [green]nextmv cloud instance list --app-id hare-app --profile hare[/green]
+        $ [dim]nextmv cloud instance list --app-id hare-app --profile hare[/dim]
 
     - List all instances and save the information to a [magenta]instances.json[/magenta] file.
-        $ [green]nextmv cloud instance list --app-id hare-app --output instances.json[/green]
+        $ [dim]nextmv cloud instance list --app-id hare-app --output instances.json[/dim]
     """
 
     cloud_app = build_app(app_id=app_id, profile=profile)

--- a/nextmv/nextmv/cli/cloud/instance/update.py
+++ b/nextmv/nextmv/cli/cloud/instance/update.py
@@ -173,8 +173,8 @@ def update(
 
     if name is None and description is None and version_id is None and not has_config_options:
         error(
-            "Provide at least one option to update: [code]--name[/code], [code]--description[/code], "
-            "[code]--version-id[/code], or any [magenta]Instance configuration[/magenta] option."
+            "Provide at least one option to update: --name, --description, "
+            "--version-id, or any [magenta]Instance configuration[/magenta] option."
         )
 
     cloud_app = build_app(app_id=app_id, profile=profile)

--- a/nextmv/nextmv/cli/cloud/instance/update.py
+++ b/nextmv/nextmv/cli/cloud/instance/update.py
@@ -132,30 +132,30 @@ def update(
     [bold][underline]Examples[/underline][/bold]
 
     - Update an instance's name.
-        $ [green]nextmv cloud instance update --app-id hare-app --instance-id prod --name "Production Instance"[/green]
+        $ [dim]nextmv cloud instance update --app-id hare-app --instance-id prod --name "Production Instance"[/dim]
 
     - Update an instance's description.
-        $ [green]nextmv cloud instance update --app-id hare-app --instance-id prod \\
-            --description "Instance for production routing jobs"[/green]
+        $ [dim]nextmv cloud instance update --app-id hare-app --instance-id prod \\
+            --description "Instance for production routing jobs"[/dim]
 
     - Update an instance to use a different version.
-        $ [green]nextmv cloud instance update --app-id hare-app --instance-id prod --version-id v2[/green]
+        $ [dim]nextmv cloud instance update --app-id hare-app --instance-id prod --version-id v2[/dim]
 
     - Update an instance's name and description at once.
-        $ [green]nextmv cloud instance update --app-id hare-app --instance-id prod \\
-            --name "Production Instance" --description "Instance for production routing jobs"[/green]
+        $ [dim]nextmv cloud instance update --app-id hare-app --instance-id prod \\
+            --name "Production Instance" --description "Instance for production routing jobs"[/dim]
 
     - Update an instance and save the updated information to a [magenta]updated_instance.json[/magenta] file.
-        $ [green]nextmv cloud instance update --app-id hare-app --instance-id prod \\
-            --name "Production Instance" --output updated_instance.json[/green]
+        $ [dim]nextmv cloud instance update --app-id hare-app --instance-id prod \\
+            --name "Production Instance" --output updated_instance.json[/dim]
 
     - Update an instance's execution class and priority.
-        $ [green]nextmv cloud instance update --app-id hare-app --instance-id prod \\
-            --execution-class 6c9500mb870s --priority 1[/green]
+        $ [dim]nextmv cloud instance update --app-id hare-app --instance-id prod \\
+            --execution-class 6c9500mb870s --priority 1[/dim]
 
     - Update an instance's runtime options.
-        $ [green]nextmv cloud instance update --app-id hare-app --instance-id prod \\
-            --options max_duration=30 --options timeout=60[/green]
+        $ [dim]nextmv cloud instance update --app-id hare-app --instance-id prod \\
+            --options max_duration=30 --options timeout=60[/dim]
     """
 
     # Check if any configuration options are provided

--- a/nextmv/nextmv/cli/cloud/managed_input/create.py
+++ b/nextmv/nextmv/cli/cloud/managed_input/create.py
@@ -62,8 +62,7 @@ def create(
         typer.Option(
             "--run-id",
             "-r",
-            help="ID of the run to use for the managed input. "
-            "Either [code]--upload-id[/code] or [code]--run-id[/code] must be specified.",
+            help="ID of the run to use for the managed input. Either --upload-id or --run-id must be specified.",
             envvar="NEXTMV_RUN_ID",
             metavar="RUN_ID",
         ),
@@ -73,8 +72,7 @@ def create(
         typer.Option(
             "--upload-id",
             "-u",
-            help="ID of the upload to use for the managed input. "
-            "Either [code]--upload-id[/code] or [code]--run-id[/code] must be specified.",
+            help="ID of the upload to use for the managed input. Either --upload-id or --run-id must be specified.",
             metavar="UPLOAD_ID",
         ),
     ] = None,
@@ -84,8 +82,8 @@ def create(
     Create a new Nextmv Cloud application managed input.
 
     A managed input can be created from either an upload or a run. Use the
-    [code]--upload-id[/code] flag to create from an upload, or the
-    [code]--run-id[/code] flag to create from a run output.
+    --upload-id flag to create from an upload, or the --run-id flag to create
+    from a run output.
 
     You can get an upload ID by using the [code]nextmv cloud upload
     create[/code] command. The [magenta].upload_id[/magenta] field in the
@@ -118,8 +116,8 @@ def create(
 
     if upload_id is None and run_id is None:
         error(
-            "Either [code]--upload-id[/code] or [code]--run-id[/code] must be specified. "
-            "Use [code]nextmv cloud upload create[/code] to create an upload first, "
+            "Either --upload-id or --run-id must be specified. "
+            "Use nextmv cloud upload create to create an upload first, "
             "or specify an existing run ID."
         )
 

--- a/nextmv/nextmv/cli/cloud/managed_input/create.py
+++ b/nextmv/nextmv/cli/cloud/managed_input/create.py
@@ -98,20 +98,20 @@ def create(
     [bold][underline]Examples[/underline][/bold]
 
     - Create a managed input from an upload.
-        $ [green]nextmv cloud managed-input create --app-id hare-app --name "Test Input 1" \
-            --upload-id upl_123456789[/green]
+        $ [dim]nextmv cloud managed-input create --app-id hare-app --name "Test Input 1" \
+            --upload-id upl_123456789[/dim]
 
     - Create a managed input from a run.
-        $ [green]nextmv cloud managed-input create --app-id hare-app --name "Baseline Run" \
-            --run-id run_123456789[/green]
+        $ [dim]nextmv cloud managed-input create --app-id hare-app --name "Baseline Run" \
+            --run-id run_123456789[/dim]
 
     - Create a managed input with a specific ID and description.
-        $ [green]nextmv cloud managed-input create --app-id hare-app --name "Test Input" \\
-            --managed-input-id inp_custom --description "Test case for validation" --upload-id upl_123456789[/green]
+        $ [dim]nextmv cloud managed-input create --app-id hare-app --name "Test Input" \\
+            --managed-input-id inp_custom --description "Test case for validation" --upload-id upl_123456789[/dim]
 
     - Create a managed input with custom format.
-        $ [green]nextmv cloud managed-input create --app-id hare-app --name "CSV Input" \\
-            --upload-id upl_123456789 --content-format csv[/green]
+        $ [dim]nextmv cloud managed-input create --app-id hare-app --name "CSV Input" \\
+            --upload-id upl_123456789 --content-format csv[/dim]
     """
 
     if upload_id is None and run_id is None:

--- a/nextmv/nextmv/cli/cloud/managed_input/delete.py
+++ b/nextmv/nextmv/cli/cloud/managed_input/delete.py
@@ -32,7 +32,7 @@ def delete(
     """
     Deletes a Nextmv Cloud application managed input.
 
-    This action is permanent and cannot be undone. Use the [code]--yes[/code]
+    This action is permanent and cannot be undone. Use the --yes
     flag to skip the confirmation prompt.
 
     [bold][underline]Examples[/underline][/bold]

--- a/nextmv/nextmv/cli/cloud/managed_input/delete.py
+++ b/nextmv/nextmv/cli/cloud/managed_input/delete.py
@@ -39,11 +39,11 @@ def delete(
 
     - Delete the managed input with the ID [magenta]inp_123456789[/magenta] from application
       [magenta]hare-app[/magenta].
-        $ [green]nextmv cloud managed-input delete --app-id hare-app \
-            --managed-input-id inp_123456789[/green]
+        $ [dim]nextmv cloud managed-input delete --app-id hare-app \
+            --managed-input-id inp_123456789[/dim]
 
     - Delete the managed input without confirmation prompt.
-        $ [green]nextmv cloud managed-input delete --app-id hare-app --managed-input-id inp_123456789 --yes[/green]
+        $ [dim]nextmv cloud managed-input delete --app-id hare-app --managed-input-id inp_123456789 --yes[/dim]
     """
 
     if not yes:

--- a/nextmv/nextmv/cli/cloud/managed_input/get.py
+++ b/nextmv/nextmv/cli/cloud/managed_input/get.py
@@ -39,12 +39,12 @@ def get(
     [bold][underline]Examples[/underline][/bold]
 
     - Get the managed input with the ID [magenta]inp_123456789[/magenta] from application [magenta]hare-app[/magenta].
-        $ [green]nextmv cloud managed-input get --app-id hare-app --managed-input-id inp_123456789[/green]
+        $ [dim]nextmv cloud managed-input get --app-id hare-app --managed-input-id inp_123456789[/dim]
 
     - Get the managed input with the ID [magenta]inp_123456789[/magenta] and save the information to a
       [magenta]managed_input.json[/magenta] file.
-        $ [green]nextmv cloud managed-input get --app-id hare-app --managed-input-id inp_123456789 \
-            --output managed_input.json[/green]
+        $ [dim]nextmv cloud managed-input get --app-id hare-app --managed-input-id inp_123456789 \
+            --output managed_input.json[/dim]
     """
 
     cloud_app = build_app(app_id=app_id, profile=profile)

--- a/nextmv/nextmv/cli/cloud/managed_input/list.py
+++ b/nextmv/nextmv/cli/cloud/managed_input/list.py
@@ -35,13 +35,13 @@ def list(
     [bold][underline]Examples[/underline][/bold]
 
     - List all managed inputs of application [magenta]hare-app[/magenta].
-        $ [green]nextmv cloud managed-input list --app-id hare-app[/green]
+        $ [dim]nextmv cloud managed-input list --app-id hare-app[/dim]
 
     - List all managed inputs using the profile named [magenta]hare[/magenta].
-        $ [green]nextmv cloud managed-input list --app-id hare-app --profile hare[/green]
+        $ [dim]nextmv cloud managed-input list --app-id hare-app --profile hare[/dim]
 
     - List all managed inputs and save the information to a [magenta]managed_inputs.json[/magenta] file.
-        $ [green]nextmv cloud managed-input list --app-id hare-app --output managed_inputs.json[/green]
+        $ [dim]nextmv cloud managed-input list --app-id hare-app --output managed_inputs.json[/dim]
     """
 
     cloud_app = build_app(app_id=app_id, profile=profile)

--- a/nextmv/nextmv/cli/cloud/managed_input/update.py
+++ b/nextmv/nextmv/cli/cloud/managed_input/update.py
@@ -54,20 +54,20 @@ def update(
     [bold][underline]Examples[/underline][/bold]
 
     - Update a managed input's name.
-        $ [green]nextmv cloud managed-input update --app-id hare-app \
-            --managed-input-id inp_123456789 --name "Updated Test Input"[/green]
+        $ [dim]nextmv cloud managed-input update --app-id hare-app \
+            --managed-input-id inp_123456789 --name "Updated Test Input"[/dim]
 
     - Update a managed input's description.
-        $ [green]nextmv cloud managed-input update --app-id hare-app --managed-input-id inp_123456789 \\
-            --description "Updated test case for validation"[/green]
+        $ [dim]nextmv cloud managed-input update --app-id hare-app --managed-input-id inp_123456789 \\
+            --description "Updated test case for validation"[/dim]
 
     - Update a managed input's name and description at once.
-        $ [green]nextmv cloud managed-input update --app-id hare-app --managed-input-id inp_123456789 \\
-            --name "Updated Test Input" --description "Updated test case for validation"[/green]
+        $ [dim]nextmv cloud managed-input update --app-id hare-app --managed-input-id inp_123456789 \\
+            --name "Updated Test Input" --description "Updated test case for validation"[/dim]
 
     - Update a managed input and save the updated information to a [magenta]updated_managed_input.json[/magenta] file.
-        $ [green]nextmv cloud managed-input update --app-id hare-app --managed-input-id inp_123456789 \\
-            --name "Updated Test Input" --output updated_managed_input.json[/green]
+        $ [dim]nextmv cloud managed-input update --app-id hare-app --managed-input-id inp_123456789 \\
+            --name "Updated Test Input" --output updated_managed_input.json[/dim]
     """
 
     if name is None and description is None:

--- a/nextmv/nextmv/cli/cloud/managed_input/update.py
+++ b/nextmv/nextmv/cli/cloud/managed_input/update.py
@@ -71,7 +71,7 @@ def update(
     """
 
     if name is None and description is None:
-        error("Provide at least one option to update: [code]--name[/code] or [code]--description[/code].")
+        error("Provide at least one option to update: --name or --description.")
 
     cloud_app = build_app(app_id=app_id, profile=profile)
 

--- a/nextmv/nextmv/cli/cloud/run/cancel.py
+++ b/nextmv/nextmv/cli/cloud/run/cancel.py
@@ -24,11 +24,11 @@ def cancel(
     [bold][underline]Examples[/underline][/bold]
 
     - Cancel the run with ID [magenta]burrow-123[/magenta] belonging to an app with ID [magenta]hare-app[/magenta].
-        $ [green]nextmv cloud run cancel --app-id hare-app --run-id burrow-123[/green]
+        $ [dim]nextmv cloud run cancel --app-id hare-app --run-id burrow-123[/dim]
 
     - Cancel the run with ID [magenta]burrow-123[/magenta] belonging to an app with ID [magenta]hare-app[/magenta].
       Use the profile named [magenta]hare[/magenta].
-        $ [green]nextmv cloud run cancel --app-id hare-app --run-id burrow-123 --profile hare[/green]
+        $ [dim]nextmv cloud run cancel --app-id hare-app --run-id burrow-123 --profile hare[/dim]
     """
 
     cloud_app = build_app(app_id=app_id, profile=profile)

--- a/nextmv/nextmv/cli/cloud/run/create.py
+++ b/nextmv/nextmv/cli/cloud/run/create.py
@@ -68,7 +68,7 @@ def create(
             "--tail",
             "-t",
             help="Tail the logs until the run completes. Logs are streamed to [magenta]stderr[/magenta]. "
-            "Specify log output location with [code]--logs[/code].",
+            "Specify log output location with --logs.",
             rich_help_panel="Output control",
         ),
     ] = False,
@@ -79,7 +79,7 @@ def create(
             "-w",
             help="Wait for the run to complete. Run result is printed to [magenta]stdout[/magenta] for "
             "[magenta]json[/magenta], to a dir for [magenta]multi-file[/magenta]. "
-            "Specify output location with [code]--output[/code].",
+            "Specify output location with --output.",
             rich_help_panel="Output control",
         ),
     ] = False,
@@ -210,8 +210,8 @@ def create(
     Create a new Nextmv Cloud application run.
 
     Input for the run should be given through [magenta]stdin[/magenta] or the
-    [code]--input[/code] flag. When using the [code]--input[/code] flag, the
-    value can be one of the following:
+    --input flag. When using the --input flag, the value can be one of the
+    following:
 
     - [green]<FILE_PATH>[/green]: path to a [magenta]file[/magenta] containing
       the input data. Use with the [magenta]json[/magenta], and
@@ -226,27 +226,26 @@ def create(
     The CLI determines how to send the input to the application based on the
     value.
 
-    Use the [code]--wait[/code] flag to wait for the run to complete, polling
-    for results. Using the [code]--output[/code] flag will also activate
-    waiting, and allows you to specify a destination (file or dir) for the
-    output, depending on the content type.
+    Use the --wait flag to wait for the run to complete, polling for results.
+    Using the --output flag will also activate waiting, and allows you to
+    specify a destination (file or dir) for the output, depending on the
+    content type.
 
-    Use the [code]--tail[/code] flag to stream logs to
-    [magenta]stderr[/magenta] until the run completes. Using the
-    [code]--logs[/code] flag will also activate waiting, and allows you to
-    specify a file to write the logs to.
+    Use the --tail flag to stream logs to [magenta]stderr[/magenta] until the
+    run completes. Using the --logs flag will also activate waiting, and allows
+    you to specify a file to write the logs to.
 
     An application run executes against a specific instance. An instance
     represents the combination of executable code and configuration. You can
-    specify the instance with the [code]--instance-id[/code] flag. These are
-    the possible values for this flag:
+    specify the instance with the --instance-id flag. These are the possible
+    values for this flag:
 
     - [green]latest[/green]: uses the special [magenta]latest[/magenta]
       instance of the application. This corresponds to the latest pushed
       executable. This is the default behavior.
     - [green]default[/green]: if the application has a [italic]default[/italic]
       instance configured, then it uses that instance. Setting the flag's value
-      to [code]''[/code] (empty string) has the same effect.
+      to [magenta]''[/magenta] (empty string) has the same effect.
     - [green]<INSTANCE_ID>[/green]: uses the instance with the given ID.
 
     [bold][underline]Examples[/underline][/bold]
@@ -304,7 +303,7 @@ def create(
     # Validate that input is provided.
     stdin = sys.stdin.read().strip() if sys.stdin.isatty() is False else None
     if stdin is None and (input is None or input == ""):
-        error("Input data must be provided via the [code]--input[/code] flag or [magenta]stdin[/magenta].")
+        error("Input data must be provided via the --input flag or [magenta]stdin[/magenta].")
 
     # Instantiate the basic requirements to start a new run.
     cloud_app = build_app(app_id=app_id, profile=profile)

--- a/nextmv/nextmv/cli/cloud/run/create.py
+++ b/nextmv/nextmv/cli/cloud/run/create.py
@@ -213,13 +213,13 @@ def create(
     --input flag. When using the --input flag, the value can be one of the
     following:
 
-    - [green]<FILE_PATH>[/green]: path to a [magenta]file[/magenta] containing
+    - [yellow]<FILE_PATH>[/yellow]: path to a [magenta]file[/magenta] containing
       the input data. Use with the [magenta]json[/magenta], and
       [magenta]text[/magenta] content formats.
-    - [green]<DIR_PATH>[/green]: path to a [magenta]directory[/magenta]
+    - [yellow]<DIR_PATH>[/yellow]: path to a [magenta]directory[/magenta]
       containing the input data files. Use with the
       [magenta]multi-file[/magenta] content format.
-    - [green]<.tar.gz_PATH>[/green]: path to a [magenta].tar.gz[/magenta] file
+    - [yellow]<.tar.gz PATH>[/yellow]: path to a [magenta].tar.gz[/magenta] file
       containing tarred input data files. Use with the
       [magenta]multi-file[/magenta] content format.
 
@@ -240,64 +240,64 @@ def create(
     specify the instance with the --instance-id flag. These are the possible
     values for this flag:
 
-    - [green]latest[/green]: uses the special [magenta]latest[/magenta]
+    - [yellow]latest[/yellow]: uses the special [magenta]latest[/magenta]
       instance of the application. This corresponds to the latest pushed
       executable. This is the default behavior.
-    - [green]default[/green]: if the application has a [italic]default[/italic]
+    - [yellow]default[/yellow]: if the application has a [italic]default[/italic]
       instance configured, then it uses that instance. Setting the flag's value
       to [magenta]''[/magenta] (empty string) has the same effect.
-    - [green]<INSTANCE_ID>[/green]: uses the instance with the given ID.
+    - [yellow]<INSTANCE_ID>[/yellow]: uses the instance with the given ID.
 
     [bold][underline]Examples[/underline][/bold]
 
     - Read a [magenta]json[/magenta] input via [magenta]stdin[/magenta], from an [magenta]input.json[/magenta] file,
       and submit a run to an app with ID [magenta]hare-app[/magenta], using the [magenta]latest[/magenta] instance.
-        $ [green]cat input.json | nextmv cloud run create --app-id hare-app[/green]
+        $ [dim]cat input.json | nextmv cloud run create --app-id hare-app[/dim]
 
     - Read a [magenta]json[/magenta] input from an [magenta]input.json[/magenta] file, and
       submit a run to an app with ID [magenta]hare-app[/magenta], using the [magenta]latest[/magenta] instance.
-        $ [green]nextmv cloud run create --app-id hare-app --input input.json[/green]
+        $ [dim]nextmv cloud run create --app-id hare-app --input input.json[/dim]
 
     - Read a [magenta]json[/magenta] input from an [magenta]input.json[/magenta] file, and
       submit a run to an app with ID [magenta]hare-app[/magenta], using the [magenta]latest[/magenta] instance.
       Wait for the run to complete and print the result to [magenta]stdout[/magenta].
-        $ [green]nextmv cloud run create --app-id hare-app --input input.json --wait[/green]
+        $ [dim]nextmv cloud run create --app-id hare-app --input input.json --wait[/dim]
 
     - Read a [magenta]json[/magenta] input from an [magenta]input.json[/magenta] file, and
       submit a run to an app with ID [magenta]hare-app[/magenta], using the [magenta]latest[/magenta] instance.
       Tail the run's logs, streaming to [magenta]stderr[/magenta].
-        $ [green]nextmv cloud run create --app-id hare-app --input input.json --tail[/green]
+        $ [dim]nextmv cloud run create --app-id hare-app --input input.json --tail[/dim]
 
     - Read a [magenta]json[/magenta] input from an [magenta]input.json[/magenta] file, and
       submit a run to an app with ID [magenta]hare-app[/magenta], using the [magenta]latest[/magenta] instance.
       Wait for the run to complete and write the result to an [magenta]output.json[/magenta] file.
-        $ [green]nextmv cloud run create --app-id hare-app --input input.json --output output.json[/green]
+        $ [dim]nextmv cloud run create --app-id hare-app --input input.json --output output.json[/dim]
 
     - Read a [magenta]json[/magenta] input from an [magenta]input.json[/magenta] file, and
       submit a run to an app with ID [magenta]hare-app[/magenta], using the [magenta]latest[/magenta] instance.
       Wait for the run to complete, and write the logs to a [magenta]logs.log[/magenta] file.
-        $ [green]nextmv cloud run create --app-id hare-app --input input.json --logs logs.log[/green]
+        $ [dim]nextmv cloud run create --app-id hare-app --input input.json --logs logs.log[/dim]
 
     - Read a [magenta]json[/magenta] input from an [magenta]input.json[/magenta] file, and submit a run to an app with
       ID [magenta]hare-app[/magenta], using the [magenta]latest[/magenta] instance. Wait for the run to complete. Tail
       the run's logs, streaming to [magenta]stderr[/magenta]. Write the logs to a [magenta]logs.log[/magenta] file.
       Write the result to an [magenta]output.json[/magenta] file.
-        $ [green]nextmv cloud run create --app-id hare-app --input input.json --tail --logs logs.log \\
-            --output output.json [/green]
+        $ [dim]nextmv cloud run create --app-id hare-app --input input.json --tail --logs logs.log \\
+            --output output.json [/dim]
 
     - Read a [magenta]multi-file[/magenta] input from an [magenta]inputs[/magenta] directory, and
       submit a run to an app with ID [magenta]hare-app[/magenta], using the [magenta]default[/magenta] instance.
-        $ [green]nextmv cloud run create --app-id hare-app --input inputs --instance-id default[/green]
+        $ [dim]nextmv cloud run create --app-id hare-app --input inputs --instance-id default[/dim]
 
     - Read a [magenta]multi-file[/magenta] input from an [magenta]inputs[/magenta] directory, and
       submit a run to an app with ID [magenta]hare-app[/magenta], using the [magenta]default[/magenta] instance.
       Wait for the run to complete, and save the results to the default location (a directory named after the run ID).
-        $ [green]nextmv cloud run create --app-id hare-app --input inputs --instance-id default --wait[/green]
+        $ [dim]nextmv cloud run create --app-id hare-app --input inputs --instance-id default --wait[/dim]
 
     - Read a [magenta]multi-file[/magenta] input from an [magenta]inputs[/magenta] directory, and
       submit a run to an app with ID [magenta]hare-app[/magenta], using the [magenta]burrow[/magenta] instance.
       Wait for the run to complete and download the result files to an [magenta]outputs[/magenta] directory.
-        $ [green]nextmv cloud run create --app-id hare-app --input inputs --instance-id burrow --output outputs[/green]
+        $ [dim]nextmv cloud run create --app-id hare-app --input inputs --instance-id burrow --output outputs[/dim]
     """
 
     # Validate that input is provided.

--- a/nextmv/nextmv/cli/cloud/run/get.py
+++ b/nextmv/nextmv/cli/cloud/run/get.py
@@ -46,7 +46,7 @@ def get(
             "-w",
             help="Wait for the run to complete. Run result is printed to [magenta]stdout[/magenta] for "
             "[magenta]json[/magenta], to a dir for [magenta]multi-file[/magenta]. "
-            "Specify output location with [code]--output[/code].",
+            "Specify output location with --output.",
         ),
     ] = False,
     profile: ProfileOption = None,
@@ -54,8 +54,8 @@ def get(
     """
     Get the result (output) of a Nextmv Cloud application run.
 
-    Use the [code]--wait[/code] flag to wait for the run to complete, polling
-    for results. Using the [code]--output[/code] flag will also activate
+    Use the --wait flag to wait for the run to complete, polling
+    for results. Using the --output flag will also activate
     waiting, and allows you to specify a destination (file or dir) for the
     output, depending on the content type.
 

--- a/nextmv/nextmv/cli/cloud/run/get.py
+++ b/nextmv/nextmv/cli/cloud/run/get.py
@@ -63,25 +63,25 @@ def get(
 
     - Get the results of a run with ID [magenta]burrow-123[/magenta], belonging to an app with ID
       [magenta]hare-app[/magenta].
-        $ [green]nextmv cloud run get --app-id hare-app --run-id burrow-123[/green]
+        $ [dim]nextmv cloud run get --app-id hare-app --run-id burrow-123[/dim]
 
     - Get the results of a run with ID [magenta]burrow-123[/magenta], belonging to an app with ID
       [magenta]hare-app[/magenta]. Wait for the run to complete if necessary.
-        $ [green]nextmv cloud run get --app-id hare-app --run-id burrow-123 --wait[/green]
+        $ [dim]nextmv cloud run get --app-id hare-app --run-id burrow-123 --wait[/dim]
 
     - Get the results of a run with ID [magenta]burrow-123[/magenta], belonging to an app with ID
       [magenta]hare-app[/magenta]. The app is a [magenta]json[/magenta] app.
       Save the results to a [magenta]results.json[/magenta] file.
-        $ [green]nextmv cloud run get --app-id hare-app --run-id burrow-123 --output results.json[/green]
+        $ [dim]nextmv cloud run get --app-id hare-app --run-id burrow-123 --output results.json[/dim]
 
     - Get the results of a run with ID [magenta]burrow-123[/magenta], belonging to an app with ID
       [magenta]hare-app[/magenta]. The app is a [magenta]multi-file[/magenta] app.
       Save the results to the [magenta]results[/magenta] dir.
-        $ [green]nextmv cloud run get --app-id hare-app --run-id burrow-123 --output results[/green]
+        $ [dim]nextmv cloud run get --app-id hare-app --run-id burrow-123 --output results[/dim]
 
     - Get the results of a run with ID [magenta]burrow-123[/magenta], belonging to an app with ID
       [magenta]hare-app[/magenta]. Use the profile named [magenta]hare[/magenta].
-        $ [green]nextmv cloud run get --app-id hare-app --run-id burrow-123 --profile hare[/green]
+        $ [dim]nextmv cloud run get --app-id hare-app --run-id burrow-123 --profile hare[/dim]
     """
 
     cloud_app = build_app(app_id=app_id, profile=profile)

--- a/nextmv/nextmv/cli/cloud/run/input.py
+++ b/nextmv/nextmv/cli/cloud/run/input.py
@@ -35,7 +35,7 @@ def input(
     Get the input of a Nextmv Cloud application run.
 
     By default, the input is fetched and printed to [magenta]stdout[/magenta].
-    Use the [code]--output[/code] flag to save the input to a file.
+    Use the --output flag to save the input to a file.
 
     [bold][underline]Examples[/underline][/bold]
 

--- a/nextmv/nextmv/cli/cloud/run/input.py
+++ b/nextmv/nextmv/cli/cloud/run/input.py
@@ -41,15 +41,15 @@ def input(
 
     - Get the input of a run with ID [magenta]burrow-123[/magenta], belonging to an app with ID
       [magenta]hare-app[/magenta]. Input is printed to [magenta]stdout[/magenta].
-        $ [green]nextmv cloud run input --app-id hare-app --run-id burrow-123[/green]
+        $ [dim]nextmv cloud run input --app-id hare-app --run-id burrow-123[/dim]
 
     - Get the input of a run with ID [magenta]burrow-123[/magenta], belonging to an app with ID
       [magenta]hare-app[/magenta]. Save the input to a [magenta]input.json[/magenta] file.
-        $ [green]nextmv cloud run input --app-id hare-app --run-id burrow-123 --output input.json[/green]
+        $ [dim]nextmv cloud run input --app-id hare-app --run-id burrow-123 --output input.json[/dim]
 
     - Get the input of a run with ID [magenta]burrow-123[/magenta], belonging to an app with ID
       [magenta]hare-app[/magenta]. Use the profile named [magenta]hare[/magenta].
-        $ [green]nextmv cloud run input --app-id hare-app --run-id burrow-123 --profile hare[/green]
+        $ [dim]nextmv cloud run input --app-id hare-app --run-id burrow-123 --profile hare[/dim]
     """
 
     cloud_app = build_app(app_id=app_id, profile=profile)

--- a/nextmv/nextmv/cli/cloud/run/list.py
+++ b/nextmv/nextmv/cli/cloud/run/list.py
@@ -43,9 +43,9 @@ def list(
     Get the list of runs for a Nextmv Cloud application.
 
     By default, the list of runs is fetched and printed to [magenta]stdout[/magenta].
-    Use the [code]--output[/code] flag to save the list to a file.
+    Use the --output flag to save the list to a file.
 
-    You can use the optional [code]--status[/code] flag to filter runs by their status.
+    You can use the optional --status flag to filter runs by their status.
 
     [bold][underline]Examples[/underline][/bold]
 

--- a/nextmv/nextmv/cli/cloud/run/list.py
+++ b/nextmv/nextmv/cli/cloud/run/list.py
@@ -50,18 +50,18 @@ def list(
     [bold][underline]Examples[/underline][/bold]
 
     - Get the list of runs for an app with ID [magenta]hare-app[/magenta]. List is printed to [magenta]stdout[/magenta].
-        $ [green]nextmv cloud run list --app-id hare-app[/green]
+        $ [dim]nextmv cloud run list --app-id hare-app[/dim]
 
     - Get the list of runs for an app with ID [magenta]hare-app[/magenta]. Save the list to a
       [magenta]runs.json[/magenta] file.
-        $ [green]nextmv cloud run list --app-id hare-app --output runs.json[/green]
+        $ [dim]nextmv cloud run list --app-id hare-app --output runs.json[/dim]
 
     - Get the list of runs for an app with ID [magenta]hare-app[/magenta].
       Use the profile named [magenta]hare[/magenta].
-        $ [green]nextmv cloud run list --app-id hare-app --profile hare[/green]
+        $ [dim]nextmv cloud run list --app-id hare-app --profile hare[/dim]
 
     - Get the list of [magenta]queued[/magenta] runs for an app with ID [magenta]hare-app[/magenta].
-        $ [green]nextmv cloud run list --app-id hare-app --status queued[/green]
+        $ [dim]nextmv cloud run list --app-id hare-app --status queued[/dim]
     """
 
     cloud_app = build_app(app_id=app_id, profile=profile)

--- a/nextmv/nextmv/cli/cloud/run/logs.py
+++ b/nextmv/nextmv/cli/cloud/run/logs.py
@@ -38,7 +38,7 @@ def logs(
             "--tail",
             "-t",
             help="Tail the logs until the run completes. Logs are streamed to [magenta]stderr[/magenta]. "
-            "Specify log output location with [code]--output[/code].",
+            "Specify log output location with --output.",
         ),
     ] = False,
     timeout: Annotated[
@@ -54,10 +54,9 @@ def logs(
     Get the logs of a Nextmv Cloud application run.
 
     By default, the logs are fetched and printed to [magenta]stderr[/magenta].
-    Use the [code]--tail[/code] flag to stream logs to
-    [magenta]stderr[/magenta] until the run completes. Using the
-    [code]--output[/code] flag will also activate waiting, and allows you to
-    specify a file to write the logs to.
+    Use the --tail flag to stream logs to [magenta]stderr[/magenta] until the
+    run completes. Using the --output flag will also activate waiting, and
+    allows you to specify a file to write the logs to.
 
     [bold][underline]Examples[/underline][/bold]
 

--- a/nextmv/nextmv/cli/cloud/run/logs.py
+++ b/nextmv/nextmv/cli/cloud/run/logs.py
@@ -62,23 +62,23 @@ def logs(
 
     - Get the logs of a run with ID [magenta]burrow-123[/magenta], belonging to an app with ID
       [magenta]hare-app[/magenta]. Logs are printed to [magenta]stderr[/magenta].
-        $ [green]nextmv cloud run logs --app-id hare-app --run-id burrow-123[/green]
+        $ [dim]nextmv cloud run logs --app-id hare-app --run-id burrow-123[/dim]
 
     - Get the logs of a run with ID [magenta]burrow-123[/magenta], belonging to an app with ID
       [magenta]hare-app[/magenta]. Tail the logs until the run completes.
-        $ [green]nextmv cloud run logs --app-id hare-app --run-id burrow-123 --tail[/green]
+        $ [dim]nextmv cloud run logs --app-id hare-app --run-id burrow-123 --tail[/dim]
 
     - Get the logs of a run with ID [magenta]burrow-123[/magenta], belonging to an app with ID
       [magenta]hare-app[/magenta]. Save the logs to a [magenta]logs.log[/magenta] file.
-        $ [green]nextmv cloud run logs --app-id hare-app --run-id burrow-123 --output logs.log[/green]
+        $ [dim]nextmv cloud run logs --app-id hare-app --run-id burrow-123 --output logs.log[/dim]
 
     - Get the logs of a run with ID [magenta]burrow-123[/magenta], belonging to an app with ID
       [magenta]hare-app[/magenta]. Tail the logs and save them to a [magenta]logs.log[/magenta] file.
-        $ [green]nextmv cloud run logs --app-id hare-app --run-id burrow-123 --tail --output logs.log[/green]
+        $ [dim]nextmv cloud run logs --app-id hare-app --run-id burrow-123 --tail --output logs.log[/dim]
 
     - Get the logs of a run with ID [magenta]burrow-123[/magenta], belonging to an app with ID
       [magenta]hare-app[/magenta]. Use the profile named [magenta]hare[/magenta].
-        $ [green]nextmv cloud run logs --app-id hare-app --run-id burrow-123 --profile hare[/green]
+        $ [dim]nextmv cloud run logs --app-id hare-app --run-id burrow-123 --profile hare[/dim]
     """
 
     cloud_app = build_app(app_id=app_id, profile=profile)

--- a/nextmv/nextmv/cli/cloud/run/metadata.py
+++ b/nextmv/nextmv/cli/cloud/run/metadata.py
@@ -40,15 +40,15 @@ def metadata(
 
     - Get the metadata of a run with ID [magenta]burrow-123[/magenta], belonging to an app with ID
       [magenta]hare-app[/magenta]. Metadata is printed to [magenta]stdout[/magenta].
-        $ [green]nextmv cloud run metadata --app-id hare-app --run-id burrow-123[/green]
+        $ [dim]nextmv cloud run metadata --app-id hare-app --run-id burrow-123[/dim]
 
     - Get the metadata of a run with ID [magenta]burrow-123[/magenta], belonging to an app with ID
       [magenta]hare-app[/magenta]. Save the metadata to a [magenta]metadata.json[/magenta] file.
-        $ [green]nextmv cloud run metadata --app-id hare-app --run-id burrow-123 --output metadata.json[/green]
+        $ [dim]nextmv cloud run metadata --app-id hare-app --run-id burrow-123 --output metadata.json[/dim]
 
     - Get the metadata of a run with ID [magenta]burrow-123[/magenta], belonging to an app with ID
       [magenta]hare-app[/magenta]. Use the profile named [magenta]hare[/magenta].
-        $ [green]nextmv cloud run metadata --app-id hare-app --run-id burrow-123 --profile hare[/green]
+        $ [dim]nextmv cloud run metadata --app-id hare-app --run-id burrow-123 --profile hare[/dim]
     """
 
     cloud_app = build_app(app_id=app_id, profile=profile)

--- a/nextmv/nextmv/cli/cloud/run/metadata.py
+++ b/nextmv/nextmv/cli/cloud/run/metadata.py
@@ -34,7 +34,7 @@ def metadata(
     Get the metadata of a Nextmv Cloud application run.
 
     By default, the metadata is fetched and printed to [magenta]stdout[/magenta].
-    Use the [code]--output[/code] flag to save the metadata to a file.
+    Use the --output flag to save the metadata to a file.
 
     [bold][underline]Examples[/underline][/bold]
 

--- a/nextmv/nextmv/cli/cloud/run/track.py
+++ b/nextmv/nextmv/cli/cloud/run/track.py
@@ -168,55 +168,55 @@ def track(
 
     - Track a [magenta]successful[/magenta] [magenta]json[/magenta] run via [magenta]stdin[/magenta]
       input, for an app with ID [magenta]hare-app[/magenta].
-        $ [green]cat input.json | nextmv cloud run track --app-id hare-app --status succeeded[/green]
+        $ [dim]cat input.json | nextmv cloud run track --app-id hare-app --status succeeded[/dim]
 
     - Track a [magenta]successful[/magenta] [magenta]json[/magenta] run with input from an
       [magenta]input.json[/magenta] file and output from an
       [magenta]output.json[/magenta] file, for an app with ID
       [magenta]hare-app[/magenta].
-        $ [green]nextmv cloud run track --app-id hare-app --status succeeded --input input.json \\
-            --output output.json[/green]
+        $ [dim]nextmv cloud run track --app-id hare-app --status succeeded --input input.json \\
+            --output output.json[/dim]
 
     - Track a [magenta]successful[/magenta] [magenta]json[/magenta] run including logs from a
       [magenta]logs.log[/magenta] file, for an app with ID
       [magenta]hare-app[/magenta].
-        $ [green]nextmv cloud run track --app-id hare-app --status succeeded --input input.json \\
-            --output output.json --logs logs.log[/green]
+        $ [dim]nextmv cloud run track --app-id hare-app --status succeeded --input input.json \\
+            --output output.json --logs logs.log[/dim]
 
     - Track a [magenta]successful[/magenta] [magenta]json[/magenta] run with assets and statistics
       from [magenta]json[/magenta] files, for an app with ID
       [magenta]hare-app[/magenta].
-        $ [green]nextmv cloud run track --app-id hare-app --status succeeded --input input.json \\
-            --output output.json --assets assets.json --statistics statistics.json[/green]
+        $ [dim]nextmv cloud run track --app-id hare-app --status succeeded --input input.json \\
+            --output output.json --assets assets.json --statistics statistics.json[/dim]
 
     - Track a [magenta]failed[/magenta] run with an error message, for an app with ID
       [magenta]hare-app[/magenta].
-        $ [green]nextmv cloud run track --app-id hare-app --status failed --input input.json \\
-            --error-msg "Solver timed out"[/green]
+        $ [dim]nextmv cloud run track --app-id hare-app --status failed --input input.json \\
+            --error-msg "Solver timed out"[/dim]
 
     - Track a [magenta]successful[/magenta] [magenta]text[/magenta] run with text content type,
       for an app with ID [magenta]hare-app[/magenta].
-        $ [green]nextmv cloud run track --app-id hare-app --status succeeded --input input.txt \\
-            --output output.txt --content-type text[/green]
+        $ [dim]nextmv cloud run track --app-id hare-app --status succeeded --input input.txt \\
+            --output output.txt --content-type text[/dim]
 
     - Track a [magenta]successful[/magenta] [magenta]multi-file[/magenta] run from an
       [magenta]inputs[/magenta] directory with output to an
       [magenta]outputs[/magenta] directory, for an app with ID
       [magenta]hare-app[/magenta], using the [magenta]default[/magenta]
       instance.
-        $ [green]nextmv cloud run track --app-id hare-app --status succeeded --input inputs \\
-            --output outputs --content-type multi-file --instance-id default[/green]
+        $ [dim]nextmv cloud run track --app-id hare-app --status succeeded --input inputs \\
+            --output outputs --content-type multi-file --instance-id default[/dim]
 
     - Track a [magenta]successful[/magenta] run with a name, description, and duration, for an app
       with ID [magenta]hare-app[/magenta].
-        $ [green]nextmv cloud run track --app-id hare-app --status succeeded --input input.json \\
-            --output output.json --name "Production run" --description "Weekly optimization" --duration 5000[/green]
+        $ [dim]nextmv cloud run track --app-id hare-app --status succeeded --input input.json \\
+            --output output.json --name "Production run" --description "Weekly optimization" --duration 5000[/dim]
 
     - Track a [magenta]successful[/magenta] [magenta]json[/magenta] run with all available options,
       for an app with ID [magenta]hare-app[/magenta].
-        $ [green]nextmv cloud run track --app-id hare-app --status succeeded --input input.json \\
+        $ [dim]nextmv cloud run track --app-id hare-app --status succeeded --input input.json \\
             --output output.json --logs logs.log --assets assets.json --statistics statistics.json \\
-                --name "Full run" --description "Complete example" --duration 10000 --instance-id burrow[/green]
+                --name "Full run" --description "Complete example" --duration 10000 --instance-id burrow[/dim]
     """
 
     # Validate that input is provided.

--- a/nextmv/nextmv/cli/cloud/run/track.py
+++ b/nextmv/nextmv/cli/cloud/run/track.py
@@ -143,27 +143,26 @@ def track(
     """
     Track an external run as a Nextmv Cloud application run.
 
-    Please see the help of the [code]--content-type[/code] option for details
-    on valid content types.
+    Please see the help of the --content-type option for details on valid
+    content types.
 
     If the content type is [magenta]json[/magenta] or [magenta]text[/magenta],
     then input for the run can be given through [magenta]stdin[/magenta]. The
-    [code]--input[/code] option allows you to specify a file or directory path
-    for the input, instead of using [magenta]stdin[/magenta]. In the case of
+    --input option allows you to specify a file or directory path for the
+    input, instead of using [magenta]stdin[/magenta]. In the case of
     [magenta]multi-file[/magenta] content type, the input must be given through
-    a directory specified via the [code]--input[/code] option.
+    a directory specified via the --input option.
 
-    The [code]--output[/code] option allows you to specify a file or directory
-    path for the output of the run. The behavior depends on the content type.
-    If the content type is [magenta]json[/magenta] or [magenta]text[/magenta],
-    then a file path must be provided. If the content type is
+    The --output option allows you to specify a file or directory path for the
+    output of the run. The behavior depends on the content type. If the content
+    type is [magenta]json[/magenta] or [magenta]text[/magenta], then a file
+    path must be provided. If the content type is
     [magenta]multi-file[/magenta], then a directory path must be provided.
 
     Run logs, assets, and statistics can be provided via files using the
-    [code]--logs[/code], [code]--assets[/code], and [code]--statistics[/code]
-    options, respectively. Assets and statistics must be provided as
-    [magenta]json[/magenta] files, while logs must be provided as a utf-8
-    encoded text file.
+    --logs, --assets, and --statistics options, respectively. Assets and
+    statistics must be provided as [magenta]json[/magenta] files, while logs
+    must be provided as a utf-8 encoded text file.
 
     [bold][underline]Examples[/underline][/bold]
 
@@ -223,7 +222,7 @@ def track(
     # Validate that input is provided.
     stdin = sys.stdin.read().strip() if sys.stdin.isatty() is False else None
     if stdin is None and (input is None or input == ""):
-        error("Input data must be provided via the [code]--input[/code] flag or [magenta]stdin[/magenta].")
+        error("Input data must be provided via the --input flag or [magenta]stdin[/magenta].")
 
     # Instantiate the basic requirements to start a new run.
     cloud_app = build_app(app_id=app_id, profile=profile)
@@ -393,7 +392,7 @@ def resolve_input(
                 error(
                     "Input provided via [magenta]stdin[/magenta] is [magenta]json[/magenta], "
                     f"but the specified content format is {content_format.value}. "
-                    "[code]--content-format[/code] should be set to [magenta]json[/magenta]."
+                    "--content-format should be set to [magenta]json[/magenta]."
                 )
 
         except json.JSONDecodeError:
@@ -402,7 +401,7 @@ def resolve_input(
                 error(
                     "Input provided via [magenta]stdin[/magenta] is [magenta]text[/magenta], "
                     f"but the specified content format is {content_format.value}. "
-                    "[code]--content-format[/code] should be set to [magenta]text[/magenta]."
+                    "--content-format should be set to [magenta]text[/magenta]."
                 )
 
         tracked_run.input = input_data

--- a/nextmv/nextmv/cli/cloud/scenario/create.py
+++ b/nextmv/nextmv/cli/cloud/scenario/create.py
@@ -142,7 +142,7 @@ def create(
         - [magenta]values[/magenta]: List of values for the configuration option.
 
     Example object format:
-    [green]{
+    [dim]{
         "instance_id": "bunny-hopper-v2",
         "scenario_input": {
             "scenario_input_type": "input_set",
@@ -157,12 +157,12 @@ def create(
                 "values": ["optimized", "balanced", "safe"]
             }
         ]
-    }[/green]
+    }[/dim]
 
     [bold][underline]Examples[/underline][/bold]
 
     - Create a scenario test with a single scenario.
-        $ [green]SCENARIO='{
+        $ [dim]SCENARIO='{
             "instance_id": "warren-planner-v1",
             "scenario_input": {
                 "scenario_input_type": "input_set",
@@ -172,10 +172,10 @@ def create(
                 }
             }
         }'
-        nextmv cloud scenario create --app-id hare-app --name "Spring Meadow Routes" --scenarios "$SCENARIO"[/green]
+        nextmv cloud scenario create --app-id hare-app --name "Spring Meadow Routes" --scenarios "$SCENARIO"[/dim]
 
     - Create with multiple scenarios by repeating the flag.
-        $ [green]SCENARIO1='{
+        $ [dim]SCENARIO1='{
             "instance_id": "hop-optimizer",
             "scenario_input": {
                 "scenario_input_type": "input_set",
@@ -196,10 +196,10 @@ def create(
             }
         }'
         nextmv cloud scenario create --app-id hare-app --name "Lettuce Delivery Optimization" \\
-            --scenarios "$SCENARIO1" --scenarios "$SCENARIO2"[/green]
+            --scenarios "$SCENARIO1" --scenarios "$SCENARIO2"[/dim]
 
     - Create with multiple scenarios in a single [magenta]json[/magenta] array.
-        $ [green]SCENARIOS='[
+        $ [dim]SCENARIOS='[
             {
                 "instance_id": "burrow-builder",
                 "scenario_input": {
@@ -222,10 +222,10 @@ def create(
             }
         ]'
         nextmv cloud scenario create --app-id hare-app --name "Warren Construction Plans" \\
-            --scenarios "$SCENARIOS"[/green]
+            --scenarios "$SCENARIOS"[/dim]
 
     - Create a scenario test and wait for it to complete.
-        $ [green]SCENARIO='{
+        $ [dim]SCENARIO='{
             "instance_id": "foraging-route",
             "scenario_input": {
                 "scenario_input_type": "input_set",
@@ -236,10 +236,10 @@ def create(
             }
         }'
         nextmv cloud scenario create --app-id hare-app --name "Autumn Carrot Collection" --scenarios "$SCENARIO" \\
-            --wait[/green]
+            --wait[/dim]
 
     - Create a scenario test and save the results to a file, waiting for completion.
-        $ [green]SCENARIO='{
+        $ [dim]SCENARIO='{
             "instance_id": "safe-hopper",
             "scenario_input": {
                 "scenario_input_type": "input_set",
@@ -250,10 +250,10 @@ def create(
             }
         }'
         nextmv cloud scenario create --app-id hare-app --name "Fox Avoidance Routes" --scenarios "$SCENARIO" \\
-            --output bunny-safety-results.json[/green]
+            --output bunny-safety-results.json[/dim]
 
     - Create a scenario test with configuration options.
-        $ [green]SCENARIO='{
+        $ [dim]SCENARIO='{
             "instance_id": "hop-optimizer",
             "scenario_input": {
                 "scenario_input_type": "input_set",
@@ -269,7 +269,7 @@ def create(
                 }
             ]
         }'
-        nextmv cloud scenario create --app-id hare-app --name "Speed Analysis" --scenarios "$SCENARIO"[/green]
+        nextmv cloud scenario create --app-id hare-app --name "Speed Analysis" --scenarios "$SCENARIO"[/dim]
     """
 
     cloud_app = build_app(app_id=app_id, profile=profile)

--- a/nextmv/nextmv/cli/cloud/scenario/create.py
+++ b/nextmv/nextmv/cli/cloud/scenario/create.py
@@ -100,7 +100,7 @@ def create(
             "--wait",
             "-w",
             help="Wait for the scenario test to complete. Results are printed to [magenta]stdout[/magenta]. "
-            "Specify output location with [code]--output[/code].",
+            "Specify output location with --output.",
             rich_help_panel="Output control",
         ),
     ] = False,
@@ -112,21 +112,21 @@ def create(
     A scenario test allows you to run multiple scenarios with different inputs,
     instances/versions, and configurations in a single test.
 
-    Use the [code]--wait[/code] flag to wait for the scenario test to complete,
-    polling for results. Using the [code]--output[/code] flag will also
+    Use the --wait flag to wait for the scenario test to complete,
+    polling for results. Using the --output flag will also
     activate waiting, and allows you to specify a destination file for the
     results.
 
     [bold][underline]Scenarios[/underline][/bold]
 
     Scenarios are provided as [magenta]json[/magenta] objects using the
-    [code]--scenarios[/code] flag. Each scenario defines the configuration for
-    a scenario test execution.
+    --scenarios flag. Each scenario defines the configuration for a scenario
+    test execution.
 
     You can provide scenarios in three ways:
     - A single scenario as a [magenta]json[/magenta] object.
-    - Multiple scenarios by repeating the [code]--scenarios[/code] flag.
-    - Multiple scenarios as a [magenta]json[/magenta] array in a single [code]--scenarios[/code] flag.
+    - Multiple scenarios by repeating the --scenarios flag.
+    - Multiple scenarios as a [magenta]json[/magenta] array in a single --scenarios flag.
 
     Each scenario must have the following fields:
     - [magenta]instance_id[/magenta]: ID of the instance to use for this scenario (required).

--- a/nextmv/nextmv/cli/cloud/scenario/delete.py
+++ b/nextmv/nextmv/cli/cloud/scenario/delete.py
@@ -40,10 +40,10 @@ def delete(
 
     - Delete the scenario test with the ID [magenta]hop-analysis[/magenta] from application
       [magenta]hare-app[/magenta].
-        $ [green]nextmv cloud scenario delete --app-id hare-app --scenario-test-id hop-analysis[/green]
+        $ [dim]nextmv cloud scenario delete --app-id hare-app --scenario-test-id hop-analysis[/dim]
 
     - Delete the scenario test without confirmation prompt.
-        $ [green]nextmv cloud scenario delete --app-id hare-app --scenario-test-id carrot-routes --yes[/green]
+        $ [dim]nextmv cloud scenario delete --app-id hare-app --scenario-test-id carrot-routes --yes[/dim]
     """
 
     if not yes:

--- a/nextmv/nextmv/cli/cloud/scenario/delete.py
+++ b/nextmv/nextmv/cli/cloud/scenario/delete.py
@@ -33,7 +33,7 @@ def delete(
     Deletes a Nextmv Cloud scenario test.
 
     This action is permanent and cannot be undone. The scenario test and all
-    associated data will be deleted. Use the [code]--yes[/code] flag to skip
+    associated data will be deleted. Use the --yes flag to skip
     the confirmation prompt.
 
     [bold][underline]Examples[/underline][/bold]

--- a/nextmv/nextmv/cli/cloud/scenario/get.py
+++ b/nextmv/nextmv/cli/cloud/scenario/get.py
@@ -59,17 +59,17 @@ def get(
 
     - Get the scenario test with ID [magenta]carrot-optimization[/magenta] from application
       [magenta]hare-app[/magenta].
-        $ [green]nextmv cloud scenario get --app-id hare-app --scenario-test-id carrot-optimization[/green]
+        $ [dim]nextmv cloud scenario get --app-id hare-app --scenario-test-id carrot-optimization[/dim]
 
     - Get the scenario test and wait for it to complete if necessary.
-        $ [green]nextmv cloud scenario get --app-id hare-app --scenario-test-id bunny-hop-test --wait[/green]
+        $ [dim]nextmv cloud scenario get --app-id hare-app --scenario-test-id bunny-hop-test --wait[/dim]
 
     - Get the scenario test and save the results to a file.
-        $ [green]nextmv cloud scenario get --app-id hare-app --scenario-test-id warren-planning \\
-            --output results.json[/green]
+        $ [dim]nextmv cloud scenario get --app-id hare-app --scenario-test-id warren-planning \\
+            --output results.json[/dim]
 
     - Get the scenario test using a specific profile.
-        $ [green]nextmv cloud scenario get --app-id hare-app --scenario-test-id lettuce-routes --profile prod[/green]
+        $ [dim]nextmv cloud scenario get --app-id hare-app --scenario-test-id lettuce-routes --profile prod[/dim]
     """
     cloud_app = build_app(app_id=app_id, profile=profile)
 

--- a/nextmv/nextmv/cli/cloud/scenario/get.py
+++ b/nextmv/nextmv/cli/cloud/scenario/get.py
@@ -42,7 +42,7 @@ def get(
             "--wait",
             "-w",
             help="Wait for the scenario test to complete. Results are printed to [magenta]stdout[/magenta]. "
-            "Specify output location with [code]--output[/code].",
+            "Specify output location with --output.",
         ),
     ] = False,
     profile: ProfileOption = None,
@@ -50,8 +50,8 @@ def get(
     """
     Get a Nextmv Cloud scenario test, including its runs.
 
-    Use the [code]--wait[/code] flag to wait for the scenario test to
-    complete, polling for results. Using the [code]--output[/code] flag will
+    Use the --wait flag to wait for the scenario test to
+    complete, polling for results. Using the --output flag will
     also activate waiting, and allows you to specify a destination file for the
     results.
 

--- a/nextmv/nextmv/cli/cloud/scenario/list.py
+++ b/nextmv/nextmv/cli/cloud/scenario/list.py
@@ -38,13 +38,13 @@ def list(
     [bold][underline]Examples[/underline][/bold]
 
     - List all scenario tests for application [magenta]hare-app[/magenta].
-        $ [green]nextmv cloud scenario list --app-id hare-app[/green]
+        $ [dim]nextmv cloud scenario list --app-id hare-app[/dim]
 
     - List all scenario tests and save to a file.
-        $ [green]nextmv cloud scenario list --app-id hare-app --output scenario_tests.json[/green]
+        $ [dim]nextmv cloud scenario list --app-id hare-app --output scenario_tests.json[/dim]
 
     - List all scenario tests using a specific profile.
-        $ [green]nextmv cloud scenario list --app-id hare-app --profile prod[/green]
+        $ [dim]nextmv cloud scenario list --app-id hare-app --profile prod[/dim]
     """
 
     cloud_app = build_app(app_id=app_id, profile=profile)

--- a/nextmv/nextmv/cli/cloud/scenario/metadata.py
+++ b/nextmv/nextmv/cli/cloud/scenario/metadata.py
@@ -41,14 +41,14 @@ def metadata(
 
     - Get metadata for scenario test [magenta]bunny-warren-optimization[/magenta] from application
       [magenta]hare-app[/magenta].
-        $ [green]nextmv cloud scenario metadata --app-id hare-app --scenario-test-id bunny-warren-optimization[/green]
+        $ [dim]nextmv cloud scenario metadata --app-id hare-app --scenario-test-id bunny-warren-optimization[/dim]
 
     - Get metadata and save to a file.
-        $ [green]nextmv cloud scenario metadata --app-id hare-app --scenario-test-id lettuce-delivery \\
-            --output metadata.json[/green]
+        $ [dim]nextmv cloud scenario metadata --app-id hare-app --scenario-test-id lettuce-delivery \\
+            --output metadata.json[/dim]
 
     - Get metadata using a specific profile.
-        $ [green]nextmv cloud scenario metadata --app-id hare-app --scenario-test-id hop-schedule --profile prod[/green]
+        $ [dim]nextmv cloud scenario metadata --app-id hare-app --scenario-test-id hop-schedule --profile prod[/dim]
     """
 
     cloud_app = build_app(app_id=app_id, profile=profile)

--- a/nextmv/nextmv/cli/cloud/scenario/update.py
+++ b/nextmv/nextmv/cli/cloud/scenario/update.py
@@ -57,17 +57,17 @@ def update(
     [bold][underline]Examples[/underline][/bold]
 
     - Update the name of a scenario test.
-        $ [green]nextmv cloud scenario update --app-id hare-app --scenario-test-id carrot-feast \\
-            --name "Spring Carrot Harvest"[/green]
+        $ [dim]nextmv cloud scenario update --app-id hare-app --scenario-test-id carrot-feast \\
+            --name "Spring Carrot Harvest"[/dim]
 
     - Update the description of a scenario test.
-        $ [green]nextmv cloud scenario update --app-id hare-app --scenario-test-id bunny-hop-routes \\
-            --description "Optimizing hop paths through the meadow"[/green]
+        $ [dim]nextmv cloud scenario update --app-id hare-app --scenario-test-id bunny-hop-routes \\
+            --description "Optimizing hop paths through the meadow"[/dim]
 
     - Update both name and description and save the result.
-        $ [green]nextmv cloud scenario update --app-id hare-app --scenario-test-id lettuce-delivery \\
+        $ [dim]nextmv cloud scenario update --app-id hare-app --scenario-test-id lettuce-delivery \\
             --name "Warren Lettuce Express" --description "Fast lettuce delivery to all burrows" \\
-            --output updated-scenario.json[/green]
+            --output updated-scenario.json[/dim]
     """
 
     cloud_app = build_app(app_id=app_id, profile=profile)

--- a/nextmv/nextmv/cli/cloud/secrets/create.py
+++ b/nextmv/nextmv/cli/cloud/secrets/create.py
@@ -67,7 +67,7 @@ def create(
     A secrets collection is a group of key-value pairs that can be used by
     your application instances during execution. Each collection can contain
     up to 20 secrets. Secrets are provided as JSON objects using the
-    [code]--secrets[/code] flag.
+    --secrets flag.
 
     Each secret must include three fields:
     - [magenta]type[/magenta]: Either [magenta]env[/magenta] or [magenta]file[/magenta],
@@ -80,10 +80,10 @@ def create(
 
     You can provide secrets in three ways:
     - A single secret as a [magenta]json[/magenta] object.
-    - Multiple secrets by repeating the [code]--secrets[/code] flag.
-    - Multiple secrets as a [magenta]json[/magenta] array in a single [code]--secrets[/code] flag.
+    - Multiple secrets by repeating the --secrets flag.
+    - Multiple secrets as a [magenta]json[/magenta] array in a single --secrets flag.
 
-    The [code]--secrets-collection-id[/code] and [code]--name[/code] are optional.
+    The --secrets-collection-id and --name are optional.
     If not provided, they will be automatically generated.
 
     [bold][underline]Examples[/underline][/bold]

--- a/nextmv/nextmv/cli/cloud/secrets/create.py
+++ b/nextmv/nextmv/cli/cloud/secrets/create.py
@@ -27,7 +27,7 @@ def create(
             "Pass multiple secrets by repeating the flag, or providing a list of objects. "
             "Allowed values for [magenta]type[/magenta] are: "
             f"{enum_values(SecretType)}. "
-            "Object format: [green]{'type': type, 'location': location, 'value': value}[/green].",
+            "Object format: [dim]{'type': type, 'location': location, 'value': value}[/dim].",
             metavar="SECRETS",
         ),
     ],
@@ -89,34 +89,34 @@ def create(
     [bold][underline]Examples[/underline][/bold]
 
     - Create a secrets collection with a single environment variable secret.
-        $ [green]nextmv cloud secrets create --app-id hare-app \\
-            --secrets '{"type": "env", "location": "API_KEY", "value": "secret-value"}'[/green]
+        $ [dim]nextmv cloud secrets create --app-id hare-app \\
+            --secrets '{"type": "env", "location": "API_KEY", "value": "secret-value"}'[/dim]
 
     - Create a secrets collection with multiple secrets by repeating the flag.
-        $ [green]nextmv cloud secrets create --app-id hare-app \\
+        $ [dim]nextmv cloud secrets create --app-id hare-app \\
             --secrets '{"type": "env", "location": "API_KEY", "value": "secret-value"}' \\
-            --secrets '{"type": "env", "location": "DATABASE_URL", "value": "postgres://localhost"}'[/green]
+            --secrets '{"type": "env", "location": "DATABASE_URL", "value": "postgres://localhost"}'[/dim]
 
     - Create a secrets collection with multiple secrets in a single JSON array.
-        $ [green]nextmv cloud secrets create --app-id hare-app \\
-            --secrets '[{"type": "env", "location": "DB_USER", "value": "admin"}, {...}]'[/green]
+        $ [dim]nextmv cloud secrets create --app-id hare-app \\
+            --secrets '[{"type": "env", "location": "DB_USER", "value": "admin"}, {...}]'[/dim]
 
     - Create a secrets collection with custom ID, name, and description.
-        $ [green]nextmv cloud secrets create --app-id hare-app \\
+        $ [dim]nextmv cloud secrets create --app-id hare-app \\
             --secrets-collection-id db-creds --name "Database Credentials" \\
             --description "Production database credentials" \\
             --secrets '{"type": "env", "location": "DB_USER", "value": "admin"}' \\
-            --secrets '{"type": "env", "location": "DB_PASS", "value": "secure123"}'[/green]
+            --secrets '{"type": "env", "location": "DB_PASS", "value": "secure123"}'[/dim]
 
     - Create a secrets collection with file-based secrets.
-        $ [green]nextmv cloud secrets create --app-id hare-app \\
+        $ [dim]nextmv cloud secrets create --app-id hare-app \\
             --secrets-collection-id certs --name "Certificates" \\
-            --secrets '{"type": "file", "location": "licenses/acme.lic", "value": "LICENSE_CONTENT_HERE"}'[/green]
+            --secrets '{"type": "file", "location": "licenses/acme.lic", "value": "LICENSE_CONTENT_HERE"}'[/dim]
 
     - Mix environment and file-based secrets.
-        $ [green]nextmv cloud secrets create --app-id hare-app \\
+        $ [dim]nextmv cloud secrets create --app-id hare-app \\
             --secrets '{"type": "env", "location": "ACME_LICENSE_KEY", "value": "abc123"}' \\
-            --secrets '{"type": "file", "location": "config/app.conf", "value": "server=prod\\nport=8080"}'[/green]
+            --secrets '{"type": "file", "location": "config/app.conf", "value": "server=prod\\nport=8080"}'[/dim]
     """
 
     cloud_app = build_app(app_id=app_id, profile=profile)

--- a/nextmv/nextmv/cli/cloud/secrets/delete.py
+++ b/nextmv/nextmv/cli/cloud/secrets/delete.py
@@ -32,7 +32,7 @@ def delete(
     """
     Deletes a Nextmv Cloud secrets collection.
 
-    This action is permanent and cannot be undone. Use the [code]--yes[/code]
+    This action is permanent and cannot be undone. Use the --yes
     flag to skip the confirmation prompt.
 
     [bold][underline]Examples[/underline][/bold]

--- a/nextmv/nextmv/cli/cloud/secrets/delete.py
+++ b/nextmv/nextmv/cli/cloud/secrets/delete.py
@@ -39,10 +39,10 @@ def delete(
 
     - Delete the secrets collection with the ID [magenta]api-keys[/magenta] from application
       [magenta]hare-app[/magenta].
-        $ [green]nextmv cloud secrets delete --app-id hare-app --secrets-collection-id api-keys[/green]
+        $ [dim]nextmv cloud secrets delete --app-id hare-app --secrets-collection-id api-keys[/dim]
 
     - Delete the secrets collection without confirmation prompt.
-        $ [green]nextmv cloud secrets delete --app-id hare-app --secrets-collection-id api-keys --yes[/green]
+        $ [dim]nextmv cloud secrets delete --app-id hare-app --secrets-collection-id api-keys --yes[/dim]
     """
 
     if not yes:

--- a/nextmv/nextmv/cli/cloud/secrets/get.py
+++ b/nextmv/nextmv/cli/cloud/secrets/get.py
@@ -41,13 +41,13 @@ def get(
 
     - Get the secrets collection with the ID [magenta]api-keys[/magenta] from
       application [magenta]hare-app[/magenta].
-        $ [green]nextmv cloud secrets get --app-id hare-app \\
-        --secrets-collection-id api-keys[/green]
+        $ [dim]nextmv cloud secrets get --app-id hare-app \\
+        --secrets-collection-id api-keys[/dim]
 
     - Get the secrets collection with the ID [magenta]api-keys[/magenta] and
       save the information to a [magenta]secrets.json[/magenta] file.
-        $ [green]nextmv cloud secrets get --app-id hare-app \\
-            --secrets-collection-id api-keys --output secrets.json[/green]
+        $ [dim]nextmv cloud secrets get --app-id hare-app \\
+            --secrets-collection-id api-keys --output secrets.json[/dim]
     """
 
     cloud_app = build_app(app_id=app_id, profile=profile)

--- a/nextmv/nextmv/cli/cloud/secrets/list.py
+++ b/nextmv/nextmv/cli/cloud/secrets/list.py
@@ -35,13 +35,13 @@ def list(
     [bold][underline]Examples[/underline][/bold]
 
     - List all secrets collections of application [magenta]hare-app[/magenta].
-        $ [green]nextmv cloud secrets list --app-id hare-app[/green]
+        $ [dim]nextmv cloud secrets list --app-id hare-app[/dim]
 
     - List all secrets collections using the profile named [magenta]hare[/magenta].
-        $ [green]nextmv cloud secrets list --app-id hare-app --profile hare[/green]
+        $ [dim]nextmv cloud secrets list --app-id hare-app --profile hare[/dim]
 
     - List all secrets collections and save the information to a [magenta]secrets.json[/magenta] file.
-        $ [green]nextmv cloud secrets list --app-id hare-app --output secrets.json[/green]
+        $ [dim]nextmv cloud secrets list --app-id hare-app --output secrets.json[/dim]
     """
 
     cloud_app = build_app(app_id=app_id, profile=profile)

--- a/nextmv/nextmv/cli/cloud/secrets/update.py
+++ b/nextmv/nextmv/cli/cloud/secrets/update.py
@@ -71,11 +71,11 @@ def update(
     secrets collection. When updating secrets, all existing secrets will be
     replaced with the new ones provided.
 
-    Secrets are provided as JSON objects using the [code]--secrets[/code] flag,
+    Secrets are provided as JSON objects using the --secrets flag,
     following the same format as the create command. You can provide secrets as:
     - A single secret as a JSON object
-    - Multiple secrets by repeating the [code]--secrets[/code] flag
-    - Multiple secrets as a JSON array in a single [code]--secrets[/code] flag
+    - Multiple secrets by repeating the --secrets flag
+    - Multiple secrets as a JSON array in a single --secrets flag
 
     [bold][underline]Examples[/underline][/bold]
 
@@ -113,10 +113,7 @@ def update(
     """
 
     if name is None and description is None and secrets is None:
-        error(
-            "Provide at least one option to update: "
-            "[code]--name[/code], [code]--description[/code], or [code]--secrets[/code]."
-        )
+        error("Provide at least one option to update: --name, --description, or --secrets.")
 
     cloud_app = build_app(app_id=app_id, profile=profile)
 

--- a/nextmv/nextmv/cli/cloud/secrets/update.py
+++ b/nextmv/nextmv/cli/cloud/secrets/update.py
@@ -57,7 +57,7 @@ def update(
             "Pass multiple secrets by repeating the flag, or providing a list of objects. "
             "Allowed values for [magenta]type[/magenta] are: "
             f"{enum_values(SecretType)}. "
-            "Object format: [green]{'type': type, 'location': location, 'value': value}[/green]. "
+            "Object format: [dim]{'type': type, 'location': location, 'value': value}[/dim]. "
             "This will replace all existing secrets in the collection.",
             metavar="SECRETS",
         ),
@@ -80,36 +80,36 @@ def update(
     [bold][underline]Examples[/underline][/bold]
 
     - Update the name of a secrets collection.
-        $ [green]nextmv cloud secrets update --app-id hare-app \\
-            --secrets-collection-id api-keys --name "Updated API Keys"[/green]
+        $ [dim]nextmv cloud secrets update --app-id hare-app \\
+            --secrets-collection-id api-keys --name "Updated API Keys"[/dim]
 
     - Update the description of a secrets collection.
-        $ [green]nextmv cloud secrets update --app-id hare-app \\
+        $ [dim]nextmv cloud secrets update --app-id hare-app \\
             --secrets-collection-id api-keys \\
-            --description "Updated collection of API keys"[/green]
+            --description "Updated collection of API keys"[/dim]
 
     - Update both name and description.
-        $ [green]nextmv cloud secrets update --app-id hare-app \\
+        $ [dim]nextmv cloud secrets update --app-id hare-app \\
             --secrets-collection-id api-keys --name "Production API Keys" \\
-            --description "API keys for production environment"[/green]
+            --description "API keys for production environment"[/dim]
 
     - Replace all secrets in a collection with new secrets.
-        $ [green]nextmv cloud secrets update --app-id hare-app \\
+        $ [dim]nextmv cloud secrets update --app-id hare-app \\
             --secrets-collection-id api-keys \\
             --secrets '{"type": "env", "location": "API_KEY", "value": "new-value"}' \\
-            --secrets '{"type": "env", "location": "DATABASE_URL", "value": "postgres://newhost"}'[/green]
+            --secrets '{"type": "env", "location": "DATABASE_URL", "value": "postgres://newhost"}'[/dim]
 
     - Replace all secrets with a JSON array.
-        $ [green]nextmv cloud secrets update --app-id hare-app \\
+        $ [dim]nextmv cloud secrets update --app-id hare-app \\
             --secrets-collection-id api-keys \\
-            --secrets '[{"type": "env", "location": "API_KEY", "value": "new-value"}, {...}]'[/green]
+            --secrets '[{"type": "env", "location": "API_KEY", "value": "new-value"}, {...}]'[/dim]
 
     - Update multiple attributes at once and save the result.
-        $ [green]nextmv cloud secrets update --app-id hare-app \\
+        $ [dim]nextmv cloud secrets update --app-id hare-app \\
             --secrets-collection-id api-keys --name "New Name" \\
             --description "New Description" \\
             --secrets '{"type": "env", "location": "NEW_KEY", "value": "new-value"}' \\
-            --output updated.json[/green]
+            --output updated.json[/dim]
     """
 
     if name is None and description is None and secrets is None:

--- a/nextmv/nextmv/cli/cloud/shadow/create.py
+++ b/nextmv/nextmv/cli/cloud/shadow/create.py
@@ -27,7 +27,7 @@ def create(
             "-c",
             help="Object mapping baseline instance IDs to a list of comparison instance IDs. "
             "Data should be valid [magenta]json[/magenta]. "
-            "Object format: [green]{'baseline_id1': ['comparison_id1', 'comparison_id2'], 'baseline_id2': ...}[/green]",
+            "Object format: [dim]{'baseline_id1': ['comparison_id1', 'comparison_id2'], 'baseline_id2': ...}[/dim]",
             metavar="COMPARISONS",
         ),
     ],
@@ -77,7 +77,7 @@ def create(
             "-r",
             formats=["%Y-%m-%dT%H:%M:%S%z"],
             help="Scheduled time for shadow test start in [magenta]RFC 3339[/magenta] format. "
-            "Object format: [green]'2024-01-01T00:00:00Z'[/green]",
+            "Object format: [dim]'2024-01-01T00:00:00Z'[/dim]",
             metavar="START_TIME",
         ),
     ] = None,
@@ -87,7 +87,7 @@ def create(
             "--termination-time",
             "-t",
             help="Scheduled time for shadow test end in [magenta]RFC 3339[/magenta] format. "
-            "Object format: [green]'2024-01-01T00:00:00Z'[/green]",
+            "Object format: [dim]'2024-01-01T00:00:00Z'[/dim]",
             formats=["%Y-%m-%dT%H:%M:%S%z"],
             metavar="TERMINATION_TIME",
         ),
@@ -103,10 +103,10 @@ def create(
     candidate lists of instance IDs to compare against the respective baseline.
 
     Here is an example comparisons object:
-    [green]{
+    [dim]{
         "baseline-instance-1": ["candidate-instance-1", "candidate-instance-2"],
         "baseline-instance-2": ["candidate-instance-3"]
-    }[/green]
+    }[/dim]
 
     You may specify the --start-time option to make the shadow test start at a
     specific time. Alternatively, you may use the [code]nextmv cloud shadow
@@ -119,18 +119,18 @@ def create(
 
     [bold][underline]Examples[/underline][/bold]
 
-    - Create a shadow test with a baseline and two candidate instances:
-        $ [green]COMPARISONS='{
+    - Create a shadow test with a baseline and two candidate instances.
+        $ [dim]COMPARISONS='{
             "fluffy-bunny-baseline": [
                 "hopping-candidate-ears",
                 "speedy-cottontail"
             ]
         }'
         nextmv cloud shadow create --app-id hare-app --shadow-test-id bunny-hop-shadow --name "Bunny Hop Showdown" \\
-            --comparisons "$COMPARISONS" --termination-maximum-runs 100[/green]
+            --comparisons "$COMPARISONS" --termination-maximum-runs 100[/dim]
 
-    - Create a shadow test with multiple baselines and candidates:
-        $ [green]COMPARISONS='{
+    - Create a shadow test with multiple baselines and candidates.
+        $ [dim]COMPARISONS='{
             "fluffy-bunny-baseline": [
                 "hopping-candidate-ears"
             ],
@@ -139,26 +139,26 @@ def create(
             ]
         }'
         nextmv cloud shadow create --app-id hare-app --shadow-test-id warren-race --name "Warren Race Test" \\
-            --comparisons "$COMPARISONS" --termination-maximum-runs 50[/green]
+            --comparisons "$COMPARISONS" --termination-maximum-runs 50[/dim]
 
-    - Create a shadow test with a scheduled start and termination time:
-        $ [green]COMPARISONS='{
+    - Create a shadow test with a scheduled start and termination time.
+        $ [dim]COMPARISONS='{
             "fluffy-bunny-baseline": [
                 "hopping-candidate-ears"
             ]
         }'
         nextmv cloud shadow create --app-id hare-app --shadow-test-id sunrise-hop --name "Sunrise Hop Test" \\
             --comparisons "$COMPARISONS" --start-time '2026-01-23T10:00:00Z' \\
-            --termination-time '2026-01-23T18:00:00Z' --termination-maximum-runs 20[/green]
+            --termination-time '2026-01-23T18:00:00Z' --termination-maximum-runs 20[/dim]
 
-    - Create a shadow test with a description:
-        $ [green]COMPARISONS='{
+    - Create a shadow test with a description.
+        $ [dim]COMPARISONS='{
             "fluffy-bunny-baseline": [
                 "hopping-candidate-ears"
             ]
         }'
         nextmv cloud shadow create --app-id hare-app --shadow-test-id carrot-compare --name "Carrot Comparison" \\
-            --description "Testing cool bunnies" --comparisons "$COMPARISONS" --termination-maximum-runs 10[/green]
+            --description "Testing cool bunnies" --comparisons "$COMPARISONS" --termination-maximum-runs 10[/dim]
     """
 
     cloud_app = build_app(app_id=app_id, profile=profile)

--- a/nextmv/nextmv/cli/cloud/shadow/create.py
+++ b/nextmv/nextmv/cli/cloud/shadow/create.py
@@ -97,11 +97,10 @@ def create(
     """
     Create a new Nextmv Cloud shadow test in draft mode.
 
-    Use the [code]--comparisons[/code] option to define how to set up instance
-    comparisons. The value should be valid [magenta]json[/magenta]. The keys of
-    the comparisons object are the baseline instance IDs, and the values
-    are the candidate lists of instance IDs to compare against the respective
-    baseline.
+    Use the --comparisons option to define how to set up instance comparisons.
+    The value should be valid [magenta]json[/magenta]. The keys of the
+    comparisons object are the baseline instance IDs, and the values are the
+    candidate lists of instance IDs to compare against the respective baseline.
 
     Here is an example comparisons object:
     [green]{
@@ -109,15 +108,14 @@ def create(
         "baseline-instance-2": ["candidate-instance-3"]
     }[/green]
 
-    You may specify the [code]--start-time[/code] option to make the shadow
-    test start at a specific time. Alternatively, you may use the
-    [code]nextmv cloud shadow start[/code] command to start the test.
+    You may specify the --start-time option to make the shadow test start at a
+    specific time. Alternatively, you may use the [code]nextmv cloud shadow
+    start[/code] command to start the test.
 
-    The [code]--termination-maximum-runs[/code] option is required and provides
-    control over when the shadow test should terminate, after said number of
-    runs. Alternatively, you may specify the [code]--termination-time[/code]
-    option or use the [code]nextmv cloud shadow stop[/code] command to stop the
-    test.
+    The --termination-maximum-runs option is required and provides control over
+    when the shadow test should terminate, after said number of runs.
+    Alternatively, you may specify the --termination-time option or use the
+    [code]nextmv cloud shadow stop[/code] command to stop the test.
 
     [bold][underline]Examples[/underline][/bold]
 

--- a/nextmv/nextmv/cli/cloud/shadow/delete.py
+++ b/nextmv/nextmv/cli/cloud/shadow/delete.py
@@ -33,7 +33,7 @@ def delete(
     Deletes a Nextmv Cloud shadow test.
 
     This action is permanent and cannot be undone. The shadow test and all
-    associated data, including runs, will be deleted. Use the [code]--yes[/code]
+    associated data, including runs, will be deleted. Use the --yes
     flag to skip the confirmation prompt.
 
     [bold][underline]Examples[/underline][/bold]

--- a/nextmv/nextmv/cli/cloud/shadow/delete.py
+++ b/nextmv/nextmv/cli/cloud/shadow/delete.py
@@ -40,10 +40,10 @@ def delete(
 
     - Delete the shadow test with the ID [magenta]hop-analysis[/magenta] from application
       [magenta]hare-app[/magenta].
-        $ [green]nextmv cloud shadow delete --app-id hare-app --shadow-test-id hop-analysis[/green]
+        $ [dim]nextmv cloud shadow delete --app-id hare-app --shadow-test-id hop-analysis[/dim]
 
     - Delete the shadow test without confirmation prompt.
-        $ [green]nextmv cloud shadow delete --app-id hare-app --shadow-test-id carrot-routes --yes[/green]
+        $ [dim]nextmv cloud shadow delete --app-id hare-app --shadow-test-id carrot-routes --yes[/dim]
     """
 
     if not yes:

--- a/nextmv/nextmv/cli/cloud/shadow/get.py
+++ b/nextmv/nextmv/cli/cloud/shadow/get.py
@@ -37,10 +37,10 @@ def get(
 
     - Get the shadow test with ID [magenta]carrot-optimization[/magenta] from application
       [magenta]hare-app[/magenta].
-        $ [green]nextmv cloud shadow get --app-id hare-app --shadow-test-id carrot-optimization[/green]
+        $ [dim]nextmv cloud shadow get --app-id hare-app --shadow-test-id carrot-optimization[/dim]
 
     - Get the shadow test using a specific profile.
-        $ [green]nextmv cloud shadow get --app-id hare-app --shadow-test-id lettuce-routes --profile prod[/green]
+        $ [dim]nextmv cloud shadow get --app-id hare-app --shadow-test-id lettuce-routes --profile prod[/dim]
     """
 
     cloud_app = build_app(app_id=app_id, profile=profile)

--- a/nextmv/nextmv/cli/cloud/shadow/list.py
+++ b/nextmv/nextmv/cli/cloud/shadow/list.py
@@ -38,13 +38,13 @@ def list(
     [bold][underline]Examples[/underline][/bold]
 
     - List all shadow tests for application [magenta]hare-app[/magenta].
-        $ [green]nextmv cloud shadow list --app-id hare-app[/green]
+        $ [dim]nextmv cloud shadow list --app-id hare-app[/dim]
 
     - List all shadow tests and save to a file.
-        $ [green]nextmv cloud shadow list --app-id hare-app --output tests.json[/green]
+        $ [dim]nextmv cloud shadow list --app-id hare-app --output tests.json[/dim]
 
     - List all shadow tests using a specific profile.
-        $ [green]nextmv cloud shadow list --app-id hare-app --profile prod[/green]
+        $ [dim]nextmv cloud shadow list --app-id hare-app --profile prod[/dim]
     """
 
     cloud_app = build_app(app_id=app_id, profile=profile)

--- a/nextmv/nextmv/cli/cloud/shadow/metadata.py
+++ b/nextmv/nextmv/cli/cloud/shadow/metadata.py
@@ -41,14 +41,14 @@ def metadata(
 
     - Get metadata for shadow test [magenta]bunny-warren-optimization[/magenta] from application
       [magenta]hare-app[/magenta].
-        $ [green]nextmv cloud shadow metadata --app-id hare-app --shadow-test-id bunny-warren-optimization[/green]
+        $ [dim]nextmv cloud shadow metadata --app-id hare-app --shadow-test-id bunny-warren-optimization[/dim]
 
     - Get metadata and save to a file.
-        $ [green]nextmv cloud shadow metadata --app-id hare-app --shadow-test-id lettuce-delivery \\
-            --output metadata.json[/green]
+        $ [dim]nextmv cloud shadow metadata --app-id hare-app --shadow-test-id lettuce-delivery \\
+            --output metadata.json[/dim]
 
     - Get metadata using a specific profile.
-        $ [green]nextmv cloud shadow metadata --app-id hare-app --shadow-test-id hop-schedule --profile prod[/green]
+        $ [dim]nextmv cloud shadow metadata --app-id hare-app --shadow-test-id hop-schedule --profile prod[/dim]
     """
 
     cloud_app = build_app(app_id=app_id, profile=profile)

--- a/nextmv/nextmv/cli/cloud/shadow/start.py
+++ b/nextmv/nextmv/cli/cloud/shadow/start.py
@@ -23,8 +23,8 @@ def start(
 
     Before starting a shadow test, it must be created in draft state. You may
     use the [code]nextmv cloud shadow create[/code] command to create a new
-    shadow test. Alternatively, define a [code]--start-time[/code] when using
-    the [code]nextmv cloud shadow create[/code] command to have the shadow test
+    shadow test. Alternatively, define a --start-time when using the
+    [code]nextmv cloud shadow create[/code] command to have the shadow test
     start automatically at a specific time.
 
     [bold][underline]Examples[/underline][/bold]

--- a/nextmv/nextmv/cli/cloud/shadow/start.py
+++ b/nextmv/nextmv/cli/cloud/shadow/start.py
@@ -31,7 +31,7 @@ def start(
 
     - Start the shadow test with the ID [magenta]hop-analysis[/magenta] from application
       [magenta]hare-app[/magenta].
-        $ [green]nextmv cloud shadow start --app-id hare-app --shadow-test-id hop-analysis[/green]
+        $ [dim]nextmv cloud shadow start --app-id hare-app --shadow-test-id hop-analysis[/dim]
     """
 
     in_progress(msg="Starting shadow test...")

--- a/nextmv/nextmv/cli/cloud/shadow/stop.py
+++ b/nextmv/nextmv/cli/cloud/shadow/stop.py
@@ -29,7 +29,7 @@ def stop(
 
     - Stop the shadow test with the ID [magenta]hop-analysis[/magenta] from application
       [magenta]hare-app[/magenta].
-        $ [green]nextmv cloud shadow stop --app-id hare-app --shadow-test-id hop-analysis[/green]
+        $ [dim]nextmv cloud shadow stop --app-id hare-app --shadow-test-id hop-analysis[/dim]
     """
 
     in_progress(msg="Stopping shadow test...")

--- a/nextmv/nextmv/cli/cloud/shadow/update.py
+++ b/nextmv/nextmv/cli/cloud/shadow/update.py
@@ -57,17 +57,17 @@ def update(
     [bold][underline]Examples[/underline][/bold]
 
     - Update the name of a shadow test.
-        $ [green]nextmv cloud shadow update --app-id hare-app --shadow-test-id carrot-feast \\
-            --name "Spring Carrot Harvest"[/green]
+        $ [dim]nextmv cloud shadow update --app-id hare-app --shadow-test-id carrot-feast \\
+            --name "Spring Carrot Harvest"[/dim]
 
     - Update the description of a shadow test.
-        $ [green]nextmv cloud shadow update --app-id hare-app --shadow-test-id bunny-hop-routes \\
-            --description "Optimizing hop paths through the meadow"[/green]
+        $ [dim]nextmv cloud shadow update --app-id hare-app --shadow-test-id bunny-hop-routes \\
+            --description "Optimizing hop paths through the meadow"[/dim]
 
     - Update both name and description and save the result.
-        $ [green]nextmv cloud shadow update --app-id hare-app --shadow-test-id lettuce-delivery \\
+        $ [dim]nextmv cloud shadow update --app-id hare-app --shadow-test-id lettuce-delivery \\
             --name "Warren Lettuce Express" --description "Fast lettuce delivery to all burrows" \\
-            --output updated-shadow-test.json[/green]
+            --output updated-shadow-test.json[/dim]
     """
 
     cloud_app = build_app(app_id=app_id, profile=profile)

--- a/nextmv/nextmv/cli/cloud/switchback/create.py
+++ b/nextmv/nextmv/cli/cloud/switchback/create.py
@@ -94,7 +94,7 @@ def create(
             "-r",
             formats=["%Y-%m-%dT%H:%M:%S%z"],
             help="Scheduled time for switchback test start in [magenta]RFC 3339[/magenta] format. "
-            "Object format: [green]'2024-01-01T00:00:00Z'[/green]",
+            "Object format: [dim]'2024-01-01T00:00:00Z'[/dim]",
             metavar="START",
         ),
     ] = None,
@@ -114,22 +114,22 @@ def create(
 
     [bold][underline]Examples[/underline][/bold]
 
-    - Create a switchback test alternating between two bunny instances:
-        $ [green]nextmv cloud switchback create --app-id hare-app --switchback-test-id bunny-switch-hop \\
+    - Create a switchback test alternating between two bunny instances.
+        $ [dim]nextmv cloud switchback create --app-id hare-app --switchback-test-id bunny-switch-hop \\
             --name "Bunny Switch Hop" --baseline-instance-id fluffy-bunny-baseline \\
-            --candidate-instance-id speedy-cottontail --unit-duration-minutes 15 --units 10[/green]
+            --candidate-instance-id speedy-cottontail --unit-duration-minutes 15 --units 10[/dim]
 
-    - Create a switchback test with a scheduled start time:
-        $ [green]nextmv cloud switchback create --app-id hare-app --switchback-test-id sunrise-switch \\
+    - Create a switchback test with a scheduled start time.
+        $ [dim]nextmv cloud switchback create --app-id hare-app --switchback-test-id sunrise-switch \\
             --name "Sunrise Switch Test" --baseline-instance-id wise-old-rabbit \\
             --candidate-instance-id burrow-master --unit-duration-minutes 30 --units 8 \\
-            --start '2026-01-23T10:00:00Z'[/green]
+            --start '2026-01-23T10:00:00Z'[/dim]
 
-    - Create a switchback test with a description:
-        $ [green]nextmv cloud switchback create --app-id hare-app --switchback-test-id carrot-switch \\
+    - Create a switchback test with a description.
+        $ [dim]nextmv cloud switchback create --app-id hare-app --switchback-test-id carrot-switch \\
             --name "Carrot Switch" --baseline-instance-id fluffy-bunny-baseline \\
             --candidate-instance-id hopping-candidate-ears --unit-duration-minutes 20 --units 12 \\
-            --description "Which bunny hops best for carrots?"[/green]
+            --description "Which bunny hops best for carrots?"[/dim]
     """
 
     cloud_app = build_app(app_id=app_id, profile=profile)

--- a/nextmv/nextmv/cli/cloud/switchback/create.py
+++ b/nextmv/nextmv/cli/cloud/switchback/create.py
@@ -103,12 +103,12 @@ def create(
     """
     Create a new Nextmv Cloud switchback test in draft mode.
 
-    The test will alternate between the [code]--baseline-instance-id[/code] and
-    [code]--candidate-instance-id[/code] over specified time intervals.
+    The test will alternate between the --baseline-instance-id and
+    --candidate-instance-id over specified time intervals.
 
-    You may specify the [code]--start[/code] option to make the switchback
-    test start at a specific time. Alternatively, you may use the
-    [code]nextmv cloud switchback start[/code] command to start the test.
+    You may specify the --start option to make the switchback test start at a
+    specific time. Alternatively, you may use the [code]nextmv cloud switchback
+    start[/code] command to start the test.
 
     Use the [code]nextmv cloud switchback stop[/code] command to stop the test.
 

--- a/nextmv/nextmv/cli/cloud/switchback/delete.py
+++ b/nextmv/nextmv/cli/cloud/switchback/delete.py
@@ -33,7 +33,7 @@ def delete(
     Deletes a Nextmv Cloud switchback test.
 
     This action is permanent and cannot be undone. The switchback test and all
-    associated data, including runs, will be deleted. Use the [code]--yes[/code]
+    associated data, including runs, will be deleted. Use the --yes
     flag to skip the confirmation prompt.
 
     [bold][underline]Examples[/underline][/bold]

--- a/nextmv/nextmv/cli/cloud/switchback/delete.py
+++ b/nextmv/nextmv/cli/cloud/switchback/delete.py
@@ -40,10 +40,10 @@ def delete(
 
     - Delete the switchback test with the ID [magenta]hop-analysis[/magenta] from application
       [magenta]hare-app[/magenta].
-        $ [green]nextmv cloud switchback delete --app-id hare-app --switchback-test-id hop-analysis[/green]
+        $ [dim]nextmv cloud switchback delete --app-id hare-app --switchback-test-id hop-analysis[/dim]
 
     - Delete the switchback test without confirmation prompt.
-        $ [green]nextmv cloud switchback delete --app-id hare-app --switchback-test-id carrot-routes --yes[/green]
+        $ [dim]nextmv cloud switchback delete --app-id hare-app --switchback-test-id carrot-routes --yes[/dim]
     """
 
     if not yes:

--- a/nextmv/nextmv/cli/cloud/switchback/get.py
+++ b/nextmv/nextmv/cli/cloud/switchback/get.py
@@ -37,11 +37,11 @@ def get(
 
     - Get the switchback test with ID [magenta]carrot-optimization[/magenta] from application
       [magenta]hare-app[/magenta].
-        $ [green]nextmv cloud switchback get --app-id hare-app --switchback-test-id carrot-optimization[/green]
+        $ [dim]nextmv cloud switchback get --app-id hare-app --switchback-test-id carrot-optimization[/dim]
 
     - Get the switchback test using a specific profile.
-        $ [green]nextmv cloud switchback get --app-id hare-app --switchback-test-id lettuce-routes \\
-            --profile prod[/green]
+        $ [dim]nextmv cloud switchback get --app-id hare-app --switchback-test-id lettuce-routes \\
+            --profile prod[/dim]
     """
 
     cloud_app = build_app(app_id=app_id, profile=profile)

--- a/nextmv/nextmv/cli/cloud/switchback/list.py
+++ b/nextmv/nextmv/cli/cloud/switchback/list.py
@@ -38,13 +38,13 @@ def list(
     [bold][underline]Examples[/underline][/bold]
 
     - List all switchback tests for application [magenta]hare-app[/magenta].
-        $ [green]nextmv cloud switchback list --app-id hare-app[/green]
+        $ [dim]nextmv cloud switchback list --app-id hare-app[/dim]
 
     - List all switchback tests and save to a file.
-        $ [green]nextmv cloud switchback list --app-id hare-app --output tests.json[/green]
+        $ [dim]nextmv cloud switchback list --app-id hare-app --output tests.json[/dim]
 
     - List all switchback tests using a specific profile.
-        $ [green]nextmv cloud switchback list --app-id hare-app --profile prod[/green]
+        $ [dim]nextmv cloud switchback list --app-id hare-app --profile prod[/dim]
     """
 
     cloud_app = build_app(app_id=app_id, profile=profile)

--- a/nextmv/nextmv/cli/cloud/switchback/metadata.py
+++ b/nextmv/nextmv/cli/cloud/switchback/metadata.py
@@ -41,16 +41,16 @@ def metadata(
 
     - Get metadata for switchback test [magenta]bunny-warren-optimization[/magenta] from application
       [magenta]hare-app[/magenta].
-        $ [green]nextmv cloud switchback metadata --app-id hare-app \\
-            --switchback-test-id bunny-warren-optimization[/green]
+        $ [dim]nextmv cloud switchback metadata --app-id hare-app \\
+            --switchback-test-id bunny-warren-optimization[/dim]
 
     - Get metadata and save to a file.
-        $ [green]nextmv cloud switchback metadata --app-id hare-app --switchback-test-id lettuce-delivery \\
-            --output metadata.json[/green]
+        $ [dim]nextmv cloud switchback metadata --app-id hare-app --switchback-test-id lettuce-delivery \\
+            --output metadata.json[/dim]
 
     - Get metadata using a specific profile.
-        $ [green]nextmv cloud switchback metadata --app-id hare-app --switchback-test-id hop-schedule \\
-            --profile prod[/green]
+        $ [dim]nextmv cloud switchback metadata --app-id hare-app --switchback-test-id hop-schedule \\
+            --profile prod[/dim]
     """
 
     cloud_app = build_app(app_id=app_id, profile=profile)

--- a/nextmv/nextmv/cli/cloud/switchback/start.py
+++ b/nextmv/nextmv/cli/cloud/switchback/start.py
@@ -31,7 +31,7 @@ def start(
 
     - Start the switchback test with the ID [magenta]hop-analysis[/magenta] from application
       [magenta]hare-app[/magenta].
-        $ [green]nextmv cloud switchback start --app-id hare-app --switchback-test-id hop-analysis[/green]
+        $ [dim]nextmv cloud switchback start --app-id hare-app --switchback-test-id hop-analysis[/dim]
     """
 
     in_progress(msg="Starting switchback test...")

--- a/nextmv/nextmv/cli/cloud/switchback/start.py
+++ b/nextmv/nextmv/cli/cloud/switchback/start.py
@@ -23,9 +23,9 @@ def start(
 
     Before starting a switchback test, it must be created in draft state. You
     may use the [code]nextmv cloud switchback create[/code] command to create a
-    new switchback test. Alternatively, define a [code]--start[/code] when
-    using the [code]nextmv cloud switchback create[/code] command to have the
-    switchback test start automatically at a specific time.
+    new switchback test. Alternatively, define a --start when using the
+    [code]nextmv cloud switchback create[/code] command to have the switchback
+    test start automatically at a specific time.
 
     [bold][underline]Examples[/underline][/bold]
 

--- a/nextmv/nextmv/cli/cloud/switchback/stop.py
+++ b/nextmv/nextmv/cli/cloud/switchback/stop.py
@@ -29,7 +29,7 @@ def stop(
 
     - Stop the switchback test with the ID [magenta]hop-analysis[/magenta] from application
       [magenta]hare-app[/magenta].
-        $ [green]nextmv cloud switchback stop --app-id hare-app --switchback-test-id hop-analysis[/green]
+        $ [dim]nextmv cloud switchback stop --app-id hare-app --switchback-test-id hop-analysis[/dim]
     """
 
     in_progress(msg="Stopping switchback test...")

--- a/nextmv/nextmv/cli/cloud/switchback/update.py
+++ b/nextmv/nextmv/cli/cloud/switchback/update.py
@@ -57,17 +57,17 @@ def update(
     [bold][underline]Examples[/underline][/bold]
 
     - Update the name of a switchback test.
-        $ [green]nextmv cloud switchback update --app-id hare-app --switchback-test-id carrot-feast \\
-            --name "Spring Carrot Harvest"[/green]
+        $ [dim]nextmv cloud switchback update --app-id hare-app --switchback-test-id carrot-feast \\
+            --name "Spring Carrot Harvest"[/dim]
 
     - Update the description of a switchback test.
-        $ [green]nextmv cloud switchback update --app-id hare-app --switchback-test-id bunny-hop-routes \\
-            --description "Optimizing hop paths through the meadow"[/green]
+        $ [dim]nextmv cloud switchback update --app-id hare-app --switchback-test-id bunny-hop-routes \\
+            --description "Optimizing hop paths through the meadow"[/dim]
 
     - Update both name and description and save the result.
-        $ [green]nextmv cloud switchback update --app-id hare-app --switchback-test-id lettuce-delivery \\
+        $ [dim]nextmv cloud switchback update --app-id hare-app --switchback-test-id lettuce-delivery \\
             --name "Warren Lettuce Express" --description "Fast lettuce delivery to all burrows" \\
-            --output updated-switchback-test.json[/green]
+            --output updated-switchback-test.json[/dim]
     """
 
     cloud_app = build_app(app_id=app_id, profile=profile)

--- a/nextmv/nextmv/cli/cloud/upload/create.py
+++ b/nextmv/nextmv/cli/cloud/upload/create.py
@@ -23,10 +23,10 @@ def create(
     [bold][underline]Examples[/underline][/bold]
 
     - Create an upload URL for application [magenta]hare-app[/magenta].
-        $ [green]nextmv cloud upload create --app-id hare-app[/green]
+        $ [dim]nextmv cloud upload create --app-id hare-app[/dim]
 
     - Create an upload URL for application [magenta]hare-app[/magenta] using profile [magenta]hare[/magenta].
-        $ [green]nextmv cloud upload create --app-id hare-app --profile hare[/green]
+        $ [dim]nextmv cloud upload create --app-id hare-app --profile hare[/dim]
     """
 
     cloud_app = build_app(app_id=app_id, profile=profile)

--- a/nextmv/nextmv/cli/cloud/version/create.py
+++ b/nextmv/nextmv/cli/cloud/version/create.py
@@ -65,20 +65,20 @@ def create(
     [bold][underline]Examples[/underline][/bold]
 
     - Create a version for application [magenta]hare-app[/magenta]. A random ID will be generated.
-        $ [green]nextmv cloud version create --app-id hare-app[/green]
+        $ [dim]nextmv cloud version create --app-id hare-app[/dim]
 
     - Create a version with a specific name.
-        $ [green]nextmv cloud version create --app-id hare-app --name "v1.0.0"[/green]
+        $ [dim]nextmv cloud version create --app-id hare-app --name "v1.0.0"[/dim]
 
     - Create a version with a specific ID.
-        $ [green]nextmv cloud version create --app-id hare-app --version-id v1[/green]
+        $ [dim]nextmv cloud version create --app-id hare-app --version-id v1[/dim]
 
     - Create a version with a name and description.
-        $ [green]nextmv cloud version create --app-id hare-app --name "v1.0.0" \\
-            --description "Initial release with routing optimization"[/green]
+        $ [dim]nextmv cloud version create --app-id hare-app --name "v1.0.0" \\
+            --description "Initial release with routing optimization"[/dim]
 
     - Create a version, or get it if it already exists.
-        $ [green]nextmv cloud version create --app-id hare-app --version-id v1 --exist-ok[/green]
+        $ [dim]nextmv cloud version create --app-id hare-app --version-id v1 --exist-ok[/dim]
     """
 
     cloud_app = build_app(app_id=app_id, profile=profile)

--- a/nextmv/nextmv/cli/cloud/version/create.py
+++ b/nextmv/nextmv/cli/cloud/version/create.py
@@ -58,10 +58,9 @@ def create(
     """
     Create a new Nextmv Cloud application version.
 
-    Use the [code]--exist-ok[/code] flag to avoid errors when creating a
-    version with an ID that already exists. This is useful for scripts that
-    need to ensure a version exists without worrying about whether it was
-    created previously.
+    Use the --exist-ok flag to avoid errors when creating a version with an ID
+    that already exists. This is useful for scripts that need to ensure a
+    version exists without worrying about whether it was created previously.
 
     [bold][underline]Examples[/underline][/bold]
 

--- a/nextmv/nextmv/cli/cloud/version/delete.py
+++ b/nextmv/nextmv/cli/cloud/version/delete.py
@@ -38,10 +38,10 @@ def delete(
     [bold][underline]Examples[/underline][/bold]
 
     - Delete the version with the ID [magenta]v1[/magenta] from application [magenta]hare-app[/magenta].
-        $ [green]nextmv cloud version delete --app-id hare-app --version-id v1[/green]
+        $ [dim]nextmv cloud version delete --app-id hare-app --version-id v1[/dim]
 
     - Delete the version without confirmation prompt.
-        $ [green]nextmv cloud version delete --app-id hare-app --version-id v1 --yes[/green]
+        $ [dim]nextmv cloud version delete --app-id hare-app --version-id v1 --yes[/dim]
     """
 
     if not yes:

--- a/nextmv/nextmv/cli/cloud/version/delete.py
+++ b/nextmv/nextmv/cli/cloud/version/delete.py
@@ -32,7 +32,7 @@ def delete(
     """
     Deletes a Nextmv Cloud application version.
 
-    This action is permanent and cannot be undone. Use the [code]--yes[/code]
+    This action is permanent and cannot be undone. Use the --yes
     flag to skip the confirmation prompt.
 
     [bold][underline]Examples[/underline][/bold]

--- a/nextmv/nextmv/cli/cloud/version/exists.py
+++ b/nextmv/nextmv/cli/cloud/version/exists.py
@@ -27,10 +27,10 @@ def exists(
     [bold][underline]Examples[/underline][/bold]
 
     - Check if the version with the ID [magenta]v1[/magenta] exists in application [magenta]hare-app[/magenta].
-        $ [green]nextmv cloud version exists --app-id hare-app --version-id v1[/green]
+        $ [dim]nextmv cloud version exists --app-id hare-app --version-id v1[/dim]
 
     - Check if the version exists using the profile named [magenta]hare[/magenta].
-        $ [green]nextmv cloud version exists --app-id hare-app --version-id v1 --profile hare[/green]
+        $ [dim]nextmv cloud version exists --app-id hare-app --version-id v1 --profile hare[/dim]
     """
 
     cloud_app = build_app(app_id=app_id, profile=profile)

--- a/nextmv/nextmv/cli/cloud/version/get.py
+++ b/nextmv/nextmv/cli/cloud/version/get.py
@@ -39,11 +39,11 @@ def get(
     [bold][underline]Examples[/underline][/bold]
 
     - Get the version with the ID [magenta]v1[/magenta] from application [magenta]hare-app[/magenta].
-        $ [green]nextmv cloud version get --app-id hare-app --version-id v1[/green]
+        $ [dim]nextmv cloud version get --app-id hare-app --version-id v1[/dim]
 
     - Get the version with the ID [magenta]v1[/magenta] and save the information to a
       [magenta]version.json[/magenta] file.
-        $ [green]nextmv cloud version get --app-id hare-app --version-id v1 --output version.json[/green]
+        $ [dim]nextmv cloud version get --app-id hare-app --version-id v1 --output version.json[/dim]
     """
 
     cloud_app = build_app(app_id=app_id, profile=profile)

--- a/nextmv/nextmv/cli/cloud/version/list.py
+++ b/nextmv/nextmv/cli/cloud/version/list.py
@@ -35,13 +35,13 @@ def list(
     [bold][underline]Examples[/underline][/bold]
 
     - List all versions of application [magenta]hare-app[/magenta].
-        $ [green]nextmv cloud version list --app-id hare-app[/green]
+        $ [dim]nextmv cloud version list --app-id hare-app[/dim]
 
     - List all versions using the profile named [magenta]hare[/magenta].
-        $ [green]nextmv cloud version list --app-id hare-app --profile hare[/green]
+        $ [dim]nextmv cloud version list --app-id hare-app --profile hare[/dim]
 
     - List all versions and save the information to a [magenta]versions.json[/magenta] file.
-        $ [green]nextmv cloud version list --app-id hare-app --output versions.json[/green]
+        $ [dim]nextmv cloud version list --app-id hare-app --output versions.json[/dim]
     """
 
     cloud_app = build_app(app_id=app_id, profile=profile)

--- a/nextmv/nextmv/cli/cloud/version/update.py
+++ b/nextmv/nextmv/cli/cloud/version/update.py
@@ -70,7 +70,7 @@ def update(
     """
 
     if name is None and description is None:
-        error("Provide at least one option to update: [code]--name[/code] or [code]--description[/code].")
+        error("Provide at least one option to update: --name or --description.")
 
     cloud_app = build_app(app_id=app_id, profile=profile)
     updated_version = cloud_app.update_version(

--- a/nextmv/nextmv/cli/cloud/version/update.py
+++ b/nextmv/nextmv/cli/cloud/version/update.py
@@ -54,19 +54,19 @@ def update(
     [bold][underline]Examples[/underline][/bold]
 
     - Update a version's name.
-        $ [green]nextmv cloud version update --app-id hare-app --version-id v1 --name "Version 1.0"[/green]
+        $ [dim]nextmv cloud version update --app-id hare-app --version-id v1 --name "Version 1.0"[/dim]
 
     - Update a version's description.
-        $ [green]nextmv cloud version update --app-id hare-app --version-id v1 \\
-            --description "Initial stable release"[/green]
+        $ [dim]nextmv cloud version update --app-id hare-app --version-id v1 \\
+            --description "Initial stable release"[/dim]
 
     - Update a version's name and description at once.
-        $ [green]nextmv cloud version update --app-id hare-app --version-id v1 \\
-            --name "Version 1.0" --description "Initial stable release"[/green]
+        $ [dim]nextmv cloud version update --app-id hare-app --version-id v1 \\
+            --name "Version 1.0" --description "Initial stable release"[/dim]
 
     - Update a version and save the updated information to a [magenta]updated_version.json[/magenta] file.
-        $ [green]nextmv cloud version update --app-id hare-app --version-id v1 \\
-            --name "Version 1.0" --output updated_version.json[/green]
+        $ [dim]nextmv cloud version update --app-id hare-app --version-id v1 \\
+            --name "Version 1.0" --output updated_version.json[/dim]
     """
 
     if name is None and description is None:

--- a/nextmv/nextmv/cli/community/clone.py
+++ b/nextmv/nextmv/cli/community/clone.py
@@ -61,20 +61,20 @@ def clone(
 
     - Clone the [magenta]go-nextroute[/magenta] community app (under the
       [magenta]"go-nextroute"[/magenta] directory), using the [magenta]latest[/magenta] version.
-        $ [green]nextmv community clone --app go-nextroute[/green]
+        $ [dim]nextmv community clone --app go-nextroute[/dim]
 
     - Clone the [magenta]go-nextroute[/magenta] community app under the
       [magenta]"~/sample/my_app"[/magenta] directory, using the [magenta]latest[/magenta] version.
-        $ [green]nextmv community clone --app go-nextroute --directory ~/sample/my_app[/green]
+        $ [dim]nextmv community clone --app go-nextroute --directory ~/sample/my_app[/dim]
 
     - Clone the [magenta]go-nextroute[/magenta] community app (under the
       [magenta]"go-nextroute"[/magenta] directory), using version [magenta]v1.2.0[/magenta].
-        $ [green]nextmv community clone --app go-nextroute --version v1.2.0[/green]
+        $ [dim]nextmv community clone --app go-nextroute --version v1.2.0[/dim]
 
     - Clone the [magenta]go-nextroute[/magenta] community app (under the
       [magenta]"go-nextroute"[/magenta] directory), using the [magenta]latest[/magenta] version
       and a profile named [magenta]hare[/magenta].
-        $ [green]nextmv community clone --app go-nextroute --profile hare[/green]
+        $ [dim]nextmv community clone --app go-nextroute --profile hare[/dim]
     """
 
     manifest = download_manifest(profile=profile)

--- a/nextmv/nextmv/cli/community/clone.py
+++ b/nextmv/nextmv/cli/community/clone.py
@@ -53,9 +53,9 @@ def clone(
     Clone a community app locally.
 
     By default, the [magenta]latest[/magenta] version will be used. You can
-    specify a version with the [code]--version[/code] flag, and customize the
-    output directory with the [code]--directory[/code] flag. If you want to
-    list the available apps, use the [code]nextmv community list[/code] command.
+    specify a version with the --version flag, and customize the output
+    directory with the --directory flag. If you want to list the available
+    apps, use the [code]nextmv community list[/code] command.
 
     [bold][underline]Examples[/underline][/bold]
 
@@ -81,7 +81,7 @@ def clone(
     app_obj = find_app(manifest, app)
 
     if version is not None and version == "":
-        error("The [code]--version[/code] flag cannot be an empty string.")
+        error("The --version flag cannot be an empty string.")
 
     if not app_has_version(app_obj, version):
         # We don't use error() here to allow printing something before exiting.

--- a/nextmv/nextmv/cli/community/list.py
+++ b/nextmv/nextmv/cli/community/list.py
@@ -37,9 +37,9 @@ def list(
     """
     List the available community apps
 
-    Use the [code]--app[/code] flag to list that app's versions. Use the
-    [code]--flat[/code] flag to flatten the list of names/versions. If you
-    want to clone a community app locally, use the [code]nextmv community clone[/code] command.
+    Use the --app flag to list that app's versions. Use the --flat flag to
+    flatten the list of names/versions. If you want to clone a community app
+    locally, use the [code]nextmv community clone[/code] command.
 
     [bold][underline]Examples[/underline][/bold]
 
@@ -60,7 +60,7 @@ def list(
     """
 
     if app is not None and app == "":
-        error("The [code]--app[/code] flag cannot be an empty string.")
+        error("The --app flag cannot be an empty string.")
 
     manifest = download_manifest(profile=profile)
     if flat and app is None:

--- a/nextmv/nextmv/cli/community/list.py
+++ b/nextmv/nextmv/cli/community/list.py
@@ -44,19 +44,19 @@ def list(
     [bold][underline]Examples[/underline][/bold]
 
     - List the available community apps.
-        $ [green]nextmv community list[/green]
+        $ [dim]nextmv community list[/dim]
 
     - List the available versions of the [magenta]go-nextroute[/magenta] community app.
-        $ [green]nextmv community list --app go-nextroute[/green]
+        $ [dim]nextmv community list --app go-nextroute[/dim]
 
     - List the names of the available community apps as a flat list.
-        $ [green]nextmv community list --flat[/green]
+        $ [dim]nextmv community list --flat[/dim]
 
     - List the available versions of the [magenta]go-nextroute[/magenta] community app as a flat list.
-        $ [green]nextmv community list --app go-nextroute --flat[/green]
+        $ [dim]nextmv community list --app go-nextroute --flat[/dim]
 
     - List the available community apps using a profile named [magenta]hare[/magenta].
-        $ [green]nextmv community list --profile hare[/green]
+        $ [dim]nextmv community list --profile hare[/dim]
     """
 
     if app is not None and app == "":

--- a/nextmv/nextmv/cli/configuration/create.py
+++ b/nextmv/nextmv/cli/configuration/create.py
@@ -58,10 +58,10 @@ def create(
     [bold][underline]Examples[/underline][/bold]
 
     - Default configuration.
-        $ [green]nextmv configuration create --api-key NEXTMV_API_KEY[/green]
+        $ [dim]nextmv configuration create --api-key NEXTMV_API_KEY[/dim]
 
     - Configure a profile named [magenta]hare[/magenta].
-        $ [green]nextmv configuration create --api-key NEXTMV_API_KEY --profile hare[/green]
+        $ [dim]nextmv configuration create --api-key NEXTMV_API_KEY --profile hare[/dim]
     """
 
     if profile is not None and profile.strip().lower() == "default":

--- a/nextmv/nextmv/cli/configuration/create.py
+++ b/nextmv/nextmv/cli/configuration/create.py
@@ -65,7 +65,7 @@ def create(
     """
 
     if profile is not None and profile.strip().lower() == "default":
-        error("[code]default[/code] is a reserved profile name.")
+        error("[magenta]default[/magenta] is a reserved profile name.")
 
     endpoint = str(endpoint)
     if endpoint.startswith("https://"):

--- a/nextmv/nextmv/cli/configuration/delete.py
+++ b/nextmv/nextmv/cli/configuration/delete.py
@@ -42,10 +42,10 @@ def delete(
     [bold][underline]Examples[/underline][/bold]
 
     - Delete a profile named [magenta]hare[/magenta].
-        $ [green]nextmv configuration delete --profile hare[/green]
+        $ [dim]nextmv configuration delete --profile hare[/dim]
 
     - Delete a profile named [magenta]hare[/magenta] without confirmation prompt.
-        $ [green]nextmv configuration delete --profile hare --yes[/green]
+        $ [dim]nextmv configuration delete --profile hare --yes[/dim]
     """
     config = load_config()
     if profile not in config:

--- a/nextmv/nextmv/cli/configuration/delete.py
+++ b/nextmv/nextmv/cli/configuration/delete.py
@@ -36,7 +36,7 @@ def delete(
     ] = False,
 ) -> None:
     """
-    Delete a profile from the configuration. Use the [code]--yes[/code]
+    Delete a profile from the configuration. Use the --yes
     flag to skip the confirmation prompt.
 
     [bold][underline]Examples[/underline][/bold]

--- a/nextmv/nextmv/cli/configuration/list.py
+++ b/nextmv/nextmv/cli/configuration/list.py
@@ -22,7 +22,7 @@ def list() -> None:
     [bold][underline]Examples[/underline][/bold]
 
     - Show current configuration and all profiles.
-        $ [green]nextmv configuration list[/green]
+        $ [dim]nextmv configuration list[/dim]
     """
 
     config = load_config()

--- a/nextmv/nextmv/cli/main.py
+++ b/nextmv/nextmv/cli/main.py
@@ -20,6 +20,7 @@ from typing import Annotated
 import rich
 import typer
 from rich.prompt import Confirm
+from typer import rich_utils
 
 from nextmv.cli.cloud import app as cloud_app
 from nextmv.cli.community import app as community_app
@@ -28,6 +29,9 @@ from nextmv.cli.configuration.config import CONFIG_DIR, GO_CLI_PATH, load_config
 from nextmv.cli.message import error, info, success, warning
 from nextmv.cli.version import app as version_app
 from nextmv.cli.version import version_callback
+
+# Disable dim text for the extended help of commands.
+rich_utils.STYLE_HELPTEXT = ""
 
 # Main CLI application.
 app = typer.Typer(

--- a/nextmv/nextmv/cli/version.py
+++ b/nextmv/nextmv/cli/version.py
@@ -18,7 +18,7 @@ def version() -> None:
     [bold][underline]Examples[/underline][/bold]
 
     - Show the version.
-        $ [green]nextmv version[/green]
+        $ [dim]nextmv version[/dim]
     """
 
     version_callback(True)


### PR DESCRIPTION
# Description

- Removes the dim auxiliary help style.
- To improve readability, changes the use of `[green]` in favor of `[dim]`. When the whole text is normal, the green examples were too saturated.
- Removes the use of `[code]` for options/flags. Typer is already changing the color automatically so there is no need for double highlighting.
- Updates the `CONTRIBUTING.md` file for the CLI.

<img width="1071" height="1382" alt="image" src="https://github.com/user-attachments/assets/69dfa0d6-dc89-4f58-a4cc-2df6e82c921c" />
