### PR TITLE
Improve `bash` detection from `_get_shell_command_elements`

### DIFF
--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -1,5 +1,11 @@
 name: python lint
-on: [push]
+on:
+  push:
+    branches: [develop]
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+permissions:
+  contents: read
 jobs:
   python-lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,5 +1,11 @@
 name: unit tests
-on: [push]
+on:
+  push:
+    branches: [develop]
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+permissions:
+  contents: read
 jobs:
   test:
     runs-on: ${{ matrix.platform }}

--- a/nextmv/nextmv/cloud/package.py
+++ b/nextmv/nextmv/cloud/package.py
@@ -134,8 +134,9 @@ def _run_build_command(
 def _get_shell_command_elements(pre_push_command):
     """Get the shell command elements based on the operating system."""
     # Check if we're in a Unix-like shell (including MINGW on Windows)
-    if "SHELL" in os.environ and shutil.which("bash"):
-        return ["bash", "-c", pre_push_command]
+    bash = shutil.which("bash")
+    if "SHELL" in os.environ and bash:
+        return [bash, "-c", pre_push_command]
     # Default to cmd on Windows
     elif platform.system() == "Windows":
         return ["cmd", "/c", pre_push_command]


### PR DESCRIPTION
# Changes

Previously, if `SHELL` is set and `shutil.which("bash")` exists `bash` would be used as the executable. 

This PR modifies `_get_shell_command_elements` to use `shutil.which("bash")` itself as the executable to ensure the correct `bash` is used from a separate process. 

This assumes that `SHELL` points to `bash`, but that is an assumption already made in the original code.

# Testing

I made the changes to `nextmv` locally and ran:

```
uvx --from <path> nextmv cloud app push
```

I also ran:

```
uv run pytest tests/test_package.py
```

And 

```
uv run pytest tests/integration -s
```

Closes #262 