### PR TITLE
Enable output retrieval on failed runs for CLI and SDK. Adds run deletion to CLI and SDK. Adds `Application.run_output` method to SDK

### DIFF
--- a/nextmv/nextmv/cli/cloud/acceptance/delete.py
+++ b/nextmv/nextmv/cli/cloud/acceptance/delete.py
@@ -2,13 +2,11 @@
 This module defines the cloud acceptance delete command for the Nextmv CLI.
 """
 
-from typing import Annotated
-
 import typer
 
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import confirmation, info, success
-from nextmv.cli.options import AcceptanceTestIDOption, AppIDOption, ProfileOption
+from nextmv.cli.options import AcceptanceTestIDOption, AppIDOption, ProfileOption, YesOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -18,14 +16,7 @@ app = typer.Typer()
 def delete(
     app_id: AppIDOption,
     acceptance_test_id: AcceptanceTestIDOption,
-    yes: Annotated[
-        bool,
-        typer.Option(
-            "--yes",
-            "-y",
-            help="Agree to deletion confirmation prompt. Useful for non-interactive sessions.",
-        ),
-    ] = False,
+    yes: YesOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/account/delete.py
+++ b/nextmv/nextmv/cli/cloud/account/delete.py
@@ -2,13 +2,11 @@
 This module defines the cloud account delete command for the Nextmv CLI.
 """
 
-from typing import Annotated
-
 import typer
 
 from nextmv.cli.configuration.config import build_account
 from nextmv.cli.message import confirmation, info, success
