### PR TITLE
Feat/eng 7122 add sso delete domain mapping

### DIFF
--- a/nextmv/nextmv/cli/cloud/sso/__init__.py
+++ b/nextmv/nextmv/cli/cloud/sso/__init__.py
@@ -7,6 +7,7 @@ import typer
 from nextmv.cli.cloud.sso.create import app as create_app
 from nextmv.cli.cloud.sso.delete import app as delete_app
 from nextmv.cli.cloud.sso.disable import app as disable_app
+from nextmv.cli.cloud.sso.domain import app as domain_app
 from nextmv.cli.cloud.sso.enable import app as enable_app
 from nextmv.cli.cloud.sso.get import app as get_app
 from nextmv.cli.cloud.sso.update import app as update_app
@@ -19,6 +20,7 @@ app.add_typer(disable_app)
 app.add_typer(enable_app)
 app.add_typer(get_app)
 app.add_typer(update_app)
+app.add_typer(domain_app, name="domain")
 
 
 @app.callback()

--- a/nextmv/nextmv/cli/cloud/sso/create.py
+++ b/nextmv/nextmv/cli/cloud/sso/create.py
@@ -108,5 +108,6 @@ def create(
         enabled=enabled,
         metadata_url=metadata_url,
         metadata_document=metadata_document,
+        mapped_domains=None,  # mapped_domains cannot be set at creation
     )
     success("SSO configuration created successfully.")

--- a/nextmv/nextmv/cli/cloud/sso/create.py
+++ b/nextmv/nextmv/cli/cloud/sso/create.py
@@ -108,6 +108,5 @@ def create(
         enabled=enabled,
         metadata_url=metadata_url,
         metadata_document=metadata_document,
-        mapped_domains=None,  # mapped_domains cannot be set at creation
     )
     success("SSO configuration created successfully.")

--- a/nextmv/nextmv/cli/cloud/sso/domain/__init__.py
+++ b/nextmv/nextmv/cli/cloud/sso/domain/__init__.py
@@ -1,0 +1,22 @@
+"""
+This module defines the cloud sso command tree for the Nextmv CLI.
+"""
+
+import typer
+
+from nextmv.cli.cloud.sso.domain.delete import app as delete_app
+
+# Set up subcommand application.
+app = typer.Typer()
+app.add_typer(delete_app)
+
+
+@app.callback()
+def callback() -> None:
+    """
+    Manage SSO mapped domains for your Nextmv Cloud organization (account).
+
+    Please contact [link=https://www.nextmv.io/contact][bold]Nextmv support[/bold][/link]
+    for assistance configuring SSO for your organization.
+    """
+    pass

--- a/nextmv/nextmv/cli/cloud/sso/domain/__init__.py
+++ b/nextmv/nextmv/cli/cloud/sso/domain/__init__.py
@@ -1,5 +1,5 @@
 """
-This module defines the cloud sso command tree for the Nextmv CLI.
+This module defines the cloud sso domain command tree for the Nextmv CLI.
 """
 
 import typer
@@ -15,6 +15,8 @@ app.add_typer(delete_app)
 def callback() -> None:
     """
     Manage SSO mapped domains for your Nextmv Cloud organization (account).
+
+    Mapped domains redirect additional domains to your IDP for federated authentication.
 
     Please contact [link=https://www.nextmv.io/contact][bold]Nextmv support[/bold][/link]
     for assistance configuring SSO for your organization.

--- a/nextmv/nextmv/cli/cloud/sso/domain/delete.py
+++ b/nextmv/nextmv/cli/cloud/sso/domain/delete.py
@@ -16,6 +16,15 @@ app = typer.Typer()
 
 @app.command()
 def delete(
+    domain: Annotated[
+        str,
+        typer.Option(
+            "--domain",
+            "-d",
+            help="The domain to delete from the SSO configuration.",
+            metavar="DOMAIN",
+        ),
+    ],
     yes: Annotated[
         bool,
         typer.Option(
@@ -24,15 +33,6 @@ def delete(
             help="Agree to deletion confirmation prompt. Useful for non-interactive sessions.",
         ),
     ] = False,
-    domain: Annotated[
-        str | None,
-        typer.Option(
-            "--domain",
-            "-d",
-            help="The domain to delete from the SSO configuration.",
-            metavar="DOMAIN",
-        ),
-    ] = None,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/sso/domain/delete.py
+++ b/nextmv/nextmv/cli/cloud/sso/domain/delete.py
@@ -53,7 +53,8 @@ def delete(
 
     if not yes:
         confirm = get_confirmation(
-            f"Are you sure you want to delete the [magenta]{domain}[/magenta] domain? You must contact Nextmv support to re-add it.",
+            f"Are you sure you want to delete the [magenta]{domain}[/magenta] domain? "
+            "You must contact Nextmv support to re-add it.",
         )
 
         if not confirm:

--- a/nextmv/nextmv/cli/cloud/sso/domain/delete.py
+++ b/nextmv/nextmv/cli/cloud/sso/domain/delete.py
@@ -1,5 +1,5 @@
 """
