### PR TITLE
Adds enum for account member role

### DIFF
--- a/nextmv/nextmv/__init__.py
+++ b/nextmv/nextmv/__init__.py
@@ -1,6 +1,7 @@
 """Nextmv Python SDK."""
 
 from .__about__ import __version__
+from .account import AccountMemberRole as AccountMemberRole
 from .base_model import BaseModel as BaseModel
 from .base_model import from_dict as from_dict
 from .content_format import ContentFormat as ContentFormat

--- a/nextmv/nextmv/account.py
+++ b/nextmv/nextmv/account.py
@@ -1,0 +1,50 @@
+"""
+Provides role enum for Nextmv accounts.
+
+This module defines enumerations for representing member roles within
+a Nextmv account.
+
+Classes
+-------
+AccountMemberRole
+    Represents the role of a member in a Nextmv account.
+"""
+
+from enum import Enum
+
+class AccountMemberRole(str, Enum):
+    """
+    The role type of an `AccountMember` represented as a string.
+
+    You can import the `AccountMemberRole` class directly from `nextmv`:
+
+    ```python
+    from nextmv import AccountMemberRole
+    ```
+
+    This enum specifies the supported roles for users in Nextmv accounts.
+
+    Attributes
+    ----------
+    ROOT : str
+        The role of the owner of the account
+    ADMIN : str
+        The role of administrators of the account
+    DEVELOPER: str
+        The role of developers of the account
+    OPERATOR: str
+        The role of operators of the account
+    VIEWER: str
+        The role of viewers of the account
+    """
+
+    ROOT = "root"
+    """The role of the owner of the account"""
+    ADMIN = "admin"
+    """The role of administrators of the account"""
+    DEVELOPER = "developer"
+    """The role of developers of the account"""
+    OPERATOR = "operator"
+    """The role of operators of the account"""
+    VIEWER = "viewer"
+    """The role of viewers of the account"""

--- a/nextmv/nextmv/account.py
+++ b/nextmv/nextmv/account.py
@@ -12,6 +12,7 @@ AccountMemberRole
 
 from enum import Enum
 
+
 class AccountMemberRole(str, Enum):
     """
     The role type of an `AccountMember` represented as a string.

--- a/nextmv/nextmv/cloud/account.py
+++ b/nextmv/nextmv/cloud/account.py
@@ -20,6 +20,7 @@ from datetime import datetime
 from pydantic import AliasChoices, Field
 
 from nextmv import deprecated
+from nextmv.account import AccountMemberRole
 from nextmv.base_model import BaseModel
 from nextmv.cloud.client import Client
 from nextmv.status import StatusV2
@@ -137,7 +138,6 @@ class Queue(BaseModel):
     runs: list[QueuedRun]
     """List of runs in the queue."""
 
-
 class AccountMember(BaseModel):
     """
     A member of a Nextmv Cloud account (organization).
@@ -173,11 +173,10 @@ class AccountMember(BaseModel):
 
     email: str | None = None
     """Email of the account member."""
-    role: str | None = None
+    role: AccountMemberRole | None = None
     """Role of the account member."""
     pending_invite: bool | None = None
     """Whether the member has a pending invite."""
-
 
 class Account(BaseModel):
     """

--- a/nextmv/nextmv/manifest.py
+++ b/nextmv/nextmv/manifest.py
@@ -64,6 +64,7 @@ from typing import Any
 import yaml
 from pydantic import AliasChoices, Field, field_validator
 
+from nextmv.account import AccountMemberRole
 from nextmv.base_model import BaseModel
 from nextmv.content_format import ContentFormat
 from nextmv.input import InputFormat
@@ -461,6 +462,9 @@ class ManifestOptionUI(BaseModel):
         A list of team roles to which this option will be hidden in the UI. For
         example, if you want to hide an option from the "operator" role, you can
         pass `hidden_from=["operator"]`.
+
+        These are validated during API handling to ensure they are one of:
+        ["root", "admin", "developer", "operator", "viewer"]
     display_name : str, optional
         An optional display name for the option. This is useful for making
         the option more user-friendly in the UI.
@@ -475,7 +479,7 @@ class ManifestOptionUI(BaseModel):
 
     control_type: str | None = None
     """The type of control to use for the option in the Nextmv Cloud UI."""
-    hidden_from: list[str] | None = None
+    hidden_from: list[AccountMemberRole] | None = None
     """A list of team roles for which this option will be hidden in the UI."""
     display_name: str | None = None
     """An optional display name for the option. This is useful for making

--- a/nextmv/nextmv/manifest.py
+++ b/nextmv/nextmv/manifest.py
@@ -458,13 +458,13 @@ class ManifestOptionUI(BaseModel):
         it is used in the Nextmv Cloud UI to define the type of control to use for
         the option. This will be validated by the Nextmv Cloud, and availability
         is based on option_type.
-    hidden_from : list[str], optional
+    hidden_from : list[AccountMemberRole], optional
         A list of team roles to which this option will be hidden in the UI. For
         example, if you want to hide an option from the "operator" role, you can
         pass `hidden_from=["operator"]`.
 
-        These are validated during API handling to ensure they are one of:
-        ["root", "admin", "developer", "operator", "viewer"]
+        Each roles is validated during API handling to ensure they are one of:
+        `"root"`, `"admin"`, `"developer"`, `"operator"`, or `"viewer"`
     display_name : str, optional
         An optional display name for the option. This is useful for making
         the option more user-friendly in the UI.

--- a/nextmv/nextmv/options.py
+++ b/nextmv/nextmv/options.py
@@ -75,7 +75,7 @@ class Option:
         it is used in the Nextmv Cloud UI to define the type of control to use for
         the option. This will be validated by the Nextmv Cloud, and availability
         is based on options_type.
-    hidden_from : list[str], optional
+    hidden_from : list[AccountMemberRole], optional
         A list of team roles to which this option will be hidden in the UI. For
         example, if you want to hide an option from the "operator" role, you can
         pass `hidden_from=["operator"]`.

--- a/nextmv/nextmv/options.py
+++ b/nextmv/nextmv/options.py
@@ -23,6 +23,7 @@ import os
 from dataclasses import dataclass
 from typing import Any
 
+from nextmv.account import AccountMemberRole
 from nextmv.base_model import BaseModel
 
 
@@ -132,7 +133,7 @@ class Option:
     the option. This will be validated by the Nextmv Cloud, and availability
     is based on options_type.
     """
-    hidden_from: list[str] | None = None
+    hidden_from: list[AccountMemberRole] | None = None
     """
     A list of team roles for which this option will be hidden in the UI. For
     example, if you want to hide an option from the "operator" role, you can


### PR DESCRIPTION
# Description

Adds enum for member roles to increase documentation coverage.

## Changes

- `nextmv/nextmv/account.py`
    - Added.
- `nextmv/nextmv/__init__.py`
    - Exports new enum
- `nextmv/nextmv/cloud/account.py`, `nextmv/nextmv/manifest.py`, and `nextmv/nextmv/options.py`
    - Replaces member role with enum where it is used.
- Adds doc comments

## Testing

Non-marketplace integration tests pass when run against local environment.

## Dependencies

None.

## Security

None.