### PR TITLE
Allows custom log callback

### DIFF
--- a/nextmv/nextmv/__about__.py
+++ b/nextmv/nextmv/__about__.py
@@ -1,1 +1,1 @@
-__version__ = "v1.2.0"
+__version__ = "v1.2.1.dev0"

--- a/nextmv/nextmv/__about__.py
+++ b/nextmv/nextmv/__about__.py
@@ -1,1 +1,1 @@
-__version__ = "v1.2.1.dev0"
+__version__ = "v1.2.1"

--- a/nextmv/nextmv/cloud/application/_run.py
+++ b/nextmv/nextmv/cloud/application/_run.py
@@ -9,7 +9,7 @@ import shutil
 import sys
 import tarfile
 import tempfile
-import typing
+from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 import rich
@@ -750,7 +750,7 @@ class ApplicationRunMixin:
         verbose: bool = False,
         rich_print: bool = False,
         polling_options: PollingOptions = DEFAULT_POLLING_OPTIONS,
-        log_func: typing.Callable[[str], None] | None = None,
+        log_func: Callable[[str], None] | None = None,
     ) -> list[TimestampedRunLog]:
         """
         Get the logs of a run with polling.
@@ -775,7 +775,8 @@ class ApplicationRunMixin:
         polling_options : PollingOptions, default=_DEFAULT_POLLING_OPTIONS
             Options to use when polling for the run logs.
         log_func : Optional[Callable[[str], None]], default=None
-            Optional custom logging function to use.
+            Optional custom logging function to use. If provided, this function will be
+            called instead of the default logging behavior when `verbose` is True.
 
         Returns
         -------

--- a/nextmv/nextmv/cloud/application/_run.py
+++ b/nextmv/nextmv/cloud/application/_run.py
@@ -9,6 +9,7 @@ import shutil
 import sys
 import tarfile
 import tempfile
+import typing
 from typing import TYPE_CHECKING, Any
 
 import rich
@@ -749,6 +750,7 @@ class ApplicationRunMixin:
         verbose: bool = False,
         rich_print: bool = False,
         polling_options: PollingOptions = DEFAULT_POLLING_OPTIONS,
+        log_func: typing.Callable[[str], None] | None = None,
     ) -> list[TimestampedRunLog]:
         """
         Get the logs of a run with polling.
@@ -772,6 +774,8 @@ class ApplicationRunMixin:
             Whether to use rich printing for better formatting of the logs.
         polling_options : PollingOptions, default=_DEFAULT_POLLING_OPTIONS
             Options to use when polling for the run logs.
+        log_func : Optional[Callable[[str], None]], default=None
+            Optional custom logging function to use.
 
         Returns
         -------
@@ -825,7 +829,9 @@ class ApplicationRunMixin:
                 log_entry = TimestampedRunLog.from_dict(resp_log)
                 if verbose:
                     msg = f"[{log_entry.timestamp}] {log_entry.log}"
-                    if rich_print:
+                    if log_func is not None:
+                        log_func(msg)
+                    elif rich_print:
                         rich.print(msg, file=sys.stderr)
                     else:
                         log(msg)


### PR DESCRIPTION
# Description

Allows the user to pass a custom log callback into `run_logs_with_polling` to replace simple printing. This allows redirecting the logs live.

## Changes

- Adds `log_func` parameter to `run_logs_with_polling` to enable easy live log redirects (callbacks).