### PR TITLE
Removes PATH check for old CLI path

### DIFF
--- a/nextmv/nextmv/cli/CONTRIBUTING.md
+++ b/nextmv/nextmv/cli/CONTRIBUTING.md
@@ -173,23 +173,27 @@ guidelines:
 
 ## Confirmation prompts
 
-For destructive actions (like deletions), use `rich.prompt.Confirm.ask()` to
-ask for user confirmation before proceeding. Follow these guidelines:
+For destructive actions (like deletions), use the `get_confirmation()` method to
+ask for user confirmation before proceeding. The method is available from the
+`cli/confirm.py` file. This method already handles sensible values used for
+getting a confirmation from a user and more importantly, it times out if a user
+does not respond within a certain time frame. Additionally, it handles
+non-interactive sessions by defaulting to `False` if no input can be provided.
 
-- The confirmation message should use `[magenta]` for the variable being
+When using confirmation prompts, follow these guidelines:
+
+- The confirmation message should use `[magenta]` for the variable/s being
   affected.
-- Set `default=False` for safety, so the user must explicitly confirm.
-- Provide a `--yes` / `-y` flag to skip the confirmation prompt, useful for
-  non-interactive sessions.
+- Provide a `--yes` / `-y` flag to skip the confirmation prompt where possible,
+  useful for non-interactive sessions.
 - If the user declines, call `info()` with the `:bulb:` emoji and return early.
 
 Consider the `nextmv cloud app delete` command:
 
 ```python
 if not yes:
-    confirm = Confirm.ask(
-        f"Are you sure you want to delete application [magenta]{app_id}[/magenta]? This action cannot be undone",
-        default=False,
+    confirm = get_confirmation(
+        f"Are you sure you want to delete application [magenta]{app_id}[/magenta]? This action cannot be undone.",
     )
 
     if not confirm:

--- a/nextmv/nextmv/cli/CONTRIBUTING.md
+++ b/nextmv/nextmv/cli/CONTRIBUTING.md
@@ -173,12 +173,11 @@ guidelines:
 
 ## Confirmation prompts
 
-For destructive actions (like deletions), use the `get_confirmation()` method to
-ask for user confirmation before proceeding. The method is available from the
-`cli/confirm.py` file. This method already handles sensible values used for
-getting a confirmation from a user and more importantly, it times out if a user
-does not respond within a certain time frame. Additionally, it handles
-non-interactive sessions by defaulting to `False` if no input can be provided.
+For destructive actions (like deletions), use the `get_confirmation()` method
+to ask for user confirmation before proceeding. The method is available from
+the `cli/confirm.py` file. This method already handles sensible values used for
+getting a confirmation from a user. Additionally, it handles non-interactive
+sessions by defaulting to `False` if no input can be provided.
 
 When using confirmation prompts, follow these guidelines:
 

--- a/nextmv/nextmv/cli/cloud/acceptance/delete.py
+++ b/nextmv/nextmv/cli/cloud/acceptance/delete.py
@@ -5,9 +5,9 @@ This module defines the cloud acceptance delete command for the Nextmv CLI.
 from typing import Annotated
 
 import typer
-from rich.prompt import Confirm
 
 from nextmv.cli.configuration.config import build_app
+from nextmv.cli.confirm import get_confirmation
 from nextmv.cli.message import info, success
 from nextmv.cli.options import AcceptanceTestIDOption, AppIDOption, ProfileOption
 
@@ -47,10 +47,9 @@ def delete(
     """
 
     if not yes:
-        confirm = Confirm.ask(
+        confirm = get_confirmation(
             f"Are you sure you want to delete acceptance test [magenta]{acceptance_test_id}[/magenta] "
             f"from application [magenta]{app_id}[/magenta]? This action cannot be undone.",
-            default=False,
         )
 
         if not confirm:

--- a/nextmv/nextmv/cli/cloud/account/delete.py
+++ b/nextmv/nextmv/cli/cloud/account/delete.py
@@ -5,9 +5,9 @@ This module defines the cloud account delete command for the Nextmv CLI.
 from typing import Annotated
 
 import typer
-from rich.prompt import Confirm
 
 from nextmv.cli.configuration.config import build_account
+from nextmv.cli.confirm import get_confirmation
 from nextmv.cli.message import info, success
 from nextmv.cli.options import AccountIDOption, ProfileOption
 
@@ -46,9 +46,8 @@ def delete(
     """
 
     if not yes:
-        confirm = Confirm.ask(
+        confirm = get_confirmation(
             f"Are you sure you want to delete account [magenta]{account_id}[/magenta]? This action cannot be undone.",
-            default=False,
         )
 
         if not confirm:

--- a/nextmv/nextmv/cli/cloud/app/delete.py
+++ b/nextmv/nextmv/cli/cloud/app/delete.py
@@ -5,9 +5,9 @@ This module defines the cloud app delete command for the Nextmv CLI.
 from typing import Annotated
 
 import typer
-from rich.prompt import Confirm
 
 from nextmv.cli.configuration.config import build_app
+from nextmv.cli.confirm import get_confirmation
 from nextmv.cli.message import info, success
 from nextmv.cli.options import AppIDOption, ProfileOption
 
@@ -44,9 +44,8 @@ def delete(
     """
 
     if not yes:
-        confirm = Confirm.ask(
+        confirm = get_confirmation(
             f"Are you sure you want to delete application [magenta]{app_id}[/magenta]? This action cannot be undone.",
-            default=False,
         )
 
         if not confirm:

--- a/nextmv/nextmv/cli/cloud/batch/delete.py
+++ b/nextmv/nextmv/cli/cloud/batch/delete.py
@@ -5,9 +5,9 @@ This module defines the cloud batch delete command for the Nextmv CLI.
 from typing import Annotated
 
 import typer
-from rich.prompt import Confirm
 
 from nextmv.cli.configuration.config import build_app
+from nextmv.cli.confirm import get_confirmation
 from nextmv.cli.message import info, success
 from nextmv.cli.options import AppIDOption, BatchExperimentIDOption, ProfileOption
 
@@ -47,10 +47,9 @@ def delete(
     """
 
     if not yes:
-        confirm = Confirm.ask(
+        confirm = get_confirmation(
             f"Are you sure you want to delete batch experiment [magenta]{batch_experiment_id}[/magenta] "
             f"from application [magenta]{app_id}[/magenta]? This action cannot be undone.",
-            default=False,
         )
 
         if not confirm:

--- a/nextmv/nextmv/cli/cloud/ensemble/delete.py
+++ b/nextmv/nextmv/cli/cloud/ensemble/delete.py
@@ -5,9 +5,9 @@ This module defines the cloud ensemble delete command for the Nextmv CLI.
 from typing import Annotated
 
 import typer
-from rich.prompt import Confirm
 
 from nextmv.cli.configuration.config import build_app
+from nextmv.cli.confirm import get_confirmation
 from nextmv.cli.message import info, success
 from nextmv.cli.options import AppIDOption, EnsembleDefinitionIDOption, ProfileOption
 
@@ -46,10 +46,9 @@ def delete(
     """
 
     if not yes:
-        confirm = Confirm.ask(
+        confirm = get_confirmation(
             f"Are you sure you want to delete ensemble definition [magenta]{ensemble_definition_id}[/magenta] "
             f"from application [magenta]{app_id}[/magenta]? This action cannot be undone.",
-            default=False,
         )
 
         if not confirm:

--- a/nextmv/nextmv/cli/cloud/instance/delete.py
+++ b/nextmv/nextmv/cli/cloud/instance/delete.py
@@ -5,9 +5,9 @@ This module defines the cloud instance delete command for the Nextmv CLI.
 from typing import Annotated
 
 import typer
-from rich.prompt import Confirm
 
 from nextmv.cli.configuration.config import build_app
+from nextmv.cli.confirm import get_confirmation
 from nextmv.cli.message import info, success
 from nextmv.cli.options import AppIDOption, InstanceIDOption, ProfileOption
 
@@ -45,10 +45,9 @@ def delete(
     """
 
     if not yes:
-        confirm = Confirm.ask(
+        confirm = get_confirmation(
             f"Are you sure you want to delete instance [magenta]{instance_id}[/magenta] "
             f"from application [magenta]{app_id}[/magenta]? This action cannot be undone.",
-            default=False,
         )
 
         if not confirm:

--- a/nextmv/nextmv/cli/cloud/managed_input/delete.py
+++ b/nextmv/nextmv/cli/cloud/managed_input/delete.py
@@ -5,9 +5,9 @@ This module defines the cloud managed-input delete command for the Nextmv CLI.
 from typing import Annotated
 
 import typer
-from rich.prompt import Confirm
 
 from nextmv.cli.configuration.config import build_app
+from nextmv.cli.confirm import get_confirmation
 from nextmv.cli.message import info, success
 from nextmv.cli.options import AppIDOption, ManagedInputIDOption, ProfileOption
 
@@ -47,10 +47,9 @@ def delete(
     """
 
     if not yes:
-        confirm = Confirm.ask(
+        confirm = get_confirmation(
             f"Are you sure you want to delete managed input [magenta]{managed_input_id}[/magenta] "
             f"from application [magenta]{app_id}[/magenta]? This action cannot be undone.",
-            default=False,
         )
 
         if not confirm:

--- a/nextmv/nextmv/cli/cloud/scenario/delete.py
+++ b/nextmv/nextmv/cli/cloud/scenario/delete.py
@@ -5,9 +5,9 @@ This module defines the cloud scenario delete command for the Nextmv CLI.
 from typing import Annotated
 
 import typer
-from rich.prompt import Confirm
 
 from nextmv.cli.configuration.config import build_app
+from nextmv.cli.confirm import get_confirmation
 from nextmv.cli.message import info, success
 from nextmv.cli.options import AppIDOption, ProfileOption, ScenarioTestIDOption
 
@@ -47,10 +47,9 @@ def delete(
     """
 
     if not yes:
-        confirm = Confirm.ask(
+        confirm = get_confirmation(
             f"Are you sure you want to delete scenario test [magenta]{scenario_test_id}[/magenta] "
             f"from application [magenta]{app_id}[/magenta]? This action cannot be undone.",
-            default=False,
         )
 
         if not confirm:

--- a/nextmv/nextmv/cli/cloud/secrets/delete.py
+++ b/nextmv/nextmv/cli/cloud/secrets/delete.py
@@ -5,9 +5,9 @@ This module defines the cloud secrets delete command for the Nextmv CLI.
 from typing import Annotated
 
 import typer
-from rich.prompt import Confirm
 
 from nextmv.cli.configuration.config import build_app
+from nextmv.cli.confirm import get_confirmation
 from nextmv.cli.message import info, success
 from nextmv.cli.options import AppIDOption, ProfileOption, SecretsCollectionIDOption
 
@@ -46,10 +46,9 @@ def delete(
     """
 
     if not yes:
-        confirm = Confirm.ask(
+        confirm = get_confirmation(
             f"Are you sure you want to delete secrets collection [magenta]{secrets_collection_id}[/magenta] "
             f"from application [magenta]{app_id}[/magenta]? This action cannot be undone.",
-            default=False,
         )
 
         if not confirm:

--- a/nextmv/nextmv/cli/cloud/shadow/delete.py
+++ b/nextmv/nextmv/cli/cloud/shadow/delete.py
@@ -5,9 +5,9 @@ This module defines the cloud shadow delete command for the Nextmv CLI.
 from typing import Annotated
 
 import typer
-from rich.prompt import Confirm
 
 from nextmv.cli.configuration.config import build_app
+from nextmv.cli.confirm import get_confirmation
 from nextmv.cli.message import info, success
 from nextmv.cli.options import AppIDOption, ProfileOption, ShadowTestIDOption
 
@@ -47,10 +47,9 @@ def delete(
     """
 
     if not yes:
-        confirm = Confirm.ask(
+        confirm = get_confirmation(
             f"Are you sure you want to delete shadow test [magenta]{shadow_test_id}[/magenta] "
             f"from application [magenta]{app_id}[/magenta]? This action cannot be undone.",
-            default=False,
         )
 
         if not confirm:

--- a/nextmv/nextmv/cli/cloud/switchback/delete.py
+++ b/nextmv/nextmv/cli/cloud/switchback/delete.py
@@ -5,9 +5,9 @@ This module defines the cloud switchback delete command for the Nextmv CLI.
 from typing import Annotated
 
 import typer
-from rich.prompt import Confirm
 
 from nextmv.cli.configuration.config import build_app
+from nextmv.cli.confirm import get_confirmation
 from nextmv.cli.message import info, success
 from nextmv.cli.options import AppIDOption, ProfileOption, SwitchbackTestIDOption
 
@@ -47,10 +47,9 @@ def delete(
     """
 
     if not yes:
-        confirm = Confirm.ask(
+        confirm = get_confirmation(
             f"Are you sure you want to delete switchback test [magenta]{switchback_test_id}[/magenta] "
             f"from application [magenta]{app_id}[/magenta]? This action cannot be undone.",
-            default=False,
         )
 
         if not confirm:

--- a/nextmv/nextmv/cli/cloud/version/delete.py
+++ b/nextmv/nextmv/cli/cloud/version/delete.py
@@ -5,9 +5,9 @@ This module defines the cloud version delete command for the Nextmv CLI.
 from typing import Annotated
 
 import typer
-from rich.prompt import Confirm
 
 from nextmv.cli.configuration.config import build_app
+from nextmv.cli.confirm import get_confirmation
 from nextmv.cli.message import info, success
 from nextmv.cli.options import AppIDOption, ProfileOption, VersionIDOption
 
@@ -45,10 +45,9 @@ def delete(
     """
 
     if not yes:
-        confirm = Confirm.ask(
+        confirm = get_confirmation(
             f"Are you sure you want to delete version [magenta]{version_id}[/magenta] "
             f"from application [magenta]{app_id}[/magenta]? This action cannot be undone.",
-            default=False,
         )
 
         if not confirm:

--- a/nextmv/nextmv/cli/configuration/config.py
+++ b/nextmv/nextmv/cli/configuration/config.py
@@ -59,6 +59,18 @@ def save_config(config: dict[str, Any]) -> None:
         yaml.safe_dump(config, file)
 
 
+def non_profile_keys() -> set[str]:
+    """
+    Returns the set of keys that are not profile names in the configuration.
+
+    Returns
+    -------
+    set[str]
+        The set of non-profile keys.
+    """
+    return {API_KEY_KEY, ENDPOINT_KEY}
+
+
 def build_client(profile: str | None = None) -> Client:
     """
     Builds a `cloud.Client` using the API key and endpoint for the given
@@ -91,23 +103,35 @@ def build_client(profile: str | None = None) -> Client:
 
     if profile is not None:
         if profile not in config:
-            error(f"Profile [magenta]{profile}[/magenta] does not exist.")
+            error(
+                f"Profile [magenta]{profile}[/magenta] does not exist. "
+                "Create it using [code]nextmv configuration create[/code] with the --profile option."
+            )
 
         api_key = config[profile].get(API_KEY_KEY)
         if api_key is None or api_key == "":
-            error(f"API key for profile [magenta]{profile}[/magenta] is not set or is empty.")
+            error(
+                f"API key for profile [magenta]{profile}[/magenta] is not set or is empty. "
+                "Set it using [code]nextmv configuration create[/code] with the --profile and --api-key options."
+            )
 
         endpoint = config[profile].get(ENDPOINT_KEY)
         if endpoint is None or endpoint == "":
-            error(f"Endpoint for profile [magenta]{profile}[/magenta] is not set or is empty.")
+            error(
+                f"Endpoint for profile [magenta]{profile}[/magenta] is not set or is empty. "
+                "Please run [code]nextmv configuration create[/code]."
+            )
     else:
         api_key = config.get(API_KEY_KEY)
         if api_key is None or api_key == "":
-            error("Default API key is not set or is empty.")
+            error(
+                "Default API key is not set or is empty. "
+                "Please run [code]nextmv configuration create[/code] with the --api-key option."
+            )
 
         endpoint = config.get(ENDPOINT_KEY)
         if endpoint is None or endpoint == "":
-            error("Default endpoint is not set or is empty.")
+            error("Default endpoint is not set or is empty. Please run [code]nextmv configuration create[/code].")
 
     return Client(api_key=api_key, url=f"https://{endpoint}")
 

--- a/nextmv/nextmv/cli/configuration/delete.py
+++ b/nextmv/nextmv/cli/configuration/delete.py
@@ -5,9 +5,9 @@ This module defines the configuration delete command for the Nextmv CLI.
 from typing import Annotated
 
 import typer
-from rich.prompt import Confirm
 
 from nextmv.cli.configuration.config import load_config, save_config
+from nextmv.cli.confirm import get_confirmation
 from nextmv.cli.message import error, info, success
 
 # Set up subcommand application.
@@ -36,8 +36,9 @@ def delete(
     ] = False,
 ) -> None:
     """
-    Delete a profile from the configuration. Use the --yes
-    flag to skip the confirmation prompt.
+    Delete a profile from the configuration.
+
+    Use the --yes flag to skip the confirmation prompt.
 
     [bold][underline]Examples[/underline][/bold]
 
@@ -52,9 +53,8 @@ def delete(
         error(f"Profile [magenta]{profile}[/magenta] does not exist.")
 
     if not yes:
-        confirm = Confirm.ask(
+        confirm = get_confirmation(
             f"Are you sure you want to delete profile [magenta]{profile}[/magenta]? This action cannot be undone.",
-            default=False,
         )
 
         if not confirm:

--- a/nextmv/nextmv/cli/configuration/list.py
+++ b/nextmv/nextmv/cli/configuration/list.py
@@ -6,7 +6,7 @@ import typer
 from rich.console import Console
 from rich.table import Table
 
-from nextmv.cli.configuration.config import API_KEY_KEY, ENDPOINT_KEY, load_config, obscure_api_key
+from nextmv.cli.configuration.config import API_KEY_KEY, ENDPOINT_KEY, load_config, non_profile_keys, obscure_api_key
 from nextmv.cli.message import error
 
 # Set up subcommand application.
@@ -38,7 +38,7 @@ def list() -> None:
 
     for k, v in config.items():
         # Skip default configuration.
-        if k in {API_KEY_KEY, ENDPOINT_KEY}:
+        if k in non_profile_keys():
             continue
 
         profile = {

--- a/nextmv/nextmv/cli/confirm.py
+++ b/nextmv/nextmv/cli/confirm.py
@@ -1,0 +1,57 @@
+import queue
+import sys
+import threading
+
+from rich.prompt import Confirm
+
+from nextmv.cli.message import info
+
+
+def get_confirmation(msg: str, timeout: int = 30) -> bool:
+    """
+    Method to get a yes/no confirmation from the user with a timeout.
+
+    Parameters
+    ----------
+    msg : str
+        The message to display to the user.
+    timeout : int
+        The timeout in seconds to wait for a response.
+
+    Returns
+    -------
+    bool
+        True if the user confirmed, False otherwise.
+    """
+
+    # If this is not an interactive terminal, do not ask for confirmation, to
+    # avoid hanging indefinitely waiting for a user response.
+    if not sys.stdin.isatty():
+        return False
+
+    result_queue = queue.Queue()
+
+    def ask():
+        result = Confirm.ask(
+            msg,
+            default=False,
+            case_sensitive=False,
+            show_default=True,
+            show_choices=True,
+        )
+        result_queue.put(result)
+
+    t = threading.Thread(target=ask, daemon=True)
+    t.start()
+
+    try:
+        return result_queue.get(timeout=float(timeout))
+
+    except queue.Empty:
+        print("\n", file=sys.stderr)
+        info(
+            msg=f"No response received within [magenta]{timeout}s[/magenta], assuming no ([magenta]n[/magenta]).",
+            emoji=":bulb:",
+        )
+
+        return False

--- a/nextmv/nextmv/cli/confirm.py
+++ b/nextmv/nextmv/cli/confirm.py
@@ -1,22 +1,16 @@
-import queue
 import sys
-import threading
 
 from rich.prompt import Confirm
 
-from nextmv.cli.message import info
 
-
-def get_confirmation(msg: str, timeout: int = 30) -> bool:
+def get_confirmation(msg: str) -> bool:
     """
-    Method to get a yes/no confirmation from the user with a timeout.
+    Method to get a yes/no confirmation from the user.
 
     Parameters
     ----------
     msg : str
         The message to display to the user.
-    timeout : int
-        The timeout in seconds to wait for a response.
 
     Returns
     -------
@@ -29,29 +23,10 @@ def get_confirmation(msg: str, timeout: int = 30) -> bool:
     if not sys.stdin.isatty():
         return False
 
-    result_queue = queue.Queue()
-
-    def ask():
-        result = Confirm.ask(
-            msg,
-            default=False,
-            case_sensitive=False,
-            show_default=True,
-            show_choices=True,
-        )
-        result_queue.put(result)
-
-    t = threading.Thread(target=ask, daemon=True)
-    t.start()
-
-    try:
-        return result_queue.get(timeout=float(timeout))
-
-    except queue.Empty:
-        print("\n", file=sys.stderr)
-        info(
-            msg=f"No response received within [magenta]{timeout}s[/magenta], assuming no ([magenta]n[/magenta]).",
-            emoji=":bulb:",
-        )
-
-        return False
+    return Confirm.ask(
+        msg,
+        default=False,
+        case_sensitive=False,
+        show_default=True,
+        show_choices=True,
+    )

--- a/nextmv/nextmv/cli/main.py
+++ b/nextmv/nextmv/cli/main.py
@@ -13,19 +13,18 @@ about the features used here. An example of Rich markup can be found in the
 epilog of the Typer application defined below.
 """
 
-import os
 import sys
 from typing import Annotated
 
 import rich
 import typer
-from rich.prompt import Confirm
 from typer import rich_utils
 
 from nextmv.cli.cloud import app as cloud_app
 from nextmv.cli.community import app as community_app
 from nextmv.cli.configuration import app as configuration_app
 from nextmv.cli.configuration.config import CONFIG_DIR, GO_CLI_PATH, load_config
+from nextmv.cli.confirm import get_confirmation
 from nextmv.cli.message import error, info, success, warning
 from nextmv.cli.version import app as version_app
 from nextmv.cli.version import version_callback
@@ -70,6 +69,15 @@ def callback(
     environment.
     """
 
+    # Skip checks for help commands.
+    if "--help" in sys.argv or "-h" in sys.argv:
+        return
+
+    # Skip checks for certain commands.
+    ignored_commands = {"configuration", "version"}
+    if ctx.invoked_subcommand in ignored_commands:
+        return
+
     handle_go_cli()
     handle_config_existence(ctx)
 
@@ -84,19 +92,21 @@ def handle_go_cli() -> None:
 
     exists = go_cli_exists()
     if exists:
-        delete = Confirm.ask(
+        delete = get_confirmation(
             "Do you want to delete the [italic red]deprecated[/italic red] Nextmv CLI "
-            f"at [magenta]{GO_CLI_PATH}[/magenta] now?",
-            default=False,
+            f"at [magenta]{GO_CLI_PATH}[/magenta] now?"
         )
         if delete:
             remove_go_cli()
-        else:
-            info(
-                msg="You can delete the [italic red]deprecated[/italic red] Nextmv CLI later by removing "
-                f"[magenta]{GO_CLI_PATH}[/magenta]. Make sure you also clean up your [code]PATH[/code].",
-                emoji=":bulb:",
-            )
+            return
+
+        info(
+            msg="You can delete the [italic red]deprecated[/italic red] Nextmv CLI later by removing "
+            f"[magenta]{GO_CLI_PATH}[/magenta]. "
+            "Make sure you also clean up your [code]PATH[/code], "
+            f"by removing references to [magenta]{CONFIG_DIR}[/magenta] from it.",
+            emoji=":bulb:",
+        )
 
 
 def handle_config_existence(ctx: typer.Context) -> None:
@@ -108,10 +118,6 @@ def handle_config_existence(ctx: typer.Context) -> None:
     ctx : typer.Context
         The Typer context object.
     """
-
-    ignored_commands = {"configuration", "version"}
-    if ctx.invoked_subcommand in ignored_commands:
-        return
 
     config = load_config()
     if config == {}:
@@ -134,10 +140,8 @@ def go_cli_exists() -> bool:
     if exists:
         warning(
             "A [italic red]deprecated[/italic red] Nextmv CLI is installed at "
-            f"[magenta]{GO_CLI_PATH}[/magenta]. You must delete it to avoid conflicts."
+            f"[magenta]{GO_CLI_PATH}[/magenta]. You should delete it to avoid conflicts."
         )
-
-    check_config_in_path()
 
     return exists
 
@@ -150,23 +154,6 @@ def remove_go_cli() -> None:
     if GO_CLI_PATH.exists():
         GO_CLI_PATH.unlink()
         success(f"Deleted deprecated [magenta]{GO_CLI_PATH}[/magenta].")
-
-    check_config_in_path()
-
-
-def check_config_in_path() -> None:
-    """
-    Check if the configuration directory is in the PATH and notify the user.
-    """
-
-    path_dirs = os.environ.get("PATH", "").split(os.pathsep)
-    config_dir_str = str(CONFIG_DIR)
-
-    if config_dir_str in path_dirs:
-        warning(
-            f"[magenta]{CONFIG_DIR}[/magenta] was found in your [code]PATH[/code]. "
-            f"You should remove any entries related to [magenta]{CONFIG_DIR}[/magenta] from your [code]PATH[/code]."
-        )
 
 
 def main() -> None:

--- a/nextmv/nextmv/cli/message.py
+++ b/nextmv/nextmv/cli/message.py
@@ -31,7 +31,7 @@ def error(msg: str) -> None:
     if not msg.endswith("."):
         msg += "."
 
-    rich.print(f"[red]Error:[/red] {msg}", file=sys.stderr)
+    rich.print(f":x: [red]Error:[/red] {msg}", file=sys.stderr)
 
     raise typer.Exit(code=1)
 
@@ -67,7 +67,7 @@ def warning(msg: str) -> None:
     if not msg.endswith("."):
         msg += "."
 
-    rich.print(f":construction: {msg}", file=sys.stderr)
+    rich.print(f":construction: [yellow] Warning:[/yellow] {msg}", file=sys.stderr)
 
 
 def info(msg: str, emoji: str | None = None) -> None:

--- a/nextmv/tests/cli/test_configuration.py
+++ b/nextmv/tests/cli/test_configuration.py
@@ -18,7 +18,7 @@ from nextmv.cli.configuration.config import (
     obscure_api_key,
     save_config,
 )
-from nextmv.cli.main import app, check_config_in_path, go_cli_exists, remove_go_cli
+from nextmv.cli.main import app, go_cli_exists, remove_go_cli
 from typer.testing import CliRunner
 
 
@@ -129,8 +129,9 @@ class TestConfigureCommand(unittest.TestCase):
 
     @patch("nextmv.cli.configuration.delete.save_config")
     @patch("nextmv.cli.configuration.delete.load_config")
-    @patch("rich.prompt.Confirm.ask", return_value=True)
-    def test_delete_profile(self, mock_confirm, mock_load, mock_save):
+    @patch("nextmv.cli.configuration.delete.get_confirmation", return_value=True)
+    @patch("sys.stdin.isatty", return_value=True)
+    def test_delete_profile(self, mock_isatty, mock_confirm, mock_load, mock_save):
         """Test deleting a profile."""
         mock_load.return_value = {
             API_KEY_KEY: "default_key",
@@ -262,78 +263,48 @@ class TestGoCliExists(unittest.TestCase):
     """Tests for the go_cli_exists function."""
 
     @patch("nextmv.cli.main.warning")
-    @patch("nextmv.cli.main.check_config_in_path")
     @patch.object(Path, "exists")
-    def test_go_cli_exists_returns_true_when_file_exists(self, mock_exists, mock_check_path, mock_warning):
+    def test_go_cli_exists_returns_true_when_file_exists(self, mock_exists, mock_warning):
         """Test that go_cli_exists returns True when the Go CLI file exists."""
         mock_exists.return_value = True
 
         result = go_cli_exists()
 
         self.assertTrue(result)
-        mock_check_path.assert_called_once()
 
-    @patch("nextmv.cli.main.check_config_in_path")
     @patch.object(Path, "exists")
-    def test_go_cli_exists_returns_false_when_file_not_exists(self, mock_exists, mock_check_path):
+    def test_go_cli_exists_returns_false_when_file_not_exists(self, mock_exists):
         """Test that go_cli_exists returns False when the Go CLI file does not exist."""
         mock_exists.return_value = False
 
         result = go_cli_exists()
 
         self.assertFalse(result)
-        mock_check_path.assert_called_once()
 
 
 class TestRemoveGoCli(unittest.TestCase):
     """Tests for the remove_go_cli function."""
 
     @patch("nextmv.cli.main.success")
-    @patch("nextmv.cli.main.check_config_in_path")
     @patch.object(Path, "unlink")
     @patch.object(Path, "exists")
-    def test_remove_go_cli_deletes_file_when_exists(self, mock_exists, mock_unlink, mock_check_path, mock_success):
+    def test_remove_go_cli_deletes_file_when_exists(self, mock_exists, mock_unlink, mock_success):
         """Test that remove_go_cli deletes the file when it exists."""
         mock_exists.return_value = True
 
         remove_go_cli()
 
         mock_unlink.assert_called_once()
-        mock_check_path.assert_called_once()
 
-    @patch("nextmv.cli.main.check_config_in_path")
     @patch.object(Path, "unlink")
     @patch.object(Path, "exists")
-    def test_remove_go_cli_does_not_delete_when_not_exists(self, mock_exists, mock_unlink, mock_check_path):
+    def test_remove_go_cli_does_not_delete_when_not_exists(self, mock_exists, mock_unlink):
         """Test that remove_go_cli does not attempt to delete when file does not exist."""
         mock_exists.return_value = False
 
         remove_go_cli()
 
         mock_unlink.assert_not_called()
-        mock_check_path.assert_called_once()
-
-
-class TestCheckConfigInPath(unittest.TestCase):
-    """Tests for the check_config_in_path function."""
-
-    @patch("nextmv.cli.main.warning")
-    @patch.dict(os.environ, {"PATH": f"/usr/bin{os.pathsep}{CONFIG_DIR}{os.pathsep}/usr/local/bin"})
-    def test_check_config_in_path_prints_warning_when_in_path(self, mock_warning):
-        """Test that a warning is printed when CONFIG_DIR is in PATH."""
-        check_config_in_path()
-
-        mock_warning.assert_called_once()
-        call_args = str(mock_warning.call_args)
-        self.assertIn("PATH", call_args)
-
-    @patch("nextmv.cli.main.warning")
-    @patch.dict(os.environ, {"PATH": "/usr/bin:/usr/local/bin"})
-    def test_check_config_in_path_no_warning_when_not_in_path(self, mock_warning):
-        """Test that no warning is printed when CONFIG_DIR is not in PATH."""
-        check_config_in_path()
-
-        mock_warning.assert_not_called()
 
 
 class TestGoCliPath(unittest.TestCase):

--- a/nextmv/tests/cli/test_main.py
+++ b/nextmv/tests/cli/test_main.py
@@ -66,34 +66,3 @@ class TestHandleGoCli(unittest.TestCase):
         result = self.runner.invoke(self.app, ["version"])
         self.assertEqual(result.exit_code, 0)
         self.assertNotIn("deprecated", result.output)
-
-    @patch("nextmv.cli.main.remove_go_cli")
-    @patch("nextmv.cli.main.go_cli_exists")
-    @patch("nextmv.cli.main.load_config")
-    def test_prompt_shown_when_go_cli_exists_user_accepts(
-        self, mock_load_config, mock_go_cli_exists, mock_remove_go_cli
-    ):
-        """Test that prompt is shown when Go CLI exists and removal happens on accept."""
-        mock_go_cli_exists.return_value = True
-        mock_load_config.return_value = {"api_key": "test_key"}
-
-        # Simulate user accepting the prompt (y)
-        result = self.runner.invoke(self.app, ["version"], input="y\n")
-        self.assertEqual(result.exit_code, 0)
-        mock_remove_go_cli.assert_called_once()
-
-    @patch("nextmv.cli.main.remove_go_cli")
-    @patch("nextmv.cli.main.go_cli_exists")
-    @patch("nextmv.cli.main.load_config")
-    def test_prompt_shown_when_go_cli_exists_user_declines(
-        self, mock_load_config, mock_go_cli_exists, mock_remove_go_cli
-    ):
-        """Test that prompt is shown when Go CLI exists and no removal on decline."""
-        mock_go_cli_exists.return_value = True
-        mock_load_config.return_value = {"api_key": "test_key"}
-
-        # Simulate user declining the prompt (n)
-        result = self.runner.invoke(self.app, ["version"], input="n\n")
-        self.assertEqual(result.exit_code, 0)
-        mock_remove_go_cli.assert_not_called()
-        self.assertIn("later by removing", result.output)


### PR DESCRIPTION
# Description

Removes the logic that was checking if the old Go CLI install path was present in the `PATH`. Given that this was about cleanup, and didn't actually affect functionality of the Python CLI, then the check is removed altogether.

This got me thinking about prompts in general in a CI/CD environment, where people can easily not use `--yes` or similar flags, or the check that prompts a user to delete the old CLI. The confirmation prompts of the project were refactored to use a single `get_confirmation` function. This function detects if the shell is not interactive and also applies a timeout strategy so it simply returns the default `False` if no answer is given.