### PR TITLE
Docs/managed input

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,8 @@
+// Reference: https://github.com/DavidAnson/markdownlint/blob/main/doc/CustomRules.md#custom-rules
+{
+  // Files ignored by the linter.
+  "ignores": [
+    ".git",
+    "**/.venv"
+  ]
+}

--- a/docs/nextmv/cloud/index.md
+++ b/docs/nextmv/cloud/index.md
@@ -40,6 +40,7 @@ Tutorials to manage your Cloud applications and their runs.
 | [Instances][instances] | Manage instances of your Cloud application |
 | [Track Runs][external-runs] | Associate external runs executed outside of Cloud with your Cloud application |
 | [Secrets][secrets] | Manage secrets to use in your Cloud application |
+| [Managed Inputs][managed-inputs] | Manage inputs for your Cloud application independent from execution |
 | [Large Payloads][large-payloads] | Manage large payloads for your Cloud application |
 | [Queuing & prioritization][queuing] | Manage queuing and prioritization for your Cloud application |
 | [Execution classes][execution-classes] | Manage execution classes for your Cloud application |
@@ -72,6 +73,7 @@ Tutorials to manage testing and experimentation for your Cloud applications.
 [instances]: ./instances.md
 [external-runs]: ./external-runs.md
 [secrets]: ./secrets.md
+[managed-inputs]: ./managed-inputs.md
 [large-payloads]: ./large-payloads.md
 [queuing]: ./queuing.md
 [execution-classes]: ./execution-classes.md

--- a/docs/nextmv/cloud/managed-inputs.md
+++ b/docs/nextmv/cloud/managed-inputs.md
@@ -3,15 +3,13 @@
 Managed inputs are input files stored on the Nextmv platform and managed at an
 application level.
 
-## Creating managed inputs
-
 Managed inputs can be created in two different ways:
 
 * Via the ID of an existing [run][runs] within the application
 * Via the ID of [data uploaded to Nextmv][application-upload-data]
   through the use of a [presigned URL][application-upload-url].
 
-### __Via a run ID__
+## Creating inputs via a run ID
 
 Example code for generating a managed input via run ID:
 
@@ -22,33 +20,32 @@ import nextmv
 from nextmv.cloud import Application, Client
 
 client = Client(api_key=os.getenv("NEXTMV_API_KEY"))
-app = Application(client=client, id=os.getenv("APP_ID"))
+app = Application(client=client, id="<YOUR_APP_ID>")
 managed_input = app.new_managed_input(
-    id=os.getenv("MANAGED_INPUT_ID"),
-    name=os.getenv("MANAGED_INPUT_ID"),
+    id="<YOUR_MANAGED_INPUT_ID>",
+    name="<YOUR_MANAGED_INPUT_ID>",
     description="An optional description",
-    run_id="latest-RNBs7AKSg",
+    run_id="<YOUR_RUN_ID>",
 )
 nextmv.write(managed_input)
 ```
 
 A possible output of such code
-(where environment variables `NEXTMV_API_KEY=routing` and `MANAGED_INPUT_ID=managed-input-3`,
-and the format of the existing run `latest-RNBs7AKSg` is the `JSON` type):
+(where the format of the existing run `<YOUR_RUN_ID` is the `JSON` type):
 
 ```json
 {
-    "app_id": "routing",
+    "app_id": "<YOUR_APP_ID>",
     "created_at": "2026-03-03T14:02:12.000000Z",
     "description": "An optional description",
-    "id": "managed-input-3",
-    "run_id": "latest-RNBs7AKSg",
+    "id": "<YOUR_MANAGED_INPUT_ID>",
+    "run_id": "<YOUR_RUN_ID>",
     "format": {
         "input": {
             "type": "json"
         }
     },
-    "name": "managed-input-3",
+    "name": "<YOUR_MANAGED_INPUT_ID>",
     "updated_at": "2026-03-03T14:02:12.000000Z"
 }
 ```
@@ -58,7 +55,7 @@ and the format of the existing run `latest-RNBs7AKSg` is the `JSON` type):
     The `format` information of a run used to create a managed input will be
     inherited by the managed input generated.
 
-### __Via the ID of uploaded data__
+## Creating inputs via the ID of uploaded data
 
 Example code for generating a managed input via uploaded data:
 
@@ -72,7 +69,7 @@ with open("<YOUR-INPUT-FILE>") as f:
     input = json.load(f)
 
 client = Client(api_key=os.getenv("NEXTMV_API_KEY"))
-app = Application(client=client, id=os.getenv("APP_ID"))
+app = Application(client=client, id="<YOUR_APP_ID>")
 
 # Get the upload URL.
 upload_url = app.upload_url()
@@ -81,30 +78,29 @@ upload_url = app.upload_url()
 app.upload_data(data=input, upload_url=upload_url)
 
 managed_input = app.new_managed_input(
-    id=os.getenv("MANAGED_INPUT_ID"),
-    name=os.getenv("MANAGED_INPUT_ID"),
+    id="<YOUR_MANAGED_INPUT_ID>",
+    name="<YOUR_MANAGED_INPUT_ID>",
     description="An optional description",
     upload_id=upload_url.upload_id,
 )
 nextmv.write(managed_input)
 ```
 
