### PR TITLE
Revises log func definition

### DIFF
--- a/nextmv/nextmv/__about__.py
+++ b/nextmv/nextmv/__about__.py
@@ -1,1 +1,1 @@
-__version__ = "v1.2.2.dev0"
+__version__ = "v1.2.2"

--- a/nextmv/nextmv/__about__.py
+++ b/nextmv/nextmv/__about__.py
@@ -1,1 +1,1 @@
-__version__ = "v1.2.1"
+__version__ = "v1.2.2.dev0"

--- a/nextmv/nextmv/cloud/application/_run.py
+++ b/nextmv/nextmv/cloud/application/_run.py
@@ -775,9 +775,9 @@ class ApplicationRunMixin:
         polling_options : PollingOptions, default=_DEFAULT_POLLING_OPTIONS
             Options to use when polling for the run logs.
         log_func : Optional[Callable[[TimestampedRunLog], None]], default=None
-            Optional custom logging function to use. This function is invoked if provided,
-            independently of the `verbose` flag. It needs to take a `TimestampedRunLog` as
-            its argument and return `None`.
+            Optional custom logging function callback. This function is invoked
+            independently of the `verbose` flag. It needs to take a
+            `TimestampedRunLog` as its argument and return `None`.
 
         Returns
         -------

--- a/nextmv/nextmv/cloud/application/_run.py
+++ b/nextmv/nextmv/cloud/application/_run.py
@@ -750,7 +750,7 @@ class ApplicationRunMixin:
         verbose: bool = False,
         rich_print: bool = False,
         polling_options: PollingOptions = DEFAULT_POLLING_OPTIONS,
-        log_func: Callable[[str], None] | None = None,
+        log_func: Callable[[TimestampedRunLog], None] | None = None,
     ) -> list[TimestampedRunLog]:
         """
         Get the logs of a run with polling.
@@ -774,9 +774,10 @@ class ApplicationRunMixin:
             Whether to use rich printing for better formatting of the logs.
         polling_options : PollingOptions, default=_DEFAULT_POLLING_OPTIONS
             Options to use when polling for the run logs.
-        log_func : Optional[Callable[[str], None]], default=None
-            Optional custom logging function to use. If provided, this function will be
-            called instead of the default logging behavior when `verbose` is True.
+        log_func : Optional[Callable[[TimestampedRunLog], None]], default=None
+            Optional custom logging function to use. This function is invoked if provided,
+            independently of the `verbose` flag. It needs to take a `TimestampedRunLog` as
+            its argument and return `None`.
 
         Returns
         -------
@@ -828,11 +829,11 @@ class ApplicationRunMixin:
             # enabled and append them to the overall logs.
             for resp_log in json_resp.get("items", []):
                 log_entry = TimestampedRunLog.from_dict(resp_log)
+                if log_func is not None:
+                    log_func(log_entry)
                 if verbose:
                     msg = f"[{log_entry.timestamp}] {log_entry.log}"
-                    if log_func is not None:
-                        log_func(msg)
-                    elif rich_print:
+                    if rich_print:
                         rich.print(msg, file=sys.stderr)
                     else:
                         log(msg)


### PR DESCRIPTION
# Description

Revises the recently introduced custom `log_func` of `run_logs_with_polling` to give the user more flexibility. Instead of the pre-formatted string, the func now receives the `TimestampedRunLog` item itself and is invoked independently of the value of `verbose`.

## Changes

- Changes `log_func` of `run_logs_with_polling` to receive `TimestampedRunLog` instead of preformatted string.