### PR TITLE
Fixes file copying in `local` package

### DIFF
--- a/nextmv/nextmv/__init__.py
+++ b/nextmv/nextmv/__init__.py
@@ -26,6 +26,7 @@ from .manifest import ManifestPythonModel as ManifestPythonModel
 from .manifest import ManifestRuntime as ManifestRuntime
 from .manifest import ManifestType as ManifestType
 from .manifest import default_python_manifest as default_python_manifest
+from .manifest import find_files as find_files
 from .model import Model as Model
 from .model import ModelConfiguration as ModelConfiguration
 from .options import Option as Option

--- a/nextmv/nextmv/cloud/package.py
+++ b/nextmv/nextmv/cloud/package.py
@@ -1,6 +1,5 @@
 """Module with the logic for pushing an app to Nextmv Cloud."""
 
-import glob
 import os
 import platform
 import re
@@ -13,7 +12,7 @@ import tempfile
 import rich
 
 from nextmv.logger import log
-from nextmv.manifest import MANIFEST_FILE_NAME, Manifest, ManifestBuild, ManifestType
+from nextmv.manifest import MANIFEST_FILE_NAME, Manifest, ManifestBuild, ManifestType, find_files
 from nextmv.model import Model, ModelConfiguration, _cleanup_python_model
 
 _MANDATORY_FILES_PER_TYPE = {
@@ -38,7 +37,7 @@ def _package(  # noqa: C901 # complexity attributed to printing.
         if manifest.type == ManifestType.PYTHON:
             __handle_python(app_dir, temp_dir, manifest, model, model_configuration, verbose, rich_print)
 
-        found, missing, files = __find_files(app_dir, manifest.files)
+        found, missing, files = find_files(app_dir, manifest.files)
         __confirm_mandatory_files(manifest, found)
 
         if len(missing) > 0:
@@ -179,61 +178,6 @@ def _run_pre_push_command(
 
     if verbose:
         log(result.stdout)
-
-
-def __find_files(
-    app_dir: str,
-    filters: list[str],
-) -> tuple[list[str], list[str], list[dict[str, str]]]:
-    """Find all files matching the given filters in the given directory."""
-
-    found = []
-    missing = []
-
-    # Temporarily switch to the directory to make the globbing work
-    cwd = os.getcwd()
-    try:
-        os.chdir(app_dir)
-    except OSError as e:
-        raise Exception(f"error changing to file root directory: {e}") from e
-
-    for filter in filters:
-        # We support "some/path/" ending with a "/". We consider it equivalent
-        # to "some/path/*".
-        pattern = filter
-        if filter.endswith("/"):
-            pattern = filter + "*"
-        # If the pattern starts with a '!': negate the pattern
-        negated = False
-        if pattern.startswith("!"):
-            pattern = pattern[1:]
-            negated = True
-        matches = glob.glob(pattern, recursive=True)
-        if not matches and not negated:
-            missing.append(filter)
-        else:
-            if negated:
-                found = [f for f in found if f not in matches]
-            else:
-                for match in matches:
-                    if os.path.isdir(match):
-                        continue
-
-                    found.append(match)
-
-    # Switch back to the original directory
-    os.chdir(cwd)
-
-    files = []
-    for file in found:
-        files.append(
-            {
-                "interior_path": file,
-                "absolute_path": os.path.join(app_dir, file),
-            }
-        )
-
-    return found, missing, files
 
 
 def __confirm_mandatory_files(manifest: Manifest, present_files: list[str]) -> None:

--- a/nextmv/nextmv/local/executor.py
+++ b/nextmv/nextmv/local/executor.py
@@ -929,7 +929,8 @@ def _copy_new_or_modified_files(  # noqa: C901
     # Get the list of files that were originally copied from manifest.files
     # These are NOT outputs, so we should NOT copy them
     _, _, manifest_files = find_files(original_src_dir, manifest.files)
-    manifest_files_rel = {file["interior_path"] for file in manifest_files}
+    # Normalize to forward slashes for cross-platform comparison
+    manifest_files_rel = {file["interior_path"].replace("\\", "/") for file in manifest_files}
 
     # Gather a list of files in the runtime directory
     runtime_files_rel = []
@@ -945,7 +946,8 @@ def _copy_new_or_modified_files(  # noqa: C901
                 continue
 
             file_path = os.path.join(root, rel_file)
-            runtime_files_rel.append(os.path.relpath(file_path, runtime_dir))
+            # Normalize to forward slashes for cross-platform comparison
+            runtime_files_rel.append(os.path.relpath(file_path, runtime_dir).replace("\\", "/"))
             runtime_files_abs.append(file_path)
 
     # Gather a list of files in exclusion directories
@@ -957,7 +959,8 @@ def _copy_new_or_modified_files(  # noqa: C901
             for root, _, files in os.walk(exclusion_dir):
                 for rel_file in files:
                     file_path = os.path.join(root, rel_file)
-                    exclusion_files_rel.add(os.path.relpath(file_path, exclusion_dir))
+                    # Normalize to forward slashes for cross-platform comparison
+                    exclusion_files_rel.add(os.path.relpath(file_path, exclusion_dir).replace("\\", "/"))
 
     # Filter to only include files that are:
     # 1. NOT in the manifest.files (i.e., they are newly generated)

--- a/nextmv/nextmv/local/executor.py
+++ b/nextmv/nextmv/local/executor.py
@@ -39,7 +39,6 @@ resolve_stdout
 import hashlib
 import json
 import os
-import re
 import shutil
 import subprocess
 import sys
@@ -49,16 +48,9 @@ from typing import Any
 
 from nextmv.input import INPUTS_KEY, InputFormat, load
 from nextmv.local.geojson_handler import handle_geojson_visual
-from nextmv.local.local import (
-    DEFAULT_OUTPUT_JSON_FILE,
-    LOGS_FILE,
-    LOGS_KEY,
-    NEXTMV_DIR,
-    OUTPUT_KEY,
-    calculate_files_size,
-)
+from nextmv.local.local import DEFAULT_OUTPUT_JSON_FILE, LOGS_FILE, LOGS_KEY, OUTPUT_KEY, calculate_files_size
 from nextmv.local.plotly_handler import handle_plotly_visual
-from nextmv.manifest import Manifest, ManifestType
+from nextmv.manifest import Manifest, ManifestType, find_files
 from nextmv.output import (
     ASSETS_KEY,
     METRICS_KEY,
@@ -139,9 +131,11 @@ def execute_run(
         # place to work from, and be cleaned up afterwards.
         with tempfile.TemporaryDirectory() as temp_dir:
             temp_src = os.path.join(temp_dir, "src")
-            shutil.copytree(src, temp_src, ignore=_ignore_patterns)
-
+            os.makedirs(temp_src, exist_ok=True)
             manifest = Manifest.from_dict(manifest_dict)
+
+            # Copy only the files specified in manifest.files
+            _copy_files_from_manifest(src, temp_src, manifest)
 
             stdin_input = process_run_input(
                 temp_src=temp_src,
@@ -772,6 +766,7 @@ def process_run_solutions(
             runtime_dir=solutions_src,
             dst_dir=solutions_dst,
             original_src_dir=src,
+            manifest=manifest,
             exclusion_dirs=[
                 os.path.join(outputs_dir, STATISTICS_KEY),
                 os.path.join(outputs_dir, METRICS_KEY),
@@ -866,90 +861,77 @@ def resolve_stdout(result: subprocess.CompletedProcess[str]) -> str | dict[str, 
         return raw_output
 
 
-def _ignore_patterns(dir_path: str, names: list[str]) -> list[str]:
+def _copy_files_from_manifest(src: str, temp_src: str, manifest: Manifest) -> None:
     """
-    Custom ignore function for copytree that filters files and directories
-    during source code copying. Excludes virtual environments, cache files,
-    the nextmv directory, and non-essential files while preserving Python
-    source files and application manifests.
+    Copy files specified in manifest.files from source to temporary directory.
 
     Parameters
     ----------
-    dir_path : str
-        The path to the directory being processed.
-    names : list[str]
-        A list of file and directory names in the current directory.
+    src : str
+        The path to the application source code.
+    temp_src : str
+        The path to the temporary source directory.
+    manifest : Manifest
+        The application manifest containing file patterns.
 
-    Returns
-    -------
-    list[str]
-        A list of names to ignore during the copy operation.
+    Raises
+    ------
+    Exception
+        If required files are missing or if copying fails.
     """
-    ignored = []
-    for name in names:
-        full_path = os.path.join(dir_path, name)
+    _, missing, files = find_files(src, manifest.files)
+    if len(missing) > 0:
+        raise Exception(f"could not find files listed in manifest: {', '.join(missing)}")
 
-        # Ignore nextmv directory
-        if name == NEXTMV_DIR:
-            ignored.append(name)
-            continue
+    for file in files:
+        target_dir = os.path.dirname(os.path.join(temp_src, file["interior_path"]))
+        try:
+            os.makedirs(target_dir, exist_ok=True)
+        except OSError as e:
+            raise Exception(f"error creating directory for file {file['interior_path']}: {e}") from e
 
-        # Ignore virtual environment directories
-        if re.match(r"^\.?(venv|env|virtualenv).*$", name):
-            ignored.append(name)
-            continue
-
-        # Ignore __pycache__ directories
-        if name == "__pycache__":
-            ignored.append(name)
-            continue
-
-        # If it's a file, only keep Python files and app.yaml
-        if os.path.isfile(full_path):
-            if not (name.endswith(".py") or name == "app.yaml"):
-                ignored.append(name)
-                continue
-
-        # Ignore .pyc files explicitly
-        if name.endswith(".pyc"):
-            ignored.append(name)
-            continue
-
-    return ignored
+        try:
+            shutil.copy2(file["absolute_path"], os.path.join(target_dir, os.path.basename(file["absolute_path"])))
+        except Exception as e:
+            raise Exception(f"error copying file {file['absolute_path']}: {e}") from e
 
 
 def _copy_new_or_modified_files(  # noqa: C901
     runtime_dir: str,
     dst_dir: str,
-    original_src_dir: str | None = None,
+    original_src_dir: str,
+    manifest: Manifest,
     exclusion_dirs: list[str] | None = None,
 ) -> None:
     """
-    Copy only new or modified files from runtime directory to destination directory.
+    Copy only newly generated output files from runtime directory to destination directory.
 
-    This function identifies files that are either new (not present in the original
-    source) or have been modified (different content, checksum, or modification time)
-    compared to the original source. It excludes files that exist in specified
-    exclusion directories to avoid copying input data, statistics, metrics, or assets as
-    solution outputs.
+    This function identifies files that were NOT part of the original manifest.files
+    (i.e., they were generated during execution) and copies them to the destination,
+    excluding files that exist in specified exclusion directories.
 
     Parameters
     ----------
     runtime_dir : str
         The path to the runtime directory containing files to potentially copy.
     dst_dir : str
-        The destination directory where new or modified files will be copied.
-    original_src_dir : Optional[str], optional
-        The path to the original source directory for comparison, by default None.
-        If None, all files from runtime_dir are considered new.
+        The destination directory where new output files will be copied.
+    original_src_dir : str
+        The path to the original source directory (used to resolve manifest patterns).
+    manifest : Manifest
+        The application manifest containing file patterns for source files.
     exclusion_dirs : Optional[list[str]], optional
         List of directory paths containing files to exclude from copying,
         by default None. Files matching those in exclusion directories will
-        not be copied even if they are new or modified.
+        not be copied even if they are new.
     """
 
-    # Gather a list of the files that are created/modified in the runtime dir,
-    # this is, the directory where the actual executable code is run from.
+    # Get the list of files that were originally copied from manifest.files
+    # These are NOT outputs, so we should NOT copy them
+    _, _, manifest_files = find_files(original_src_dir, manifest.files)
+    manifest_files_rel = {file["interior_path"] for file in manifest_files}
+
+    # Gather a list of files in the runtime directory
     runtime_files_rel = []
     runtime_files_abs = []
     for root, _, files in os.walk(runtime_dir):
@@ -966,66 +948,35 @@ def _copy_new_or_modified_files(  # noqa: C901
             runtime_files_rel.append(os.path.relpath(file_path, runtime_dir))
             runtime_files_abs.append(file_path)
 
-    # Gather a list of the files that exist in the original source dir. Given
-    # that the source dir is copied to the runtime dir before execution, we can
-    # use this to determine which files are new or modified.
-    original_src_files_rel = set()
-    if original_src_dir is not None:
-        for root, _, files in os.walk(original_src_dir):
-            for rel_file in files:
-                file_path = os.path.join(root, rel_file)
-                original_src_files_rel.add(os.path.relpath(file_path, original_src_dir))
-
-    # Gather a list of the files that exist in the exclusion dirs. This is used
-    # to avoid copying files that are part of this special exclusion set.
+    # Gather a list of files in exclusion directories
     exclusion_files_rel = set()
     if exclusion_dirs is not None:
         for exclusion_dir in exclusion_dirs:
+            if not os.path.exists(exclusion_dir):
+                continue
             for root, _, files in os.walk(exclusion_dir):
                 for rel_file in files:
                     file_path = os.path.join(root, rel_file)
                     exclusion_files_rel.add(os.path.relpath(file_path, exclusion_dir))
 
-    # Now we filter the runtime files to only keep those that are new or
-    # modified compared to the original source files.
-    files_before_exclusion = []
+    # Filter to only include files that are:
+    # 1. NOT in the manifest.files (i.e., they are newly generated)
+    # 2. NOT in the exclusion directories
+    final_files = []
     for ix, rel_file in enumerate(runtime_files_rel):
         abs_file = runtime_files_abs[ix]
 
-        # If the file is net new, we keep it.
-        if rel_file not in original_src_files_rel:
-            files_before_exclusion.append(abs_file)
+        # Skip if this file was part of the original manifest.files
+        if rel_file in manifest_files_rel:
             continue
 
-        # If content of the file is different, we keep it.
-        runtime_checksum = _calculate_file_checksum(abs_file)
-        original_abs_file = os.path.join(original_src_dir, rel_file)
-        original_checksum = _calculate_file_checksum(original_abs_file)
-        if runtime_checksum != original_checksum:
-            files_before_exclusion.append(abs_file)
+        # Skip if this file is in an exclusion directory
+        if rel_file in exclusion_files_rel:
             continue
 
-        # If content of the file is the same, but the date is newer, we keep it.
-        src_mtime = os.path.getmtime(abs_file)
-        original_mtime = os.path.getmtime(original_abs_file)
-        if src_mtime > original_mtime:
-            files_before_exclusion.append(abs_file)
-            continue
+        final_files.append(abs_file)
 
-    # Now we filter out any files that are part of the exclusion set.
-    final_files = []
-    if exclusion_dirs is not None:
-        for file in files_before_exclusion:
-            rel_file = os.path.relpath(file, runtime_dir)
-            if rel_file in exclusion_files_rel:
-                continue
-
-            final_files.append(file)
-    else:
-        final_files = files_before_exclusion
-
-    # Now that we have a clean list of files that we are going to copy, we
-    # proceed to copy them over to the destination directory.
+    # Copy the filtered files to the destination directory
     for file in final_files:
         rel_file = os.path.relpath(file, runtime_dir)
         dst_file = os.path.join(dst_dir, rel_file)

--- a/nextmv/nextmv/manifest.py
+++ b/nextmv/nextmv/manifest.py
@@ -1536,6 +1536,7 @@ def find_files(
         raise Exception(f"error changing to file root directory: {e}") from e
 
     try:
+        filtered_files: set[str] = set()
         for filter in filters:
             # We support "some/path/" ending with a "/". We consider it equivalent
             # to "some/path/*".
@@ -1547,18 +1548,15 @@ def find_files(
             if pattern.startswith("!"):
                 pattern = pattern[1:]
                 negated = True
-            matches = glob.glob(pattern, recursive=True)
+            matches = {os.path.normpath(m) for m in glob.glob(pattern, recursive=True)}
             if not matches and not negated:
                 missing.append(filter)
             else:
                 if negated:
-                    found = [f for f in found if f not in matches]
+                    filtered_files = {f for f in filtered_files if f not in matches}
                 else:
-                    for match in matches:
-                        if os.path.isdir(match):
-                            continue
-
-                        found.append(match)
+                    filtered_files.update([f for f in matches if os.path.isfile(f)])
+        found = sorted(filtered_files)
     finally:
         # Switch back to the original directory
         os.chdir(cwd)

--- a/nextmv/nextmv/manifest.py
+++ b/nextmv/nextmv/manifest.py
@@ -51,6 +51,7 @@ MANIFEST_FILE_NAME
     Name of the app manifest file.
 """
 
+import glob
 import os
 from enum import Enum
 from typing import Any
@@ -1468,3 +1469,106 @@ def default_python_manifest() -> Manifest:
     )
 
     return m
+
+
+def find_files(
+    app_dir: str,
+    filters: list[str],
+) -> tuple[list[str], list[str], list[dict[str, str]]]:
+    """
+    Find all files matching the given filters in the given directory.
+
+    This function supports glob patterns with recursive matching, negation
+    patterns (starting with '!'), and directory patterns (ending with '/').
+    It temporarily changes to the app directory to perform globbing, then
+    returns to the original directory.
+
+    You can import the `find_files` function directly from `nextmv`:
+
+    ```python
+    from nextmv import find_files
+    ```
+
+    Parameters
+    ----------
+    app_dir : str
+        The root directory to search for files.
+    filters : list[str]
+        List of glob patterns to match files. Patterns starting with '!'
+        are treated as exclusions. Patterns ending with '/' are treated
+        as directory wildcards (equivalent to '/*').
+
+    Returns
+    -------
+    tuple[list[str], list[str], list[dict[str, str]]]
+        A tuple containing three elements:
+        - found: List of found file paths (relative to app_dir)
+        - missing: List of patterns that didn't match any files (excluding negation patterns)
+        - files: List of dicts with 'interior_path' (relative path) and 'absolute_path' keys
+
+    Raises
+    ------
+    Exception
+        If there is an error changing to the app directory.
+
+    Examples
+    --------
+    >>> # Find Python files
+    >>> found, missing, files = find_files("/path/to/app", ["*.py", "src/"])
+    >>> # Exclude cache files
+    >>> found, missing, files = find_files("/path/to/app", ["*.py", "!__pycache__/*"])
+
+    Notes
+    -----
+    - Only files are returned; directories are automatically excluded
+    - Negation patterns don't cause an error if they don't match anything
+    - The function changes the current working directory temporarily during execution
+    """
+
+    found = []
+    missing = []
+
+    # Temporarily switch to the directory to make the globbing work
+    cwd = os.getcwd()
+    try:
+        os.chdir(app_dir)
+    except OSError as e:
+        raise Exception(f"error changing to file root directory: {e}") from e
+
+    for filter in filters:
+        # We support "some/path/" ending with a "/". We consider it equivalent
+        # to "some/path/*".
+        pattern = filter
+        if filter.endswith("/"):
+            pattern = filter + "*"
+        # If the pattern starts with a '!': negate the pattern
+        negated = False
+        if pattern.startswith("!"):
+            pattern = pattern[1:]
+            negated = True
+        matches = glob.glob(pattern, recursive=True)
+        if not matches and not negated:
+            missing.append(filter)
+        else:
+            if negated:
+                found = [f for f in found if f not in matches]
+            else:
+                for match in matches:
+                    if os.path.isdir(match):
+                        continue
+
+                    found.append(match)
+
+    # Switch back to the original directory
+    os.chdir(cwd)
+
+    files = []
+    for file in found:
+        files.append(
+            {
+                "interior_path": file,
+                "absolute_path": os.path.join(app_dir, file),
+            }
+        )
+
+    return found, missing, files

--- a/nextmv/nextmv/manifest.py
+++ b/nextmv/nextmv/manifest.py
@@ -1535,33 +1535,33 @@ def find_files(
     except OSError as e:
         raise Exception(f"error changing to file root directory: {e}") from e
 
-    for filter in filters:
-        # We support "some/path/" ending with a "/". We consider it equivalent
-        # to "some/path/*".
-        pattern = filter
-        if filter.endswith("/"):
-            pattern = filter + "*"
-        # If the pattern starts with a '!': negate the pattern
-        negated = False
-        if pattern.startswith("!"):
-            pattern = pattern[1:]
-            negated = True
-        matches = glob.glob(pattern, recursive=True)
-        if not matches and not negated:
-            missing.append(filter)
-        else:
-            if negated:
-                found = [f for f in found if f not in matches]
+    try:
+        for filter in filters:
+            # We support "some/path/" ending with a "/". We consider it equivalent
+            # to "some/path/*".
+            pattern = filter
+            if filter.endswith("/"):
+                pattern = filter + "*"
+            # If the pattern starts with a '!': negate the pattern
+            negated = False
+            if pattern.startswith("!"):
+                pattern = pattern[1:]
+                negated = True
+            matches = glob.glob(pattern, recursive=True)
+            if not matches and not negated:
+                missing.append(filter)
             else:
-                for match in matches:
-                    if os.path.isdir(match):
-                        continue
+                if negated:
+                    found = [f for f in found if f not in matches]
+                else:
+                    for match in matches:
+                        if os.path.isdir(match):
+                            continue
 
-                    found.append(match)
-
-    # Switch back to the original directory
-    os.chdir(cwd)
-
+                        found.append(match)
+    finally:
+        # Switch back to the original directory
+        os.chdir(cwd)
     files = []
     for file in found:
         files.append(

--- a/nextmv/tests/local/test_executor.py
+++ b/nextmv/tests/local/test_executor.py
@@ -42,6 +42,7 @@ class TestLocalExecutor(unittest.TestCase):
 
         # Create mock manifest
         self.mock_manifest = Mock(spec=Manifest)
+        self.mock_manifest.files = []
         self.mock_manifest.execution = Mock(spec=ManifestExecution)
         self.mock_manifest.execution.entrypoint = "main.py"
         self.mock_manifest.configuration = None
@@ -569,14 +570,14 @@ class TestLocalExecutor(unittest.TestCase):
     @patch("nextmv.local.executor.process_run_input")
     @patch("builtins.open", new_callable=unittest.mock.mock_open)
     @patch("nextmv.local.executor.subprocess.run")
-    @patch("nextmv.local.executor.shutil.copytree")
+    @patch("nextmv.local.executor._copy_files_from_manifest")
     @patch("nextmv.local.executor.tempfile.TemporaryDirectory")
     @patch("nextmv.local.executor.os.makedirs")
     def test_execute_run_full_flow(
         self,
         mock_makedirs,
         mock_temp_dir,
-        mock_copytree,
+        mock_copy_files_from_manifest,
         mock_subprocess_run,
         mock_open,
         mock_process_input,
@@ -612,8 +613,8 @@ class TestLocalExecutor(unittest.TestCase):
             options={"duration": "10s"},
         )
 
-        # Verify copytree was called to copy source
-        mock_copytree.assert_called_once_with("/test/src", temp_src, ignore=unittest.mock.ANY)
+        # Verify _copy_files_from_manifest was called to copy source files
+        mock_copy_files_from_manifest.assert_called_once_with("/test/src", temp_src, unittest.mock.ANY)
 
         # Verify process_run_input was called
         mock_process_input.assert_called_once_with(
@@ -743,6 +744,10 @@ class TestCopyNewOrModifiedFiles(unittest.TestCase):
         ]:
             os.makedirs(dir_path, exist_ok=True)
 
+        # Create mock manifest with empty files list
+        self.mock_manifest = Mock(spec=Manifest)
+        self.mock_manifest.files = []
+
     def tearDown(self):
         """Clean up test fixtures."""
         shutil.rmtree(self.test_dir)
@@ -781,14 +786,15 @@ class TestCopyNewOrModifiedFiles(unittest.TestCase):
         self._create_file(self.runtime_dir, "subdir/file2.txt", "content2")
         self._create_file(self.runtime_dir, "file3.py", "print('hello')")
 
-        _copy_new_or_modified_files(self.runtime_dir, self.dst_dir)
+        _copy_new_or_modified_files(self.runtime_dir, self.dst_dir, self.original_src_dir, self.mock_manifest)
 
         # All files should be copied
         self._assert_file_exists_with_content(os.path.join(self.dst_dir, "file1.txt"), "content1")
         self._assert_file_exists_with_content(os.path.join(self.dst_dir, "subdir/file2.txt"), "content2")
         self._assert_file_exists_with_content(os.path.join(self.dst_dir, "file3.py"), "print('hello')")
 
-    def test_copy_new_files_only(self):
+    @patch("nextmv.local.executor.find_files")
+    def test_copy_new_files_only(self, mock_find_files):
         """Test copying only new files not present in original source."""
 
         # Create files in original source
@@ -810,7 +816,17 @@ class TestCopyNewOrModifiedFiles(unittest.TestCase):
         os.utime(runtime_file1, (older_time, older_time))
         os.utime(runtime_file2, (older_time, older_time))
 
-        _copy_new_or_modified_files(self.runtime_dir, self.dst_dir, self.original_src_dir)
+        # Mock find_files to return existing files as manifest files
+        mock_find_files.return_value = (
+            [],  # warnings
+            [],  # missing
+            [
+                {"interior_path": "existing_file.txt"},
+                {"interior_path": "subdir/existing_file2.txt"},
+            ],
+        )
+
+        _copy_new_or_modified_files(self.runtime_dir, self.dst_dir, self.original_src_dir, self.mock_manifest)
 
         # Only new files should be copied
         self._assert_file_exists_with_content(os.path.join(self.dst_dir, "new_file.txt"), "new_content")
@@ -831,7 +847,7 @@ class TestCopyNewOrModifiedFiles(unittest.TestCase):
         self._create_file(self.runtime_dir, "file1.txt", "modified_content")
         self._create_file(self.runtime_dir, "subdir/file2.txt", "modified_content2")
 
-        _copy_new_or_modified_files(self.runtime_dir, self.dst_dir, self.original_src_dir)
+        _copy_new_or_modified_files(self.runtime_dir, self.dst_dir, self.original_src_dir, self.mock_manifest)
 
         # Modified files should be copied
         self._assert_file_exists_with_content(os.path.join(self.dst_dir, "file1.txt"), "modified_content")
@@ -855,13 +871,14 @@ class TestCopyNewOrModifiedFiles(unittest.TestCase):
         self.assertGreater(os.path.getmtime(runtime_file1), os.path.getmtime(original_file1))
         self.assertGreater(os.path.getmtime(runtime_file2), os.path.getmtime(original_file2))
 
-        _copy_new_or_modified_files(self.runtime_dir, self.dst_dir, self.original_src_dir)
+        _copy_new_or_modified_files(self.runtime_dir, self.dst_dir, self.original_src_dir, self.mock_manifest)
 
         # Files with newer timestamps should be copied
         self._assert_file_exists_with_content(os.path.join(self.dst_dir, "file1.txt"), "same_content")
         self._assert_file_exists_with_content(os.path.join(self.dst_dir, "subdir/file2.txt"), "same_content2")
 
-    def test_skip_unchanged_files(self):
+    @patch("nextmv.local.executor.find_files")
+    def test_skip_unchanged_files(self, mock_find_files):
         """Test that unchanged files are not copied."""
 
         # Create files in original source
@@ -877,7 +894,16 @@ class TestCopyNewOrModifiedFiles(unittest.TestCase):
         newer_time = os.path.getmtime(runtime_file1) + 1
         os.utime(original_file1, (newer_time, newer_time))
 
-        _copy_new_or_modified_files(self.runtime_dir, self.dst_dir, self.original_src_dir)
+        # Mock find_files to return the file as a manifest file
+        mock_find_files.return_value = (
+            [],  # warnings
+            [],  # missing
+            [
+                {"interior_path": "file1.txt"},
+            ],
+        )
+
+        _copy_new_or_modified_files(self.runtime_dir, self.dst_dir, self.original_src_dir, self.mock_manifest)
 
         # Unchanged file should not be copied
         self._assert_file_not_exists(os.path.join(self.dst_dir, "file1.txt"))
@@ -896,7 +922,9 @@ class TestCopyNewOrModifiedFiles(unittest.TestCase):
         self._create_file(self.exclusion_dir2, "subdir/exclude_this2.txt", "any_content2")
 
         exclusion_dirs = [self.exclusion_dir1, self.exclusion_dir2]
-        _copy_new_or_modified_files(self.runtime_dir, self.dst_dir, exclusion_dirs=exclusion_dirs)
+        _copy_new_or_modified_files(
+            self.runtime_dir, self.dst_dir, self.original_src_dir, self.mock_manifest, exclusion_dirs=exclusion_dirs
+        )
 
         # Files not in exclusion should be copied
         self._assert_file_exists_with_content(os.path.join(self.dst_dir, "keep_this.txt"), "keep_content")
@@ -925,7 +953,7 @@ class TestCopyNewOrModifiedFiles(unittest.TestCase):
         # Create .pyc file in regular directory
         self._create_file(self.runtime_dir, "direct_pyc.pyc", "bytecode3")
 
-        _copy_new_or_modified_files(self.runtime_dir, self.dst_dir)
+        _copy_new_or_modified_files(self.runtime_dir, self.dst_dir, self.original_src_dir, self.mock_manifest)
 
         # Regular Python file should be copied
         self._assert_file_exists_with_content(os.path.join(self.dst_dir, "normal_file.py"), "print('hello')")
@@ -947,7 +975,7 @@ class TestCopyNewOrModifiedFiles(unittest.TestCase):
         # Create corresponding original file for the modified one
         self._create_binary_file(self.original_src_dir, "modified.png", b"\x89PNG\r\n\x1a\n")
 
-        _copy_new_or_modified_files(self.runtime_dir, self.dst_dir, self.original_src_dir)
+        _copy_new_or_modified_files(self.runtime_dir, self.dst_dir, self.original_src_dir, self.mock_manifest)
 
         # New binary file should be copied
         self.assertTrue(os.path.exists(os.path.join(self.dst_dir, "new_image.jpg")))
@@ -978,7 +1006,7 @@ class TestCopyNewOrModifiedFiles(unittest.TestCase):
             self.runtime_dir, "level1/level2/level3/level4/new_deep_file.txt", "deep_new"
         )  # New deep file
 
-        _copy_new_or_modified_files(self.runtime_dir, self.dst_dir, self.original_src_dir)
+        _copy_new_or_modified_files(self.runtime_dir, self.dst_dir, self.original_src_dir, self.mock_manifest)
 
         # Modified files should be copied
         self._assert_file_exists_with_content(os.path.join(self.dst_dir, "root_file.txt"), "root_modified")
@@ -1004,7 +1032,13 @@ class TestCopyNewOrModifiedFiles(unittest.TestCase):
         # The exclusion path must match the relative path from runtime_dir
         self._create_file(self.exclusion_dir1, "remove_empty/exclude_this.txt", "any_content")
 
-        _copy_new_or_modified_files(self.runtime_dir, self.dst_dir, exclusion_dirs=[self.exclusion_dir1])
+        _copy_new_or_modified_files(
+            self.runtime_dir,
+            self.dst_dir,
+            self.original_src_dir,
+            self.mock_manifest,
+            exclusion_dirs=[self.exclusion_dir1],
+        )
 
         # Directory with kept file should exist
         self.assertTrue(os.path.exists(os.path.join(self.dst_dir, "keep")))
@@ -1018,7 +1052,7 @@ class TestCopyNewOrModifiedFiles(unittest.TestCase):
         """Test behavior with empty runtime directory."""
 
         # Runtime directory is empty
-        _copy_new_or_modified_files(self.runtime_dir, self.dst_dir, self.original_src_dir)
+        _copy_new_or_modified_files(self.runtime_dir, self.dst_dir, self.original_src_dir, self.mock_manifest)
 
         # Destination should remain empty (except for the directory itself)
         dst_contents = os.listdir(self.dst_dir)
@@ -1033,7 +1067,9 @@ class TestCopyNewOrModifiedFiles(unittest.TestCase):
         exclusion_dirs = [nonexistent_dir]
 
         # Should not raise an error
-        _copy_new_or_modified_files(self.runtime_dir, self.dst_dir, exclusion_dirs=exclusion_dirs)
+        _copy_new_or_modified_files(
+            self.runtime_dir, self.dst_dir, self.original_src_dir, self.mock_manifest, exclusion_dirs=exclusion_dirs
+        )
 
         # File should still be copied
         self._assert_file_exists_with_content(os.path.join(self.dst_dir, "file1.txt"), "content1")
@@ -1060,7 +1096,7 @@ class TestCopyNewOrModifiedFiles(unittest.TestCase):
         modified_checksum = _calculate_file_checksum(runtime_file)
         self.assertNotEqual(original_checksum, modified_checksum)
 
-        _copy_new_or_modified_files(self.runtime_dir, self.dst_dir, self.original_src_dir)
+        _copy_new_or_modified_files(self.runtime_dir, self.dst_dir, self.original_src_dir, self.mock_manifest)
 
         # Modified file should be copied due to different checksum
         self._assert_file_exists_with_content(os.path.join(self.dst_dir, "test_file.txt"), modified_content)
@@ -1075,7 +1111,7 @@ class TestCopyNewOrModifiedFiles(unittest.TestCase):
         os.chmod(test_file, stat.S_IRUSR | stat.S_IWUSR)
         original_mode = os.stat(test_file).st_mode
 
-        _copy_new_or_modified_files(self.runtime_dir, self.dst_dir)
+        _copy_new_or_modified_files(self.runtime_dir, self.dst_dir, self.original_src_dir, self.mock_manifest)
 
         # Check that copied file has same permissions
         copied_file = os.path.join(self.dst_dir, "test_file.txt")
@@ -1109,7 +1145,11 @@ class TestCopyNewOrModifiedFiles(unittest.TestCase):
         self._create_file(self.exclusion_dir1, "exclude_me.txt", "any_content")
 
         _copy_new_or_modified_files(
-            self.runtime_dir, self.dst_dir, self.original_src_dir, exclusion_dirs=[self.exclusion_dir1]
+            self.runtime_dir,
+            self.dst_dir,
+            self.original_src_dir,
+            self.mock_manifest,
+            exclusion_dirs=[self.exclusion_dir1],
         )
 
         # Files with newer timestamps should be copied


### PR DESCRIPTION
# Description

Fixes the file copying when running locally so that we only copy over the files listed by the manifest, as opposed to figuring out which files we need to copy to the temporary directory where the run happens. When the run is concluded, for `multi-file` we figure out which files to retrieve as solutions based on them not being listed by the manifest and not being part of the exclusion directories.