### PR TITLE
addresses breaking changes

### DIFF
--- a/nextmv/nextmv/cloud/application/_run.py
+++ b/nextmv/nextmv/cloud/application/_run.py
@@ -239,7 +239,6 @@ class ApplicationRunMixin:
     def new_run(  # noqa: C901 # Refactor this function at some point.
         self: "Application",
         input: Input | dict[str, Any] | BaseModel | str = None,
-        managed_input_id: str | None = None,
         instance_id: str | None = None,
         name: str | None = None,
         description: str | None = None,
@@ -250,6 +249,7 @@ class ApplicationRunMixin:
         external_result: ExternalRunResult | dict[str, Any] | None = None,
         json_configurations: dict[str, Any] | None = None,
         input_dir_path: str | None = None,
+        managed_input_id: str | None = None,
     ) -> str:
         """
         Submit an input to start a new run of the application. Returns the
@@ -288,9 +288,6 @@ class ApplicationRunMixin:
 
             In general, if an input is too large, it will be uploaded with the
             `upload_data` method.
-        managed_input_id: Optional[str]
-            The ID of an existing managed input (`nextmv.cloud.ManagedInput`)
-            to use as the run's input.
         instance_id: Optional[str]
             ID of the instance to use for the run. If not provided, the default
             instance ID associated to the Class (`default_instance_id`) is
@@ -335,6 +332,9 @@ class ApplicationRunMixin:
             like `nextmv.InputFormat.CSV_ARCHIVE` or `nextmv.InputFormat.MULTI_FILE`.
             If both `input` and `input_dir_path` are specified, the `input` is
             ignored, and the files in the directory are used instead.
+        managed_input_id: Optional[str]
+            The ID of an existing managed input (`nextmv.cloud.ManagedInput`)
+            to use as the run's input.
 
         Returns
         ----------
@@ -368,7 +368,12 @@ class ApplicationRunMixin:
 
         managed_input_id_used = managed_input_id is not None and managed_input_id != ""
         upload_id_used = upload_id is not None and upload_id != ""
-        if self.__upload_url_required(upload_id_used or managed_input_id_used, input_size, tar_file, input):
+        if self.__upload_url_required(
+            uploaded_input_used=upload_id_used or managed_input_id_used,
+            input_size=input_size,
+            tar_file=tar_file,
+            input=input,
+        ):
             upload_url = self.upload_url()
             self.upload_data(data=input_data, upload_url=upload_url, tar_file=tar_file)
             upload_id = upload_url.upload_id
@@ -431,7 +436,6 @@ class ApplicationRunMixin:
     def new_run_with_result(
         self: "Application",
         input: Input | dict[str, Any] | BaseModel | str = None,
-        managed_input_id: str | None = None,
         instance_id: str | None = None,
         name: str | None = None,
         description: str | None = None,
@@ -444,6 +448,7 @@ class ApplicationRunMixin:
         json_configurations: dict[str, Any] | None = None,
         input_dir_path: str | None = None,
         output_dir_path: str | None = ".",
+        managed_input_id: str | None = None,
     ) -> RunResult:
         """
         Submit an input to start a new run of the application and poll for the

--- a/nextmv/nextmv/cloud/client.py
+++ b/nextmv/nextmv/cloud/client.py
@@ -84,7 +84,7 @@ class Client:
     timeout : float
         Timeout to use for requests to the Nextmv Cloud API, in seconds.
         Defaults to ``20``.
-    url : str
+    url : str, optional
         URL of the Nextmv Cloud API. Defaults to
         ``"https://api.cloud.nextmv.io"``.
     console_url : str
@@ -156,6 +156,10 @@ class Client:
             If `apikey` is not found in the configuration file for the
             selected profile.
         """
+
+        # Fallback for backwards compatibility with empty string
+        if not self.url:
+            self.url = "https://api.cloud.nextmv.io"
 
         if self.api_key is not None and self.api_key != "":
             self._set_headers_api_key(self.api_key)

--- a/nextmv/nextmv/cloud/client.py
+++ b/nextmv/nextmv/cloud/client.py
@@ -157,10 +157,6 @@ class Client:
             selected profile.
         """
 
-        # Fallback for integration tests
-        if not self.url:
-            self.url = "https://api.cloud.nextmv.io"
-
         if self.api_key is not None and self.api_key != "":
             self._set_headers_api_key(self.api_key)
             return


### PR DESCRIPTION
# Description

Addresses feedback from [prior PR](https://github.com/nextmv-io/nextmv-py/pull/243) to avoid breaking changes

## Changes

- `nextmv/nextmv/cloud/application/_run.py`
    - ensures new function arguments are at the end to avoid the function signature breaking for anyone not using keyword args up to at least `instance_id`
    - When checking if a run is made via an uploaded input, use `kwargs` for visual clarity
- `nextmv/nextmv/cloud/client.py`
    - Actual important part of `if not self.url` check commented in now (does not introduce breaking changes)
    
## Testing

Tried to be thorough with this but VSCode and `debugpy` were not cooperating for me so had to punt for the sake of getting changes out in a reasonable time.