### PR TITLE
Fix bug in creating an input set solely with run IDs in `nextmv cloud input-set create` CLI cmd

### DIFF
--- a/nextmv/nextmv/cli/cloud/input_set/create.py
+++ b/nextmv/nextmv/cli/cloud/input_set/create.py
@@ -146,13 +146,14 @@ def create(
     if input_set_id is None:
         input_set_id = safe_id("input-set")
 
-    managed_inputs = []
+    managed_input_list = []
     if managed_inputs is not None:
         for d in json.loads(managed_inputs):
             i = ManagedInput.from_dict(d)
             if i is None:
                 error(f"[magenta]{d}[/magenta] is not a valid [yellow]ManagedInput[/yellow]")
-            managed_inputs.append(i)
+
+            managed_input_list.append(i)
 
     input_set = cloud_app.new_input_set(
         input_set_id,
@@ -163,6 +164,6 @@ def create(
         start_time=start_time,
         end_time=end_time,
         maximum_runs=maximum_runs,
-        inputs=managed_inputs,
+        inputs=managed_input_list or None,
     )
     print_json(input_set.to_dict())


### PR DESCRIPTION
# Description

`managed_inputs` was defined as `[]`, shadowing the command variable and thus never making it not `None`. Managed inputs were always going to be deserialized as a consequence, showing this error:

```
the JSON object must be str, bytes or bytearray, not list.
```

Now, a different variable is used to separate the received `managed_inputs` vs the ones that are parsed: `managed_input_list`.