### PR TITLE
Add instance locking/unlocking to SDK and CLI

### DIFF
--- a/nextmv/nextmv/cli/cloud/account/update.py
+++ b/nextmv/nextmv/cli/cloud/account/update.py
@@ -8,7 +8,7 @@ from typing import Annotated
 import typer
 
 from nextmv.cli.configuration.config import build_account
-from nextmv.cli.message import print_json, success
+from nextmv.cli.message import in_progress, print_json, success
 from nextmv.cli.options import AccountIDOption, ProfileOption
 
 # Set up subcommand application.
@@ -55,6 +55,7 @@ def update(
     """
 
     cloud_account = build_account(account_id=account_id, profile=profile)
+    in_progress(msg="Updating account...")
     updated_account = cloud_account.update(name=name)
     success(f"Account [magenta]{account_id}[/magenta] updated successfully.")
     updated_account_dict = updated_account.to_dict()

--- a/nextmv/nextmv/cli/cloud/app/update.py
+++ b/nextmv/nextmv/cli/cloud/app/update.py
@@ -8,7 +8,7 @@ from typing import Annotated
 import typer
 
 from nextmv.cli.configuration.config import build_app
-from nextmv.cli.message import error, print_json, success
+from nextmv.cli.message import error, in_progress, print_json, success
 from nextmv.cli.options import AppIDOption, ProfileOption
 
 # Set up subcommand application.
@@ -104,6 +104,7 @@ def update(
         )
 
     cloud_app = build_app(app_id=app_id, profile=profile)
+    in_progress(msg="Updating application...")
     updated_app = cloud_app.update(
         name=name,
         description=description,

--- a/nextmv/nextmv/cli/cloud/ensemble/update.py
+++ b/nextmv/nextmv/cli/cloud/ensemble/update.py
@@ -8,7 +8,7 @@ from typing import Annotated
 import typer
 
 from nextmv.cli.configuration.config import build_app
-from nextmv.cli.message import error, print_json, success
+from nextmv.cli.message import error, in_progress, print_json, success
 from nextmv.cli.options import AppIDOption, EnsembleDefinitionIDOption, ProfileOption
 
 # Set up subcommand application.
@@ -81,7 +81,7 @@ def update(
         error("Provide at least one option to update: --name or --description.")
 
     cloud_app = build_app(app_id=app_id, profile=profile)
-
+    in_progress(msg="Updating ensemble definition...")
     ensemble_definition = cloud_app.update_ensemble_definition(
         id=ensemble_definition_id,
         name=name,

--- a/nextmv/nextmv/cli/cloud/instance/update.py
+++ b/nextmv/nextmv/cli/cloud/instance/update.py
@@ -9,7 +9,7 @@ import typer
 
 from nextmv.cli.cloud.instance.create import build_config, build_options
 from nextmv.cli.configuration.config import build_app
-from nextmv.cli.message import enum_values, error, print_json, success
+from nextmv.cli.message import enum_values, error, in_progress, print_json, success
 from nextmv.cli.options import AppIDOption, InstanceIDOption, ProfileOption
 from nextmv.input import InputFormat
 
@@ -28,6 +28,13 @@ def update(
             "-d",
             help="A new description for the instance.",
             metavar="DESCRIPTION",
+        ),
+    ] = None,
+    locked: Annotated[
+        bool | None,
+        typer.Option(
+            "--locked/--unlocked",
+            help="Whether to lock or unlock the instance. If not provided, the locked status will not be updated.",
         ),
     ] = None,
     name: Annotated[
@@ -171,9 +178,9 @@ def update(
         ]
     )
 
-    if name is None and description is None and version_id is None and not has_config_options:
+    if name is None and description is None and version_id is None and locked is None and not has_config_options:
         error(
-            "Provide at least one option to update: --name, --description, "
+            "Provide at least one option to update: --description, --locked/--unlocked, --name, "
             "--version-id, or any [magenta]Instance configuration[/magenta] option."
         )
 
@@ -193,12 +200,14 @@ def update(
             secret_collection_id=secret_collection_id,
         )
 
+    in_progress(msg="Updating instance...")
     updated_instance = cloud_app.update_instance(
         id=instance_id,
         name=name,
         description=description,
         version_id=version_id,
         configuration=configuration,
+        locked=locked,
     )
     success(
         f"Instance [magenta]{instance_id}[/magenta] updated successfully in application [magenta]{app_id}[/magenta]."

--- a/nextmv/nextmv/cli/cloud/managed_input/update.py
+++ b/nextmv/nextmv/cli/cloud/managed_input/update.py
@@ -8,7 +8,7 @@ from typing import Annotated
 import typer
 
 from nextmv.cli.configuration.config import build_app
-from nextmv.cli.message import error, print_json, success
+from nextmv.cli.message import error, in_progress, print_json, success
 from nextmv.cli.options import AppIDOption, ManagedInputIDOption, ProfileOption
 
 # Set up subcommand application.
@@ -75,6 +75,7 @@ def update(
 
     cloud_app = build_app(app_id=app_id, profile=profile)
 
+    in_progress(msg="Updating managed input...")
     updated_managed_input = cloud_app.update_managed_input(
         managed_input_id=managed_input_id,
         name=name,

--- a/nextmv/nextmv/cli/cloud/secrets/update.py
+++ b/nextmv/nextmv/cli/cloud/secrets/update.py
@@ -9,7 +9,7 @@ import typer
 
 from nextmv.cli.cloud.secrets.create import build_secrets
 from nextmv.cli.configuration.config import build_app
-from nextmv.cli.message import enum_values, error, print_json, success
+from nextmv.cli.message import enum_values, error, in_progress, print_json, success
 from nextmv.cli.options import AppIDOption, ProfileOption, SecretsCollectionIDOption
 from nextmv.cloud.secrets import SecretType
 
@@ -122,6 +122,7 @@ def update(
     if secrets is not None:
         secrets_list = build_secrets(secrets)
 
+    in_progress(msg="Updating secrets collection...")
     collection = cloud_app.update_secrets_collection(
         secrets_collection_id=secrets_collection_id,
         name=name,

--- a/nextmv/nextmv/cli/cloud/sso/update.py
+++ b/nextmv/nextmv/cli/cloud/sso/update.py
@@ -7,7 +7,7 @@ from typing import Annotated
 import typer
 
 from nextmv.cli.configuration.config import build_sso_config
-from nextmv.cli.message import success
+from nextmv.cli.message import in_progress, success
 from nextmv.cli.options import ProfileOption
 
 # Set up subcommand application.
@@ -53,5 +53,6 @@ def update(
     """
 
     sso_config = build_sso_config(profile)
+    in_progress(msg="Updating SSO configuration...")
     sso_config.update(metadata_url=metadata_url, metadata_document=metadata_document)
     success("SSO configuration updated successfully.")

--- a/nextmv/nextmv/cli/cloud/version/update.py
+++ b/nextmv/nextmv/cli/cloud/version/update.py
@@ -8,7 +8,7 @@ from typing import Annotated
 import typer
 
 from nextmv.cli.configuration.config import build_app
-from nextmv.cli.message import error, print_json, success
+from nextmv.cli.message import error, in_progress, print_json, success
 from nextmv.cli.options import AppIDOption, ProfileOption, VersionIDOption
 
 # Set up subcommand application.
@@ -73,6 +73,7 @@ def update(
         error("Provide at least one option to update: --name or --description.")
 
     cloud_app = build_app(app_id=app_id, profile=profile)
+    in_progress(msg="Updating version...")
     updated_version = cloud_app.update_version(
         version_id=version_id,
         name=name,

--- a/nextmv/nextmv/cloud/application/_instance.py
+++ b/nextmv/nextmv/cloud/application/_instance.py
@@ -231,6 +231,7 @@ class ApplicationInstanceMixin:
         version_id: str | None = None,
         description: str | None = None,
         configuration: InstanceConfiguration | dict[str, Any] | None = None,
+        locked: bool | None = None,
     ) -> Instance:
         """
         Update an instance.
@@ -247,6 +248,10 @@ class ApplicationInstanceMixin:
             Optional description of the instance.
         configuration : Optional[InstanceConfiguration | dict[str, Any]], default=None
             Optional configuration to use for the instance.
+        locked : Optional[bool], default=None
+            Optional locked status of the instance. If True, the instance will
+            be locked. If False, the instance will be unlocked. If None, the
+            locked status will not be updated.
 
         Returns
         -------
@@ -286,4 +291,14 @@ class ApplicationInstanceMixin:
             payload=payload,
         )
 
-        return Instance.from_dict(response.json())
+        if locked is None:
+            return Instance.from_dict(response.json())
+
+        lock_payload = {"locked": locked}
+        lock_resp = self.client.request(
+            method="PUT",
+            endpoint=f"{self.endpoint}/instances/{id}/lock",
+            payload=lock_payload,
+        )
+
+        return Instance.from_dict(lock_resp.json())

--- a/nextmv/tests/integration/cloud/test_integration_cloud.py
+++ b/nextmv/tests/integration/cloud/test_integration_cloud.py
@@ -180,6 +180,12 @@ class CloudIntegrationWorkflow(FlowSpec):
         assert inst1.name == name
         assert inst1.description == description
 
+        # We can unlock the instance. Although it starts as unlocked, we are
+        # avoiding that locking it might not allow the testing workflow to
+        # continue.
+        inst1 = app.update_instance(id=inst1.id, locked=False)
+        assert not inst1.locked
+
         # We can delete an instance.
         app.delete_instance(instance_id=inst3.id)
         exists = app.instance_exists(instance_id=inst3.id)


### PR DESCRIPTION
# Description

- **SDK**: adds the `locked` argument to the `cloud.Application.update_instance` method to allow instance locking and unlocking.
- **CLI**: adds the `--locked/--unlocked` flags to the `nextmv cloud instance update` command for the same purpose.
- For consistency, adds the in progress message when updating an entity to all commands in the CLI that didn't have it.