-from nextmv.cli.options import AccountIDOption, ProfileOption
+from nextmv.cli.options import AccountIDOption, ProfileOption, YesOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -17,14 +15,7 @@ app = typer.Typer()
 @app.command()
 def delete(
     account_id: AccountIDOption,
-    yes: Annotated[
-        bool,
-        typer.Option(
-            "--yes",
-            "-y",
-            help="Agree to deletion confirmation prompt. Useful for non-interactive sessions.",
-        ),
-    ] = False,
+    yes: YesOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/app/delete.py
+++ b/nextmv/nextmv/cli/cloud/app/delete.py
@@ -2,13 +2,11 @@
 This module defines the cloud app delete command for the Nextmv CLI.
 """
 
-from typing import Annotated
-
 import typer
 
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import confirmation, info, success
-from nextmv.cli.options import AppIDOption, ProfileOption
+from nextmv.cli.options import AppIDOption, ProfileOption, YesOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -17,14 +15,7 @@ app = typer.Typer()
 @app.command()
 def delete(
     app_id: AppIDOption,
-    yes: Annotated[
-        bool,
-        typer.Option(
-            "--yes",
-            "-y",
-            help="Agree to deletion confirmation prompt. Useful for non-interactive sessions.",
-        ),
-    ] = False,
+    yes: YesOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/batch/delete.py
+++ b/nextmv/nextmv/cli/cloud/batch/delete.py
@@ -2,13 +2,11 @@
 This module defines the cloud batch delete command for the Nextmv CLI.
 """
 
-from typing import Annotated
-
 import typer
 
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import confirmation, info, success
-from nextmv.cli.options import AppIDOption, BatchExperimentIDOption, ProfileOption
+from nextmv.cli.options import AppIDOption, BatchExperimentIDOption, ProfileOption, YesOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -18,14 +16,7 @@ app = typer.Typer()
 def delete(
     app_id: AppIDOption,
     batch_experiment_id: BatchExperimentIDOption,
-    yes: Annotated[
-        bool,
-        typer.Option(
-            "--yes",
-            "-y",
-            help="Agree to deletion confirmation prompt. Useful for non-interactive sessions.",
-        ),
-    ] = False,
+    yes: YesOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/ensemble/delete.py
+++ b/nextmv/nextmv/cli/cloud/ensemble/delete.py
@@ -2,13 +2,11 @@
 This module defines the cloud ensemble delete command for the Nextmv CLI.
 """
 
-from typing import Annotated
-
 import typer
 
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import confirmation, info, success
-from nextmv.cli.options import AppIDOption, EnsembleDefinitionIDOption, ProfileOption
+from nextmv.cli.options import AppIDOption, EnsembleDefinitionIDOption, ProfileOption, YesOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -18,14 +16,7 @@ app = typer.Typer()
 def delete(
     app_id: AppIDOption,
     ensemble_definition_id: EnsembleDefinitionIDOption,
-    yes: Annotated[
-        bool,
-        typer.Option(
-            "--yes",
-            "-y",
-            help="Agree to deletion confirmation prompt. Useful for non-interactive sessions.",
-        ),
-    ] = False,
+    yes: YesOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/input_set/delete.py
+++ b/nextmv/nextmv/cli/cloud/input_set/delete.py
@@ -2,13 +2,11 @@
 This module defines the cloud input-set delete command for the Nextmv CLI.
 """
 
-from typing import Annotated
-
 import typer
 
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import confirmation, info, success
-from nextmv.cli.options import AppIDOption, InputSetIDOption, ProfileOption
+from nextmv.cli.options import AppIDOption, InputSetIDOption, ProfileOption, YesOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -18,14 +16,7 @@ app = typer.Typer()
 def delete(
     app_id: AppIDOption,
     input_set_id: InputSetIDOption,
-    yes: Annotated[
-        bool,
-        typer.Option(
-            "--yes",
-            "-y",
-            help="Agree to deletion confirmation prompt. Useful for non-interactive sessions.",
-        ),
-    ] = False,
+    yes: YesOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/instance/delete.py
+++ b/nextmv/nextmv/cli/cloud/instance/delete.py
@@ -2,13 +2,11 @@
 This module defines the cloud instance delete command for the Nextmv CLI.
 """
 
-from typing import Annotated
-
 import typer
 
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import confirmation, info, success
-from nextmv.cli.options import AppIDOption, InstanceIDOption, ProfileOption
+from nextmv.cli.options import AppIDOption, InstanceIDOption, ProfileOption, YesOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -18,14 +16,7 @@ app = typer.Typer()
 def delete(
     app_id: AppIDOption,
     instance_id: InstanceIDOption,
-    yes: Annotated[
-        bool,
-        typer.Option(
-            "--yes",
-            "-y",
-            help="Agree to deletion confirmation prompt. Useful for non-interactive sessions.",
-        ),
-    ] = False,
+    yes: YesOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/managed_input/delete.py
+++ b/nextmv/nextmv/cli/cloud/managed_input/delete.py
@@ -2,13 +2,11 @@
 This module defines the cloud managed-input delete command for the Nextmv CLI.
 """
 
-from typing import Annotated
-
 import typer
 
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import confirmation, info, success
-from nextmv.cli.options import AppIDOption, ManagedInputIDOption, ProfileOption
+from nextmv.cli.options import AppIDOption, ManagedInputIDOption, ProfileOption, YesOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -18,14 +16,7 @@ app = typer.Typer()
 def delete(
     app_id: AppIDOption,
     managed_input_id: ManagedInputIDOption,
-    yes: Annotated[
-        bool,
-        typer.Option(
-            "--yes",
-            "-y",
-            help="Agree to deletion confirmation prompt. Useful for non-interactive sessions.",
-        ),
-    ] = False,
+    yes: YesOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/marketplace/subscription/delete.py
+++ b/nextmv/nextmv/cli/cloud/marketplace/subscription/delete.py
@@ -2,13 +2,11 @@
 This module defines the cloud marketplace subscription delete command for the Nextmv CLI.
 """
 
-from typing import Annotated
-
 import typer
 
 from nextmv.cli.configuration.config import build_marketplace_subscription
 from nextmv.cli.message import confirmation, info, success
-from nextmv.cli.options import MarketplaceSubscriptionIDOption, ProfileOption
+from nextmv.cli.options import MarketplaceSubscriptionIDOption, ProfileOption, YesOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -17,14 +15,7 @@ app = typer.Typer()
 @app.command()
 def delete(
     subscription_id: MarketplaceSubscriptionIDOption,
-    yes: Annotated[
-        bool,
-        typer.Option(
-            "--yes",
-            "-y",
-            help="Agree to deletion confirmation prompt. Useful for non-interactive sessions.",
-        ),
-    ] = False,
+    yes: YesOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/run/__init__.py
+++ b/nextmv/nextmv/cli/cloud/run/__init__.py
@@ -6,6 +6,7 @@ import typer
 
 from nextmv.cli.cloud.run.cancel import app as cancel_app
 from nextmv.cli.cloud.run.create import app as create_app
+from nextmv.cli.cloud.run.delete import app as delete_app
 from nextmv.cli.cloud.run.get import app as get_app
 from nextmv.cli.cloud.run.input import app as input_app
 from nextmv.cli.cloud.run.list import app as list_app
@@ -17,6 +18,7 @@ from nextmv.cli.cloud.run.track import app as track_app
 app = typer.Typer()
 app.add_typer(cancel_app)
 app.add_typer(create_app)
+app.add_typer(delete_app)
 app.add_typer(get_app)
 app.add_typer(input_app)
 app.add_typer(list_app)

--- a/nextmv/nextmv/cli/cloud/run/delete.py
+++ b/nextmv/nextmv/cli/cloud/run/delete.py
@@ -1,0 +1,50 @@
+"""
+This module defines the cloud run delete command for the Nextmv CLI.
+"""
+
+import typer
+
+from nextmv.cli.configuration.config import build_cloud_app
+from nextmv.cli.message import confirmation, info, success
+from nextmv.cli.options import AppIDOption, ProfileOption, RunIDOption, YesOption
+
+# Set up subcommand application.
+app = typer.Typer()
+
+
+@app.command()
+def delete(
+    app_id: AppIDOption,
+    run_id: RunIDOption,
+    yes: YesOption = False,
+    profile: ProfileOption = None,
+) -> None:
+    """
+    Deletes a Nextmv Cloud application run.
+
+    This action is permanent and cannot be undone. Use the --yes
+    flag to skip the confirmation prompt.
+
+    [bold][underline]Examples[/underline][/bold]
+
+    - Delete the run with ID [magenta]burrow-123[/magenta] belonging to an app with ID [magenta]hare-app[/magenta].
+        $ [dim]nextmv cloud run delete --app-id hare-app --run-id burrow-123[/dim]
+
+    - Delete the run with ID [magenta]burrow-123[/magenta] belonging to an app with ID [magenta]hare-app[/magenta].
+      Use the profile named [magenta]hare[/magenta].
+        $ [dim]nextmv cloud run delete --app-id hare-app --run-id burrow-123 --profile hare[/dim]
+    """
+
+    if not yes:
+        confirm = confirmation(
+            f"Are you sure you want to delete run [magenta]{run_id}[/magenta] from "
+            f"application [magenta]{app_id}[/magenta]? This action cannot be undone.",
+        )
+
+        if not confirm:
+            info(f"Run [magenta]{run_id}[/magenta] from application [magenta]{app_id}[/magenta] will not be deleted.")
+            return
+
+    cloud_app, _ = build_cloud_app(app_id=app_id, profile=profile)
+    cloud_app.delete_run(run_id)
+    success(f"Run [magenta]{run_id}[/magenta] from application [magenta]{app_id}[/magenta] deleted successfully.")

--- a/nextmv/nextmv/cli/cloud/run/get.py
+++ b/nextmv/nextmv/cli/cloud/run/get.py
@@ -8,7 +8,7 @@ from typing import Annotated
 import typer
 
 from nextmv.cli.configuration.config import build_cloud_app
-from nextmv.cli.message import in_progress, info, print_json, success
+from nextmv.cli.message import in_progress, print_json, success
 from nextmv.cli.options import AppIDOption, ProfileOption, RunIDOption
 from nextmv.cloud.application import Application
 from nextmv.output import OutputFormat
@@ -187,13 +187,8 @@ def handle_outputs(
 
     # At this point, we know that the output is multi-file or csv-archive.
     result_dict = run_result.to_dict()
-    if "output" in result_dict and run_result.metadata.run_is_finalized():
+    if "output" in result_dict:
         del result_dict["output"]
-        success(f"Run outputs saved to [magenta]{output_dir}[/magenta]. Here is the metadata.")
-    else:
-        info(
-            f"Run is not finalized (status: [magenta]{run_result.metadata.status_v2.value}[/magenta]). "
-            "Here is the metadata."
-        )
 
+    success(f"Run outputs saved to [magenta]{output_dir}[/magenta]. Here is the metadata.")
     print_json(result_dict)

--- a/nextmv/nextmv/cli/cloud/scenario/delete.py
+++ b/nextmv/nextmv/cli/cloud/scenario/delete.py
@@ -2,13 +2,11 @@
 This module defines the cloud scenario delete command for the Nextmv CLI.
 """
 
-from typing import Annotated
-
 import typer
 
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import confirmation, info, success
-from nextmv.cli.options import AppIDOption, ProfileOption, ScenarioTestIDOption
+from nextmv.cli.options import AppIDOption, ProfileOption, ScenarioTestIDOption, YesOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -18,14 +16,7 @@ app = typer.Typer()
 def delete(
     app_id: AppIDOption,
     scenario_test_id: ScenarioTestIDOption,
-    yes: Annotated[
-        bool,
-        typer.Option(
-            "--yes",
-            "-y",
-            help="Agree to deletion confirmation prompt. Useful for non-interactive sessions.",
-        ),
-    ] = False,
+    yes: YesOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/secrets/delete.py
+++ b/nextmv/nextmv/cli/cloud/secrets/delete.py
@@ -2,13 +2,11 @@
 This module defines the cloud secrets delete command for the Nextmv CLI.
 """
 
-from typing import Annotated
-
 import typer
 
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import confirmation, info, success
-from nextmv.cli.options import AppIDOption, ProfileOption, SecretsCollectionIDOption
+from nextmv.cli.options import AppIDOption, ProfileOption, SecretsCollectionIDOption, YesOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -18,14 +16,7 @@ app = typer.Typer()
 def delete(
     app_id: AppIDOption,
     secrets_collection_id: SecretsCollectionIDOption,
-    yes: Annotated[
-        bool,
-        typer.Option(
-            "--yes",
-            "-y",
-            help="Agree to deletion confirmation prompt. Useful for non-interactive sessions.",
-        ),
-    ] = False,
+    yes: YesOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/shadow/delete.py
+++ b/nextmv/nextmv/cli/cloud/shadow/delete.py
@@ -2,13 +2,11 @@
 This module defines the cloud shadow delete command for the Nextmv CLI.
 """
 
-from typing import Annotated
-
 import typer
 
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import confirmation, info, success
-from nextmv.cli.options import AppIDOption, ProfileOption, ShadowTestIDOption
+from nextmv.cli.options import AppIDOption, ProfileOption, ShadowTestIDOption, YesOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -18,14 +16,7 @@ app = typer.Typer()
 def delete(
     app_id: AppIDOption,
     shadow_test_id: ShadowTestIDOption,
-    yes: Annotated[
-        bool,
-        typer.Option(
-            "--yes",
-            "-y",
-            help="Agree to deletion confirmation prompt. Useful for non-interactive sessions.",
-        ),
-    ] = False,
+    yes: YesOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/sso/delete.py
+++ b/nextmv/nextmv/cli/cloud/sso/delete.py
@@ -2,13 +2,11 @@
 This module defines the cloud sso delete command for the Nextmv CLI.
 """
 
-from typing import Annotated
-
 import typer
 
 from nextmv.cli.configuration.config import build_sso_config
 from nextmv.cli.message import confirmation, info, success
-from nextmv.cli.options import ProfileOption
+from nextmv.cli.options import ProfileOption, YesOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -16,14 +14,7 @@ app = typer.Typer()
 
 @app.command()
 def delete(
-    yes: Annotated[
-        bool,
-        typer.Option(
-            "--yes",
-            "-y",
-            help="Agree to deletion confirmation prompt. Useful for non-interactive sessions.",
-        ),
-    ] = False,
+    yes: YesOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/sso/domain/delete.py
+++ b/nextmv/nextmv/cli/cloud/sso/domain/delete.py
@@ -8,7 +8,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_sso_config
 from nextmv.cli.message import confirmation, in_progress, info, success
-from nextmv.cli.options import ProfileOption
+from nextmv.cli.options import ProfileOption, YesOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -25,14 +25,7 @@ def delete(
             metavar="DOMAIN",
         ),
     ],
-    yes: Annotated[
-        bool,
-        typer.Option(
-            "--yes",
-            "-y",
-            help="Agree to deletion confirmation prompt. Useful for non-interactive sessions.",
-        ),
-    ] = False,
+    yes: YesOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/switchback/delete.py
+++ b/nextmv/nextmv/cli/cloud/switchback/delete.py
@@ -2,13 +2,11 @@
 This module defines the cloud switchback delete command for the Nextmv CLI.
 """
 
-from typing import Annotated
-
 import typer
 
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import confirmation, info, success
-from nextmv.cli.options import AppIDOption, ProfileOption, SwitchbackTestIDOption
+from nextmv.cli.options import AppIDOption, ProfileOption, SwitchbackTestIDOption, YesOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -18,14 +16,7 @@ app = typer.Typer()
 def delete(
     app_id: AppIDOption,
     switchback_test_id: SwitchbackTestIDOption,
-    yes: Annotated[
-        bool,
-        typer.Option(
-            "--yes",
-            "-y",
-            help="Agree to deletion confirmation prompt. Useful for non-interactive sessions.",
-        ),
-    ] = False,
+    yes: YesOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/version/delete.py
+++ b/nextmv/nextmv/cli/cloud/version/delete.py
@@ -2,13 +2,11 @@
 This module defines the cloud version delete command for the Nextmv CLI.
 """
 
-from typing import Annotated
-
 import typer
 
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import confirmation, info, success
-from nextmv.cli.options import AppIDOption, ProfileOption, VersionIDOption
+from nextmv.cli.options import AppIDOption, ProfileOption, VersionIDOption, YesOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -18,14 +16,7 @@ app = typer.Typer()
 def delete(
     app_id: AppIDOption,
     version_id: VersionIDOption,
-    yes: Annotated[
-        bool,
-        typer.Option(
-            "--yes",
-            "-y",
-            help="Agree to deletion confirmation prompt. Useful for non-interactive sessions.",
-        ),
-    ] = False,
+    yes: YesOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/configuration/delete.py
+++ b/nextmv/nextmv/cli/configuration/delete.py
@@ -8,6 +8,7 @@ import typer
 
 from nextmv.cli.configuration.config import load_config, save_config
 from nextmv.cli.message import confirmation, error, info, success
+from nextmv.cli.options import YesOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -25,14 +26,7 @@ def delete(
             metavar="PROFILE_NAME",
         ),
     ],
-    yes: Annotated[
-        bool,
-        typer.Option(
-            "--yes",
-            "-y",
-            help="Agree to deletion confirmation prompt. Useful for non-interactive sessions.",
-        ),
-    ] = False,
+    yes: YesOption = False,
 ) -> None:
     """
     Delete a profile from the configuration.

--- a/nextmv/nextmv/cli/local/app/delete.py
+++ b/nextmv/nextmv/cli/local/app/delete.py
@@ -3,12 +3,11 @@ This module defines the local app delete command for the Nextmv CLI.
 """
 
 import os
-from typing import Annotated
 
 import typer
 
 from nextmv.cli.message import confirmation, info, success, warning
-from nextmv.cli.options import LocalAppIDOption, LocalAppSrcOption
+from nextmv.cli.options import LocalAppIDOption, LocalAppSrcOption, YesOption
 from nextmv.local.registry import Registry
 
 # Set up subcommand application.
@@ -19,14 +18,7 @@ app = typer.Typer()
 def delete(
     app_id: LocalAppIDOption = None,
     app_src: LocalAppSrcOption = None,
-    yes: Annotated[
-        bool,
-        typer.Option(
-            "--yes",
-            "-y",
-            help="Agree to deletion confirmation prompt. Useful for non-interactive sessions.",
-        ),
-    ] = False,
+    yes: YesOption = False,
 ) -> None:
     """
     Deletes a Nextmv application from the local registry.

--- a/nextmv/nextmv/cli/options.py
+++ b/nextmv/nextmv/cli/options.py
@@ -304,3 +304,15 @@ LocalAppSrcOption = Annotated[
         metavar="APP_SRC",
     ),
 ]
+
+# Yes option - can be used in any command that requires a deletion confirmation.
+# Define it as follows in commands or callbacks, as necessary:
+# yes: YesOption = False
+YesOption = Annotated[
+    bool,
+    typer.Option(
+        "--yes",
+        "-y",
+        help="Agree to deletion confirmation prompt. Useful for non-interactive sessions.",
+    ),
+]

--- a/nextmv/nextmv/cloud/application/_run.py
+++ b/nextmv/nextmv/cloud/application/_run.py
@@ -51,6 +51,30 @@ class ApplicationRunMixin:
     Mixin class for managing app runs within an application.
     """
 
+    def delete_run(self: "Application", run_id: str) -> None:
+        """
+        Delete a run.
+
+        Parameters
+        ----------
+        run_id : str
+            ID of the run to delete.
+
+        Raises
+        ------
+        requests.HTTPError
+            If the response status code is not 2xx.
+
+        Examples
+        --------
+        >>> app.delete_run("run-456")
+        """
+
+        _ = self.client.request(
+            method="DELETE",
+            endpoint=f"{self.endpoint}/runs/{run_id}",
+        )
+
     def cancel_run(self: "Application", run_id: str) -> None:
         """
         Cancel a run.

--- a/nextmv/nextmv/cloud/application/_run.py
+++ b/nextmv/nextmv/cloud/application/_run.py
@@ -911,6 +911,59 @@ class ApplicationRunMixin:
             `output_dir_path`.
         """
 
+        # Get the run information to check how we need to handle the output.
+        run_information = self.run_metadata(run_id=run_id)
+        output_format = run_information.metadata.format.format_output.output_type
+        is_json = output_format == OutputFormat.JSON
+
+        # We need to specify `output_dir_path` for non-JSON.
+        if not is_json and (not output_dir_path or output_dir_path == ""):
+            raise ValueError(
+                f"Output format is {output_format.value} (not json), an `output_dir_path` must be provided.",
+            )
+
+        # If the output is large or non-JSON, we need to fetch it from the
+        # download URL.
+        query_params = None
+        use_presigned_url = False
+        if not is_json or run_information.metadata.output_size > _MAX_RUN_SIZE:
+            query_params = {"format": "url"}
+            use_presigned_url = True
+
+        response = self.client.request(
+            method="GET",
+            endpoint=f"{self.endpoint}/runs/{run_id}/output",
+            query_params=query_params,
+        )
+        json_resp = response.json()
+
+        # If we don't need to use a presigned URL, we can return the output
+        # directly.
+        if not use_presigned_url:
+            return json_resp
+
+        download_url = DownloadURL.from_dict(json_resp["output"])
+        download_response = self.client.request(
+            method="GET",
+            endpoint=download_url.url,
+            headers={"Content-Type": "application/json"},
+        )
+
+        # If the run is JSON, we can just return the large output immediately.
+        if is_json:
+            return download_response.json()
+
+        # At this point, we know that we are working with non-JSON data.
+        if not os.path.exists(output_dir_path):
+            os.makedirs(output_dir_path, exist_ok=True)
+
+        # Save .tar.gz file to a temp directory and extract contents to output_dir_path
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            temp_tar_path = os.path.join(tmpdirname, f"{run_id}.tar.gz")
+            with open(temp_tar_path, "wb") as f:
+                f.write(download_response.content)
+            shutil.unpack_archive(temp_tar_path, output_dir_path)
+
     def run_result(self: "Application", run_id: str, output_dir_path: str | None = ".") -> RunResult:
         """
         Get the result of a run.

--- a/nextmv/nextmv/cloud/application/_run.py
+++ b/nextmv/nextmv/cloud/application/_run.py
@@ -938,8 +938,10 @@ class ApplicationRunMixin:
         json_resp = response.json()
 
         # If we don't need to use a presigned URL, we can return the output
-        # directly.
-        if not use_presigned_url:
+        # directly. Only attempt to download the output once the run has
+        # reached a final state. This avoids hitting the pre-signed URL for
+        # queued or running executions.
+        if not use_presigned_url or not run_information.metadata.run_is_finalized():
             return json_resp
 
         download_url = DownloadURL.from_dict(json_resp)
@@ -1328,8 +1330,10 @@ class ApplicationRunMixin:
         result.console_url = self.__console_url(result.id)
 
         # If we don't need to use a presigned URL, we can return the output
-        # directly.
-        if not use_presigned_url:
+        # directly. Only attempt to download the output once the run has
+        # reached a final state. This avoids hitting the `/runs/{id}/output`
+        # endpoint for queued or running executions.
+        if not use_presigned_url or not run_information.metadata.run_is_finalized():
             return result
 
         output = self.run_output(run_id=run_id, output_dir_path=output_dir_path)

--- a/nextmv/nextmv/cloud/application/_run.py
+++ b/nextmv/nextmv/cloud/application/_run.py
@@ -942,7 +942,7 @@ class ApplicationRunMixin:
         if not use_presigned_url:
             return json_resp
 
-        download_url = DownloadURL.from_dict(json_resp["output"])
+        download_url = DownloadURL.from_dict(json_resp)
         download_response = self.client.request(
             method="GET",
             endpoint=download_url.url,
@@ -1327,33 +1327,14 @@ class ApplicationRunMixin:
         result = RunResult.from_dict(response.json())
         result.console_url = self.__console_url(result.id)
 
-        if not use_presigned_url or result.metadata.status_v2 != StatusV2.succeeded:
+        # If we don't need to use a presigned URL, we can return the output
+        # directly.
+        if not use_presigned_url:
             return result
 
-        download_url = DownloadURL.from_dict(response.json()["output"])
-        download_response = self.client.request(
-            method="GET",
-            endpoint=download_url.url,
-            headers={"Content-Type": "application/json"},
-        )
-
-        # See whether we can attach the output directly or need to save to the given
-        # directory
-        if run_information.metadata.format.format_output.output_type != OutputFormat.JSON:
-            if not output_dir_path or output_dir_path == "":
-                raise ValueError(
-                    "If the output format is not JSON, an output_dir_path must be provided.",
-                )
-            if not os.path.exists(output_dir_path):
-                os.makedirs(output_dir_path, exist_ok=True)
-            # Save .tar.gz file to a temp directory and extract contents to output_dir_path
-            with tempfile.TemporaryDirectory() as tmpdirname:
-                temp_tar_path = os.path.join(tmpdirname, f"{run_id}.tar.gz")
-                with open(temp_tar_path, "wb") as f:
-                    f.write(download_response.content)
-                shutil.unpack_archive(temp_tar_path, output_dir_path)
-        else:
-            result.output = download_response.json()
+        output = self.run_output(run_id=run_id, output_dir_path=output_dir_path)
+        if output is not None:
+            result.output = output
 
         return result
 

--- a/nextmv/nextmv/cloud/application/_run.py
+++ b/nextmv/nextmv/cloud/application/_run.py
@@ -22,14 +22,7 @@ from nextmv.cloud.url import DownloadURL
 from nextmv.input import Input, InputFormat
 from nextmv.logger import log
 from nextmv.options import Options
-from nextmv.output import (
-    ASSETS_KEY,
-    STATISTICS_KEY,
-    Asset,
-    Output,
-    OutputFormat,
-    Statistics,
-)
+from nextmv.output import ASSETS_KEY, STATISTICS_KEY, Asset, Output, OutputFormat, Statistics
 from nextmv.polling import DEFAULT_POLLING_OPTIONS, PollingOptions, poll
 from nextmv.run import (
     ExternalRunResult,
@@ -867,6 +860,33 @@ class ApplicationRunMixin:
 
         return sorted(logs, key=lambda log: log.timestamp)
 
+    def run_output(self: "Application", run_id: str, output_dir_path: str | None = ".") -> dict[str, Any] | None:
+        """
+        Gets the output, and only the output, of a run.
+
+        This method is different from the `run_result` method, which retrieves
+        the complete result of a run, including the run output. This method is
+        useful when you only need the output of a run and not the complete
+        result with metadata.
+
+        Parameters
+        ----------
+        run_id : str
+            ID of the run to retrieve the output for.
+
+        output_dir_path : Optional[str], default="."
+            Path to a directory where non-JSON output files will be saved. This is
+            required if the output is non-JSON. If the directory does not exist, it
+            will be created. Uses the current directory by default.
+
+        Returns
+        -------
+        dict[str, Any] | None
+            Output of the run as a dictionary. If the output format is non-JSON,
+            the method returns None after saving the output files to the specified
+            `output_dir_path`.
+        """
+
     def run_result(self: "Application", run_id: str, output_dir_path: str | None = ".") -> RunResult:
         """
         Get the result of a run.
@@ -1212,6 +1232,7 @@ class ApplicationRunMixin:
         output size exceeds _MAX_RUN_SIZE. If it does, the method will request
         a download URL and fetch the output data separately.
         """
+
         query_params = None
         use_presigned_url = False
         if (

--- a/nextmv/nextmv/run.py
+++ b/nextmv/nextmv/run.py
@@ -384,6 +384,7 @@ class StatisticsIndicator(BaseModel):
     value: Any
     """Value of the indicator."""
 
+
 class RunInfoStatistics(BaseModel):
     """
     !!! warning
@@ -438,6 +439,7 @@ class RunInfoStatistics(BaseModel):
     indicators: list[StatisticsIndicator] | None = None
     """List of statistics indicators."""
 
+
 class MetricsIndicator(BaseModel):
     """
     Metrics indicator of a run.
@@ -476,6 +478,7 @@ class MetricsIndicator(BaseModel):
     """Name of the indicator."""
     value: Any
     """Value of the indicator."""
+
 
 class RunInfoMetrics(BaseModel):
     """
@@ -720,6 +723,7 @@ class Run(BaseModel):
     input_set_id: str | None = None
     """ID of the input set associated with the run."""
 
+
 class RunTrackingMetadata(BaseModel):
     """
     Metadata elements for tracking elements of the run that
@@ -744,6 +748,7 @@ class RunTrackingMetadata(BaseModel):
     """ID of the run that was "cloned" to generate a new run."""
     input_id: str | None = None
     """ID of the managed input used to make the run."""
+
 
 class Metadata(BaseModel):
     """

--- a/nextmv/tests/integration/cloud/test_integration_cloud.py
+++ b/nextmv/tests/integration/cloud/test_integration_cloud.py
@@ -246,6 +246,9 @@ class CloudIntegrationWorkflow(FlowSpec):
             run_input = app.run_input(run_id=run.id)
             assert run_input == input_data
 
+            run_output = app.run_output(run_id=run.id)
+            assert run_output is not None
+
             logs = app.run_logs(run_id=run.id)
             assert logs.log is not None and logs.log != ""
 
@@ -462,7 +465,7 @@ class CloudIntegrationWorkflow(FlowSpec):
         metadata = app.shadow_test_metadata(shadow_test_id=shadow_test.shadow_test_id)
         assert metadata.status in {
             cloud.ExperimentStatus.COMPLETED,
-            cloud.ExperimentStatus.STOPPING,    # Cancelation is asynchronous; test may be in temporary STOPPING state.
+            cloud.ExperimentStatus.STOPPING,  # Cancelation is asynchronous; test may be in temporary STOPPING state.
         }
 
         # Get the results of the shadow test and assert that it registered the
@@ -541,7 +544,7 @@ class CloudIntegrationWorkflow(FlowSpec):
         metadata = app.switchback_test_metadata(switchback_test_id=switchback_test.switchback_test_id)
         assert metadata.status in {
             cloud.ExperimentStatus.COMPLETED,
-            cloud.ExperimentStatus.STOPPING,    # Cancelation is asynchronous; test may be in temporary STOPPING state.
+            cloud.ExperimentStatus.STOPPING,  # Cancelation is asynchronous; test may be in temporary STOPPING state.
         }
 
         # Get the results of the switchback test and assert that it registered the


### PR DESCRIPTION
# Description

- When a `multi-file` run failed, it was assumed that it produced no outputs. This PR makes it possible to retrieve outputs on failed runs. When using the `Application.run_resultxxx` method in the SDK or the `nextmv cloud run get` command in the CLI, a failed `multi-file` run will still attempt to download output files.
- Adds the `Application.delete_run` method to the SDK and the `nextmv cloud run delete` command to the CLI to delete runs.
- Adds the `Application.run_output` method to the SDK specifically for getting a run's output.
- Small refactor to use a `YesOption` on deletion commands in the CLI.

```bash
$ nextmv cloud run get -a foo -r latest-grFIVv5vg -o my_output
⏳ Getting run results...
✅ Run outputs saved to my_output. Here is the metadata.
{
  "description": "",
  "id": "latest-grFIVv5vg",
  "metadata": {
    "application_id": "foo",
    "application_instance_id": "latest",
    "application_version_id": "",
    "created_at": "2026-03-20T20:11:10Z",
    "duration": 9630.0,
    "error": "exit status 1",
    "input_size": 5112.0,
    "output_size": 4792.0,
    "format": {
      "input": {
        "type": "multi-file"
      },
      "output": {
        "type": "multi-file"
      }
    },
    "status_v2": "failed"
  },
  "name": "",
  "user_email": "sebastian@nextmv.io",
  "console_url": "https://cloud.nextmv.io/app/foo/run/latest-grFIVv5vg?view=details",
  "error_log": {
    "error": "exit status 1",
    "stdout": "\u0....",
    "stderr": "Solving multi-knapsack problem:\n  - items: 11\n  - knapsacks: 2\nTraceback (most recent call last):\n  File \"/tmp/binary1958180214/main.py\", line 153, in <module>\n    main()\n  File \"/tmp/binary1958180214/main.py\", line 58, in main\n    raise Exception(\"All praise the mighty jumpy mcsolver! 🦘✨\")\nException: All praise the mighty jumpy mcsolver! 🦘✨\n[nextmv] file does not exist for assets skipping content\n\nexit status 1\n"
  }
}
```

And when inspecting the contents of `my_output`:
```bash
$ tree my_output
my_output
├── assignments.csv
└── assignments.xlsx

1 directory, 2 files
```

Note that before, the `my_output` folder wouldn't be populated.