-A possible output of such code
-(where environment variables `NEXTMV_API_KEY=routing` and `MANAGED_INPUT_ID=managed-input-3`):
+A possible output of such code:
 
 ```json
 {
-    "app_id": "routing",
+    "app_id": "<YOUR_APP_ID>",
     "created_at": "2026-03-03T14:02:12.000000Z",
     "description": "An optional description",
-    "id": "managed-input-3",
+    "id": "<YOUR_MANAGED_INPUT_ID>",
     "upload_id": "generated-upload-id",
     "format": {
         "input": {
             "type": "json"
         }
     },
-    "name": "managed-input-3",
+    "name": "<YOUR_MANAGED_INPUT_ID>",
     "updated_at": "2026-03-03T14:02:12.000000Z"
 }
 ```

--- a/docs/nextmv/cloud/managed-inputs.md
+++ b/docs/nextmv/cloud/managed-inputs.md
@@ -1,0 +1,120 @@
+# Managed inputs
+
+Managed inputs are input files stored on the Nextmv platform and managed at an
+application level.
+
+## Creating managed inputs
+
+Managed inputs can be created in two different ways:
+
+* Via the ID of an existing [run][runs] within the application
+* Via the ID of [data uploaded to Nextmv][application-upload-data]
+  through the use of a [presigned URL][application-upload-url].
+
+### __Via a run ID__
+
+Example code for generating a managed input via run ID:
+
+```python
+import os
+
+import nextmv
+from nextmv.cloud import Application, Client
+
+client = Client(api_key=os.getenv("NEXTMV_API_KEY"))
+app = Application(client=client, id=os.getenv("APP_ID"))
+managed_input = app.new_managed_input(
+    id=os.getenv("MANAGED_INPUT_ID"),
+    name=os.getenv("MANAGED_INPUT_ID"),
+    description="An optional description",
+    run_id="latest-RNBs7AKSg",
+)
+nextmv.write(managed_input)
+```
+
+A possible output of such code
+(where environment variables `NEXTMV_API_KEY=routing` and `MANAGED_INPUT_ID=managed-input-3`,
+and the format of the existing run `latest-RNBs7AKSg` is the `JSON` type):
+
+```json
+{
+    "app_id": "routing",
+    "created_at": "2026-03-03T14:02:12.000000Z",
+    "description": "An optional description",
+    "id": "managed-input-3",
+    "run_id": "latest-RNBs7AKSg",
+    "format": {
+        "input": {
+            "type": "json"
+        }
+    },
+    "name": "managed-input-3",
+    "updated_at": "2026-03-03T14:02:12.000000Z"
+}
+```
+
+!!! tip
+
+    The `format` information of a run used to create a managed input will be
+    inherited by the managed input generated.
+
+### __Via the ID of uploaded data__
+
+Example code for generating a managed input via uploaded data:
+
+```python
+import os
+
+import nextmv
+from nextmv.cloud import Application, Client
+
+with open("<YOUR-INPUT-FILE>") as f:
+    input = json.load(f)
+
+client = Client(api_key=os.getenv("NEXTMV_API_KEY"))
+app = Application(client=client, id=os.getenv("APP_ID"))
+
+# Get the upload URL.
+upload_url = app.upload_url()
+
+# Upload the input.
+app.upload_data(data=input, upload_url=upload_url)
+
+managed_input = app.new_managed_input(
+    id=os.getenv("MANAGED_INPUT_ID"),
+    name=os.getenv("MANAGED_INPUT_ID"),
+    description="An optional description",
+    upload_id=upload_url.upload_id,
+)
+nextmv.write(managed_input)
+```
+
+A possible output of such code
+(where environment variables `NEXTMV_API_KEY=routing` and `MANAGED_INPUT_ID=managed-input-3`):
+
+```json
+{
+    "app_id": "routing",
+    "created_at": "2026-03-03T14:02:12.000000Z",
+    "description": "An optional description",
+    "id": "managed-input-3",
+    "upload_id": "generated-upload-id",
+    "format": {
+        "input": {
+            "type": "json"
+        }
+    },
+    "name": "managed-input-3",
+    "updated_at": "2026-03-03T14:02:12.000000Z"
+}
+```
+
+!!! warning
+
+    When using input that is not `JSON` formatted, the `Format` argument _must_
+    be supplied to the `new_managed_input` function
+
+[runs]: ./runs.md
+[application-managed-inputs]: ./reference/application.md#nextmv.nextmv.cloud.application._managed_input
+[application-upload-url]: ./reference/application.md#nextmv.nextmv.cloud.application.Application.upload_url
+[application-upload-data]: ./reference/application.md#nextmv.nextmv.cloud.application.Application.upload_data

