### PR TITLE
Normalizes clone directory path

### DIFF
--- a/nextmv/nextmv/cli/community/clone.py
+++ b/nextmv/nextmv/cli/community/clone.py
@@ -97,8 +97,10 @@ def clone(
     if version == LATEST_VERSION:
         version = app_obj.get("latest_app_version")
 
-    destination = directory
-    if directory is None or directory == "":
+    # Clean and normalize directory path in an OS-independent way
+    if directory is not None and directory != "":
+        destination = os.path.normpath(directory)
+    else:
         destination = app
 
     full_destination = get_valid_path(destination, os.stat)

--- a/nextmv/tests/cli/test_community.py
+++ b/nextmv/tests/cli/test_community.py
@@ -501,7 +501,8 @@ class TestCommunityCloneCommand(unittest.TestCase):
                         result = self.runner.invoke(self.app, ["--app", "go-nextroute", "--directory", "/custom/path"])
 
                         self.assertEqual(result.exit_code, 0)
-                        mock_get_valid_path.assert_called_once_with("/custom/path", os.stat)
+                        expected_path = os.path.join(os.sep, "custom", "path")
+                        mock_get_valid_path.assert_called_once_with(expected_path, os.stat)
 
 
 class TestAppHasVersion(unittest.TestCase):


### PR DESCRIPTION
# Description

Normalizes the path when using the `nextmv community clone` command with the `--directory` option so using it like `--directory foo/` is normalized as `--directory foo`.