-This module defines the cloud sso delete domain command for the Nextmv CLI.
+This module defines the cloud sso domain delete command for the Nextmv CLI.
 """
 
 from typing import Annotated
@@ -38,10 +38,7 @@ def delete(
     """
     Delete a mapped domain from a Nextmv Cloud SSO configuration.
 
-    Mapped domains redirect additional domains to your IDP for federated authentication.
-    This command deletes a domain from an existing SSO configuration.
-
-    You can use the command [code] nextmv cloud sso get[/code] command to view all
+    You can use the [code]nextmv cloud sso get[/code] command to view all
     mapped domains in your SSO configuration.
 
     [bold][underline]Examples[/underline][/bold]

--- a/nextmv/nextmv/cli/cloud/sso/domain/delete.py
+++ b/nextmv/nextmv/cli/cloud/sso/domain/delete.py
@@ -38,6 +38,10 @@ def delete(
     """
     Delete a mapped domain from a Nextmv Cloud SSO configuration.
 
+
+    This action will prevent users from the deleted domain from accessing your
+    account using SSO. Use the --yes flag to skip the confirmation prompt.
+
     You can use the [code]nextmv cloud sso get[/code] command to view all
     mapped domains in your SSO configuration.
 

--- a/nextmv/nextmv/cli/cloud/sso/domain/delete.py
+++ b/nextmv/nextmv/cli/cloud/sso/domain/delete.py
@@ -7,8 +7,7 @@ from typing import Annotated
 import typer
 
 from nextmv.cli.configuration.config import build_sso_config
-from nextmv.cli.confirm import get_confirmation
-from nextmv.cli.message import in_progress, info, success
+from nextmv.cli.message import confirmation, in_progress, info, success
 from nextmv.cli.options import ProfileOption
 
 # Set up subcommand application.
@@ -52,7 +51,7 @@ def delete(
     """
 
     if not yes:
-        confirm = get_confirmation(
+        confirm = confirmation(
             f"Are you sure you want to delete the [magenta]{domain}[/magenta] domain? "
             "You must contact Nextmv support to re-add it.",
         )

--- a/nextmv/nextmv/cli/cloud/sso/domain/delete.py
+++ b/nextmv/nextmv/cli/cloud/sso/domain/delete.py
@@ -1,0 +1,66 @@
+"""
+This module defines the cloud sso delete domain command for the Nextmv CLI.
+"""
+
+from typing import Annotated
+
+import typer
+
+from nextmv.cli.configuration.config import build_sso_config
+from nextmv.cli.confirm import get_confirmation
+from nextmv.cli.message import in_progress, info, success
+from nextmv.cli.options import ProfileOption
+
+# Set up subcommand application.
+app = typer.Typer()
+
+
+@app.command()
+def delete(
+    yes: Annotated[
+        bool,
+        typer.Option(
+            "--yes",
+            "-y",
+            help="Agree to deletion confirmation prompt. Useful for non-interactive sessions.",
+        ),
+    ] = False,
+    domain: Annotated[
+        str | None,
+        typer.Option(
+            "--domain",
+            "-d",
+            help="The domain to delete from the SSO configuration.",
+            metavar="DOMAIN",
+        ),
+    ] = None,
+    profile: ProfileOption = None,
+) -> None:
+    """
+    Delete a mapped domain from a Nextmv Cloud SSO configuration.
+
+    Mapped domains redirect additional domains to your IDP for federated authentication.
+    This command deletes a domain from an existing SSO configuration.
+
+    You can use the command [code] nextmv cloud sso get[/code] command to view all
+    mapped domains in your SSO configuration.
+
+    [bold][underline]Examples[/underline][/bold]
+
+    - Delete a mapped domain from the SSO configuration.
+        $ [dim]nextmv cloud sso domain delete --domain "example.com"[/dim]
+    """
+
+    if not yes:
+        confirm = get_confirmation(
+            f"Are you sure you want to delete the [magenta]{domain}[/magenta] domain? You must contact Nextmv support to re-add it.",
+        )
+
+        if not confirm:
+            info("SSO mapped domain will not be deleted.")
+            return
+
+    sso_config = build_sso_config(profile)
+    in_progress(msg="Deleting SSO mapped domain from configuration...")
+    sso_config.delete_domain(domain=domain)
+    success("SSO mapped domain deleted successfully.")

--- a/nextmv/nextmv/cloud/sso.py
+++ b/nextmv/nextmv/cloud/sso.py
@@ -74,6 +74,9 @@ class SSOConfiguration(BaseModel):
         The URL to the SSO metadata document.
     metadata_document : str, optional
         The SSO metadata document as a string.
+    mapped_domains : list[str], optional
+        A list of mapped domains in the SSO configuration. This is read only, mapped
+        domains are added through an explicit command.
     client : Client
         Client to use for interacting with the Nextmv Cloud API. This is an
         SDK-specific attribute and it is not part of the API representation of
@@ -100,6 +103,11 @@ class SSOConfiguration(BaseModel):
     metadata_document: str | None = None
     """
     The SSO metadata document as a string.
+    """
+    mapped_domains: list[str] = Field(default_factory=list)
+    """
+    A list of mapped domains in the SSO configuration. Mapped domains redirect
+    additional domains to your IDP for federated authentication.
     """
 
     # SDK-specific attributes for convenience when using methods.
@@ -133,7 +141,6 @@ class SSOConfiguration(BaseModel):
             method="GET",
             endpoint="v1/enterprise/sso",
         )
-
         return cls.from_dict({"client": client} | response.json())
 
     @classmethod
@@ -144,6 +151,7 @@ class SSOConfiguration(BaseModel):
         enabled: bool | None = None,
         metadata_url: str | None = None,
         metadata_document: str | None = None,
+        mapped_domains: list[str] | None = None,
     ) -> None:
         """
         Create a new SSO configuration for the current Nextmv Cloud
@@ -165,6 +173,8 @@ class SSOConfiguration(BaseModel):
             The URL to the SSO metadata document.
         metadata_document : str, optional
             The SSO metadata document as a string.
+        mapped_domains : list[str], optional
+            A list of mapped domains in the SSO configuration.
 
         Raises
         ------
@@ -201,6 +211,22 @@ class SSOConfiguration(BaseModel):
         self.client.request(
             method="DELETE",
             endpoint=self.sso_endpoint,
+        )
+
+    def delete_domain(self, domain: str) -> None:
+        """
+        Deletes a domain from an existing SSO configuration for the current Nextmv
+        Cloud organization (account).
+
+        Raises
+        ------
+        requests.HTTPError
+            If the response status code is not 2xx.
+        """
+
+        self.client.request(
+            method="DELETE",
+            endpoint=f"{self.sso_endpoint}/domains/{domain}",
         )
 
     def disable(self) -> None:

--- a/nextmv/nextmv/cloud/sso.py
+++ b/nextmv/nextmv/cloud/sso.py
@@ -104,7 +104,7 @@ class SSOConfiguration(BaseModel):
     """
     The SSO metadata document as a string.
     """
-    mapped_domains: list[str] = Field(default_factory=list)
+    mapped_domains: list[str] | None = None
     """
     A list of mapped domains in the SSO configuration. Mapped domains redirect
     additional domains to your IDP for federated authentication.

--- a/nextmv/nextmv/cloud/sso.py
+++ b/nextmv/nextmv/cloud/sso.py
@@ -151,7 +151,6 @@ class SSOConfiguration(BaseModel):
         enabled: bool | None = None,
         metadata_url: str | None = None,
         metadata_document: str | None = None,
-        mapped_domains: list[str] | None = None,
     ) -> None:
         """
         Create a new SSO configuration for the current Nextmv Cloud
@@ -173,8 +172,6 @@ class SSOConfiguration(BaseModel):
             The URL to the SSO metadata document.
         metadata_document : str, optional
             The SSO metadata document as a string.
-        mapped_domains : list[str], optional
-            A list of mapped domains in the SSO configuration.
 
         Raises
         ------


### PR DESCRIPTION
# Description

This feature adds the SSO domain command tree. Creating an SSO domain mapping is under Nextmv control, so its in our internal `nextmv-ops tool` until we can do txt record validation for domain ownership.

* `nextmv cloud sso domain delete --domain foo.bar --profile local` - deletes an already mapped domain from an existing SSO configuration
* `nextmv sso get` now returns `mapped_domains` as a field if there are mapped domains

