### PR TITLE
Allows override of endpoint via env var

### DIFF
--- a/nextmv/nextmv/__about__.py
+++ b/nextmv/nextmv/__about__.py
@@ -1,1 +1,1 @@
-__version__ = "v1.4.1.dev1"
+__version__ = "v1.4.1.dev2"

--- a/nextmv/nextmv/__about__.py
+++ b/nextmv/nextmv/__about__.py
@@ -1,1 +1,1 @@
-__version__ = "v1.4.0"
+__version__ = "v1.4.1.dev1"

--- a/nextmv/nextmv/cli/configuration/create.py
+++ b/nextmv/nextmv/cli/configuration/create.py
@@ -39,6 +39,8 @@ def create(
             "--endpoint",
             "-e",
             hidden=True,
+            envvar="NEXTMV_ENDPOINT",
+            metavar="NEXTMV_ENDPOINT",
         ),
     ] = DEFAULT_ENDPOINT,
     profile: Annotated[  # Similar to nextmv.cli.options.ProfileOption but with different help text.

--- a/nextmv/nextmv/cloud/client.py
+++ b/nextmv/nextmv/cloud/client.py
@@ -138,7 +138,7 @@ class Client:
     console_url: str = "https://cloud.nextmv.io"
     """URL of the Nextmv Cloud console."""
 
-    def __post_init__(self):
+    def __post_init__(self):  # noqa: C901
         """
         Initializes the client after dataclass construction.
 

--- a/nextmv/nextmv/cloud/client.py
+++ b/nextmv/nextmv/cloud/client.py
@@ -161,6 +161,10 @@ class Client:
         if not self.url:
             self.url = "https://api.cloud.nextmv.io"
 
+        endpoint_env = os.getenv("NEXTMV_ENDPOINT")
+        if endpoint_env is not None:
+            self.url = f"https://{endpoint_env}"
+
         if self.api_key is not None and self.api_key != "":
             self._set_headers_api_key(self.api_key)
             return


### PR DESCRIPTION
# Description

Allows override of the endpoint via `NEXTMV_ENDPOINT` env var. This is mostly useful internally or with custom deployments (it's why the flag stays hidden to avoid unnecessary confusion).

## Changes

- Allows override of the endpoint via `NEXTMV_ENDPOINT` env var.