--- a/docs/nextmv/cloud/managed-inputs.md
+++ b/docs/nextmv/cloud/managed-inputs.md
@@ -115,6 +115,5 @@ A possible output of such code
     be supplied to the `new_managed_input` function
 
 [runs]: ./runs.md
-[application-managed-inputs]: ./reference/application.md#nextmv.nextmv.cloud.application._managed_input
 [application-upload-url]: ./reference/application.md#nextmv.nextmv.cloud.application.Application.upload_url
 [application-upload-data]: ./reference/application.md#nextmv.nextmv.cloud.application.Application.upload_data

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,6 +50,7 @@ nav:
           - Instances: nextmv/cloud/instances.md
           - Track runs: nextmv/cloud/external-runs.md
           - Secrets: nextmv/cloud/secrets.md
+          - Managed Inputs: nextmv/cloud/managed-inputs.md
           - Large payloads: nextmv/cloud/large-payloads.md
           - Queuing & prioritization: nextmv/cloud/queuing.md
           - Execution classes: nextmv/cloud/execution-classes.md

--- a/nextmv/tests/integration/cloud/test_integration_cloud.py
+++ b/nextmv/tests/integration/cloud/test_integration_cloud.py
@@ -743,7 +743,7 @@ class CloudIntegrationWorkflow(FlowSpec):
 
         # We can start an ensemble run.
         input_data = {"name": "world", "radius": 6378, "distance": 147.6}
-        run = app.new_run_with_result(
+        result = app.new_run_with_result(
             input=input_data,
             configuration=nextmv.RunConfiguration(
                 run_type=nextmv.RunTypeConfiguration(
@@ -752,7 +752,7 @@ class CloudIntegrationWorkflow(FlowSpec):
                 ),
             ),
         )
-        assert run.metadata.status_v2 == nextmv.StatusV2.succeeded
+        assert result.metadata.status_v2 == nextmv.StatusV2.succeeded
 
         # We can delete an ensemble definition.
         app.delete_ensemble_definition(ensemble_definition_id=definition.id)


### PR DESCRIPTION
# Description

Adds docs for managed input

## Changes

- `.markdownlint-cli2.jsonc`
    - Added to prevent `markdownlint-cli2` from burrowing into `.git` and `.venv` by default
- `docs/nextmv/cloud/managed-inputs.md`
    - Adds doc file that shows example code of how to generate managed inputs both by run ID and by upload endpoint
- `docs/nextmv/cloud/index.md`
    - reference to managed inputs page added under app managment
- `mkdocs.yml`
    - reference to managed inputs page added under app managment 
- `nextmv/tests/integration/cloud/test_integration_cloud.py`
    - Update from prior PR review (moved to this branch given the importance of addressing test stability quickly)
    
## Testing

Only one tightly scoped variable name changed for the integration test, no functional changes. Left to the PR to do because there was little point in also doing them manually. Docs didn't have any notable formatting errors when I poked around in them on the `readthedocs` GH action.

## Feedback requested

- Beyond not having obvious _errors_ in the formatting, is the new doc page sufficiently well formatted?
- Is the new doc page sufficiently descriptive?
- Is the new doc page sufficiently concise?