### PR TITLE
Make `Client` optional for an `Application`, allow `NEXMTV_ENDPOINT`

### DIFF
--- a/nextmv/CONTRIBUTING.md
+++ b/nextmv/CONTRIBUTING.md
@@ -586,7 +586,7 @@ to use it.
           $ [dim]nextmv cloud app get --app-id hare-app --output app.json[/dim]
       """
 
-      client = build_client(profile)
+      client = Client(profile=profile)
       in_progress("Getting application...")
 
       cloud_app = Application.get(

--- a/nextmv/nextmv/__about__.py
+++ b/nextmv/nextmv/__about__.py
@@ -1,1 +1,1 @@
-__version__ = "v1.4.0"
+__version__ = "v1.4.1.dev3"

--- a/nextmv/nextmv/__about__.py
+++ b/nextmv/nextmv/__about__.py
@@ -1,1 +1,1 @@
-__version__ = "v1.4.1.dev3"
+__version__ = "v1.4.1.dev4"

--- a/nextmv/nextmv/cli/cloud/account/create.py
+++ b/nextmv/nextmv/cli/cloud/account/create.py
@@ -6,10 +6,10 @@ from typing import Annotated
 
 import typer
 
-from nextmv.cli.configuration.config import build_client
 from nextmv.cli.message import in_progress, print_json
 from nextmv.cli.options import ProfileOption
 from nextmv.cloud.account import Account
+from nextmv.cloud.client import Client
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -70,7 +70,7 @@ def create(
             --admins "thumper@forestmail.com,flopsy@warren.io"[/dim]
     """
 
-    cloud_client = build_client(profile)
+    client = Client(profile=profile)
     in_progress(msg="Creating account...")
 
     admin_list = []
@@ -82,5 +82,5 @@ def create(
         for sub_admin in sub_admins:
             admin_list.append(sub_admin.strip())
 
-    account = Account.new(client=cloud_client, name=name, admins=admin_list)
+    account = Account.new(client=client, name=name, admins=admin_list)
     print_json(account.to_dict())

--- a/nextmv/nextmv/cli/cloud/account/get.py
+++ b/nextmv/nextmv/cli/cloud/account/get.py
@@ -7,10 +7,10 @@ from typing import Annotated
 
 import typer
 
-from nextmv.cli.configuration.config import build_client
 from nextmv.cli.message import in_progress, print_json, success
 from nextmv.cli.options import AccountIDOption, ProfileOption
 from nextmv.cloud.account import Account
+from nextmv.cloud.client import Client
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -46,7 +46,7 @@ def get(
         $ [dim]nextmv cloud account get --account-id cottontail-couriers --output account.json[/dim]
     """
 
-    client = build_client(profile)
+    client = Client(profile=profile)
     in_progress(msg="Getting account...")
 
     cloud_account = Account.get(

--- a/nextmv/nextmv/cli/cloud/app/create.py
+++ b/nextmv/nextmv/cli/cloud/app/create.py
@@ -6,10 +6,10 @@ from typing import Annotated
 
 import typer
 
-from nextmv.cli.configuration.config import build_client
 from nextmv.cli.message import in_progress, print_json
 from nextmv.cli.options import ProfileOption
 from nextmv.cloud.application import Application
+from nextmv.cloud.client import Client
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -121,7 +121,7 @@ def create(
             --default-experiment-instance experiment-v1[/dim]
     """
 
-    client = build_client(profile)
+    client = Client(profile=profile)
     if exist_ok:
         in_progress(msg="Creating or getting application...")
     else:

--- a/nextmv/nextmv/cli/cloud/app/exists.py
+++ b/nextmv/nextmv/cli/cloud/app/exists.py
@@ -4,10 +4,10 @@ This module defines the cloud app exists command for the Nextmv CLI.
 
 import typer
 
-from nextmv.cli.configuration.config import build_client
 from nextmv.cli.message import in_progress, print_json
 from nextmv.cli.options import AppIDOption, ProfileOption
 from nextmv.cloud.application import Application
+from nextmv.cloud.client import Client
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -34,7 +34,7 @@ def exists(
         $ [dim]nextmv cloud app exists --app-id hare-app --profile hare[/dim]
     """
 
-    client = build_client(profile)
+    client = Client(profile=profile)
     in_progress(msg="Checking if application exists...")
 
     ok = Application.exists(

--- a/nextmv/nextmv/cli/cloud/app/get.py
+++ b/nextmv/nextmv/cli/cloud/app/get.py
@@ -7,10 +7,10 @@ from typing import Annotated
 
 import typer
 
-from nextmv.cli.configuration.config import build_client
 from nextmv.cli.message import in_progress, print_json, success
 from nextmv.cli.options import AppIDOption, ProfileOption
 from nextmv.cloud.application import Application
+from nextmv.cloud.client import Client
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -46,7 +46,7 @@ def get(
         $ [dim]nextmv cloud app get --app-id hare-app --output app.json[/dim]
     """
 
-    client = build_client(profile)
+    client = Client(profile=profile)
     in_progress(msg="Getting application...")
 
     cloud_app = Application.get(client=client, id=app_id)

--- a/nextmv/nextmv/cli/cloud/app/list.py
+++ b/nextmv/nextmv/cli/cloud/app/list.py
@@ -7,10 +7,10 @@ from typing import Annotated
 
 import typer
 
-from nextmv.cli.configuration.config import build_client
 from nextmv.cli.message import in_progress, print_json, success
 from nextmv.cli.options import ProfileOption
 from nextmv.cloud.application import list_applications
+from nextmv.cloud.client import Client
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -44,7 +44,7 @@ def list(
         $ [dim]nextmv cloud app list --output apps.json[/dim]
     """
 
-    client = build_client(profile)
+    client = Client(profile=profile)
     in_progress(msg="Listing applications...")
 
     cloud_apps = list_applications(client)

--- a/nextmv/nextmv/cli/cloud/marketplace/app/create.py
+++ b/nextmv/nextmv/cli/cloud/marketplace/app/create.py
@@ -6,9 +6,9 @@ from typing import Annotated
 
 import typer
 
-from nextmv.cli.configuration.config import build_client
 from nextmv.cli.message import in_progress, print_json
 from nextmv.cli.options import ProfileOption
+from nextmv.cloud.client import Client
 from nextmv.cloud.marketplace import MarketplaceApplication
 
 # Set up subcommand application.
@@ -128,7 +128,7 @@ def create(
             --features "real-time optimization"[/dim]
     """
 
-    client = build_client(profile)
+    client = Client(profile=profile)
     in_progress(msg="Creating application...")
     marketplace_app = MarketplaceApplication.new(
         client=client,

--- a/nextmv/nextmv/cli/cloud/marketplace/app/list.py
+++ b/nextmv/nextmv/cli/cloud/marketplace/app/list.py
@@ -7,9 +7,9 @@ from typing import Annotated
 
 import typer
 
-from nextmv.cli.configuration.config import build_client
 from nextmv.cli.message import in_progress, print_json, success
 from nextmv.cli.options import ProfileOption
+from nextmv.cloud.client import Client
 from nextmv.cloud.marketplace import list_marketplace_applications
 
 # Set up subcommand application.
@@ -60,7 +60,7 @@ def list(
         $ [dim]nextmv cloud marketplace app list --output apps.json[/dim]
     """
 
-    client = build_client(profile)
+    client = Client(profile=profile)
     in_progress(msg="Listing applications...")
 
     mkt_apps = list_marketplace_applications(client, partner_id)

--- a/nextmv/nextmv/cli/cloud/marketplace/subscription/create.py
+++ b/nextmv/nextmv/cli/cloud/marketplace/subscription/create.py
@@ -6,9 +6,9 @@ from typing import Annotated
 
 import typer
 
-from nextmv.cli.configuration.config import build_client
 from nextmv.cli.message import in_progress, print_json
 from nextmv.cli.options import ProfileOption
+from nextmv.cloud.client import Client
 from nextmv.cloud.marketplace import MarketplaceSubscription
 
 # Set up subcommand application.
@@ -48,7 +48,7 @@ def create(
             --profile hare[/dim]
     """
 
-    client = build_client(profile)
+    client = Client(profile=profile)
     in_progress(msg="Creating subscription...")
     subscription = MarketplaceSubscription.new(client, subscription_id)
     print_json(subscription.to_dict())

--- a/nextmv/nextmv/cli/cloud/marketplace/subscription/list.py
+++ b/nextmv/nextmv/cli/cloud/marketplace/subscription/list.py
@@ -7,9 +7,9 @@ from typing import Annotated
 
 import typer
 
-from nextmv.cli.configuration.config import build_client
 from nextmv.cli.message import in_progress, print_json, success
 from nextmv.cli.options import ProfileOption
+from nextmv.cloud.client import Client
 from nextmv.cloud.marketplace import list_marketplace_subscriptions
 
 # Set up subcommand application.
@@ -44,7 +44,7 @@ def list(
         $ [dim]nextmv cloud marketplace subscription list --output subscriptions.json[/dim]
     """
 
-    client = build_client(profile)
+    client = Client(profile=profile)
     in_progress(msg="Listing subscriptions...")
 
     subscriptions = list_marketplace_subscriptions(client)

--- a/nextmv/nextmv/cli/cloud/sso/create.py
+++ b/nextmv/nextmv/cli/cloud/sso/create.py
@@ -7,9 +7,9 @@ from typing import Annotated
 
 import typer
 
-from nextmv.cli.configuration.config import build_client
 from nextmv.cli.message import in_progress, success
 from nextmv.cli.options import ProfileOption
+from nextmv.cloud.client import Client
 from nextmv.cloud.sso import SSOConfiguration
 
 # Set up subcommand application.
@@ -99,11 +99,11 @@ def create(
     if stdin is not None:
         metadata_document = stdin
 
-    cloud_client = build_client(profile)
+    client = Client(profile=profile)
     in_progress(msg="Creating configuration...")
 
     SSOConfiguration.new(
-        client=cloud_client,
+        client=client,
         allow_non_domain_users=allow_non_domain_users,
         enabled=enabled,
         metadata_url=metadata_url,

--- a/nextmv/nextmv/cli/cloud/sso/get.py
+++ b/nextmv/nextmv/cli/cloud/sso/get.py
@@ -7,9 +7,9 @@ from typing import Annotated
 
 import typer
 
-from nextmv.cli.configuration.config import build_client
 from nextmv.cli.message import in_progress, print_json, success
 from nextmv.cli.options import ProfileOption
+from nextmv.cloud.client import Client
 from nextmv.cloud.sso import SSOConfiguration
 
 # Set up subcommand application.
@@ -44,7 +44,7 @@ def get(
         $ [dim]nextmv cloud sso get --output sso_config.json[/dim]
     """
 
-    client = build_client(profile)
+    client = Client(profile=profile)
     in_progress(msg="Getting SSO configuration...")
 
     sso_config = SSOConfiguration.get(client)

--- a/nextmv/nextmv/cli/community/clone.py
+++ b/nextmv/nextmv/cli/community/clone.py
@@ -6,9 +6,9 @@ from typing import Annotated
 
 import typer
 
-from nextmv.cli.configuration.config import build_client
 from nextmv.cli.message import error
 from nextmv.cli.options import ProfileOption
+from nextmv.cloud.client import Client
 from nextmv.cloud.community import clone_community_app
 
 # Set up subcommand application.
@@ -77,7 +77,7 @@ def clone(
     if version is not None and version == "":
         error("The --version flag cannot be an empty string.")
 
-    client = build_client(profile)
+    client = Client(profile=profile)
     clone_community_app(
         client=client,
         app=app,

--- a/nextmv/nextmv/cli/community/list.py
+++ b/nextmv/nextmv/cli/community/list.py
@@ -9,7 +9,6 @@ import typer
 from rich.console import Console
 from rich.table import Table
 
-from nextmv.cli.configuration.config import build_client
 from nextmv.cli.message import error
 from nextmv.cli.options import ProfileOption
 from nextmv.cloud.client import Client
@@ -62,7 +61,7 @@ def list(
     if app is not None and app == "":
         error("The --app flag cannot be an empty string.")
 
-    client = build_client(profile)
+    client = Client(profile=profile)
     if flat and app is None:
         _apps_list(client)
         raise typer.Exit()

--- a/nextmv/nextmv/cli/configuration/config.py
+++ b/nextmv/nextmv/cli/configuration/config.py
@@ -73,71 +73,6 @@ def non_profile_keys() -> set[str]:
     return {API_KEY_KEY, ENDPOINT_KEY}
 
 
-def build_client(profile: str | None = None) -> Client:
-    """
-    Builds a `cloud.Client` using the API key and endpoint for the given
-    profile. If no profile is given, the default profile is used. If either the
-    API key or endpoint is missing, an exception is raised. If the config is
-    not available, an exception is raised.
-
-    Parameters
-    ----------
-    profile : str | None
-        The profile name to use. If None, the default profile is used.
-
-    Returns
-    -------
-    Client
-        A client configured with the API key and endpoint for the selected
-        profile or the default configuration.
-
-    Raises
-    ------
-    typer.Exit
-        If no configuration is found, if the requested profile does not exist,
-        or if the API key or endpoint (for either the selected profile or the
-        default configuration) is not set or is empty.
-    """
-
-    config = load_config()
-    if config == {}:
-        error("No configuration found. Please run [code]nextmv configuration create[/code].")
-
-    if profile is not None:
-        if profile not in config:
-            error(
-                f"Profile [magenta]{profile}[/magenta] does not exist. "
-                "Create it using [code]nextmv configuration create[/code] with the --profile option."
-            )
-
-        api_key = config[profile].get(API_KEY_KEY)
-        if api_key is None or api_key == "":
-            error(
-                f"API key for profile [magenta]{profile}[/magenta] is not set or is empty. "
-                "Set it using [code]nextmv configuration create[/code] with the --profile and --api-key options."
-            )
-
-        endpoint = config[profile].get(ENDPOINT_KEY)
-        if endpoint is None or endpoint == "":
-            error(
-                f"Endpoint for profile [magenta]{profile}[/magenta] is not set or is empty. "
-                "Please run [code]nextmv configuration create[/code]."
-            )
-    else:
-        api_key = config.get(API_KEY_KEY)
-        if api_key is None or api_key == "":
-            error(
-                "Default API key is not set or is empty. "
-                "Please run [code]nextmv configuration create[/code] with the --api-key option."
-            )
-
-        endpoint = config.get(ENDPOINT_KEY)
-        if endpoint is None or endpoint == "":
-            error("Default endpoint is not set or is empty. Please run [code]nextmv configuration create[/code].")
-
-    return Client(api_key=api_key, url=f"https://{endpoint}")
-
-
 def build_cloud_app(app_id: str, profile: str | None = None) -> tuple[cloud.Application, bool]:
     """
     Builds a `cloud.Application` using the given application ID and the API
@@ -163,7 +98,7 @@ def build_cloud_app(app_id: str, profile: str | None = None) -> tuple[cloud.Appl
         If the application does not exist.
     """
 
-    client = build_client(profile)
+    client = Client(profile=profile)
     exists = cloud.Application.exists(client=client, id=app_id)
     if exists:
         return cloud.Application(client=client, id=app_id), False
@@ -213,7 +148,7 @@ def build_marketplace_app(app_id: str, partner_id: str, profile: str | None = No
         If the marketplace application does not exist.
     """
 
-    client = build_client(profile)
+    client = Client(profile=profile)
     try:
         return MarketplaceApplication.get(
             client=client,
@@ -253,7 +188,7 @@ def build_marketplace_subscription(subscription_id: str, profile: str | None = N
         If the marketplace subscription does not exist.
     """
 
-    client = build_client(profile)
+    client = Client(profile=profile)
     try:
         return MarketplaceSubscription.get(client=client, subscription_id=subscription_id)
     except Exception as e:
@@ -286,7 +221,7 @@ def build_account(account_id: str | None = None, profile: str | None = None) -> 
         If the configuration is invalid or missing.
     """
 
-    client = build_client(profile)
+    client = Client(profile=profile)
 
     return Account(account_id=account_id, client=client)
 
@@ -312,7 +247,7 @@ def build_sso_config(profile: str | None = None) -> SSOConfiguration:
         If the configuration is invalid or missing.
     """
 
-    client = build_client(profile)
+    client = Client(profile=profile)
 
     return SSOConfiguration(client=client)
 

--- a/nextmv/nextmv/cli/configuration/create.py
+++ b/nextmv/nextmv/cli/configuration/create.py
@@ -39,6 +39,8 @@ def create(
             "--endpoint",
             "-e",
             hidden=True,
+            envvar="NEXTMV_ENDPOINT",
+            metavar="NEXTMV_ENDPOINT",
         ),
     ] = DEFAULT_ENDPOINT,
     profile: Annotated[  # Similar to nextmv.cli.options.ProfileOption but with different help text.

--- a/nextmv/nextmv/cli/mcp/tools/_helpers.py
+++ b/nextmv/nextmv/cli/mcp/tools/_helpers.py
@@ -7,7 +7,6 @@ import tempfile
 from typing import Any
 
 from nextmv import local
-from nextmv.cli.configuration.config import build_client
 from nextmv.cloud import Application, Client
 from nextmv.input import InputFormat
 from nextmv.local.executor import process_run_visuals
@@ -67,9 +66,9 @@ class ProfileSession:
 
         # Fall back to the CLI configuration file (~/.nextmv/config.yaml).
         try:
-            # "default" means use top-level keys (profile=None in build_client).
+            # "default" means use top-level keys (profile=None in Client).
             p = None if resolved is None or resolved == "default" else resolved
-            return build_client(profile=p)
+            return Client(profile=p)
         except Exception as e:
             raise ValueError(
                 f"Could not build a Nextmv client: {e}. Either set the "

--- a/nextmv/nextmv/cloud/application/__init__.py
+++ b/nextmv/nextmv/cloud/application/__init__.py
@@ -198,8 +198,15 @@ class Application(
     """Last update timestamp of the application."""
 
     # SDK-specific attributes for convenience when using methods.
-    client: Client = Field(exclude=True)
-    """Client to use for interacting with the Nextmv Cloud API."""
+    client: Client = Field(exclude=True, default_factory=Client)
+    """
+    Client to use for interacting with the Nextmv Cloud API.
+
+    This attribute is optional, and if not provided, it will be initialized
+    with a default `Client` instance. We suggest that you read the docstrings
+    on the `Client` class for more information about how to properly initialize
+    the client using your API key and other configurations.
+    """
     endpoint: str = Field(exclude=True, default="v1/applications/{id}")
     """Base endpoint for the application."""
     experiments_endpoint: str = Field(exclude=True, default="{base}/experiments")

--- a/nextmv/nextmv/cloud/client.py
+++ b/nextmv/nextmv/cloud/client.py
@@ -24,6 +24,7 @@ import requests
 import yaml
 from requests.adapters import HTTPAdapter, Retry
 
+from nextmv import deprecated
 from nextmv._serialization import deflated_serialize_json
 
 _MAX_LAMBDA_PAYLOAD_SIZE: int = 500 * 1024 * 1024
@@ -197,12 +198,10 @@ class Client:
     backoff_max: float = 60
     """Maximum backoff time to use for requests to the Nextmv Cloud API, in
     seconds."""
-    configuration_file: str = "~/.nextmv/config.yaml"
+    configuration_file: str | None = None
     """
     Deprecated. This attribute is no longer being used. Use the `profile`
     attribute to specify different configurations instead.
-
-    Path to the configuration file used by the Nextmv CLI.
     """
     headers: dict[str, str] | None = None
     """Headers to use for requests to the Nextmv Cloud API."""
@@ -255,11 +254,14 @@ class Client:
         Raises
         ------
         ValueError
-            If `api_key` is an empty string.
-            If no API key is found in any of the lookup locations.
-            If a profile is specified via `NEXTMV_PROFILE` but not found in
-            the configuration file.
-            If `apikey` is not found in the configuration file for the
+            If no API key is found after checking the constructor argument,
+            the ``NEXTMV_API_KEY`` environment variable, and the
+            configuration file (for the resolved profile or the default
+            profile). A ``None`` or empty ``api_key`` is treated as unset
+            and causes the lookup to fall through to the next source.
+            If a profile is specified via ``NEXTMV_PROFILE`` or the
+            ``profile`` attribute but is not found in the configuration file.
+            If ``apikey`` is not found in the configuration file for the
             selected profile.
         """
 
@@ -267,6 +269,12 @@ class Client:
         self.url = self.__resolve_endpoint(profile)
         self.api_key = self.__resolve_api_key(profile)
         self.__set_headers_api_key(self.api_key)
+
+        if self.configuration_file is not None and self.configuration_file != "":
+            deprecated(
+                name="Client.configuration_file",
+                reason="`Client.configuration_file` is deprecated, use `Client.profile` to work with another profile",
+            )
 
     def request(
         self,
@@ -558,6 +566,7 @@ class Client:
             if profile_env != "":
                 if profile_env.lower() == "default":
                     return None
+
                 return profile_env
 
         if self.profile is not None:
@@ -565,6 +574,7 @@ class Client:
             if profile != "":
                 if profile.lower() == "default":
                     return None
+
                 return profile
 
         return None

--- a/nextmv/nextmv/cloud/client.py
+++ b/nextmv/nextmv/cloud/client.py
@@ -601,11 +601,10 @@ class Client:
         str
             The resolved API endpoint URL.
         """
-        url_key_env = os.getenv("NEXTMV_ENDPOINT")
         if self.url is not None and self.url != "":
             url = self.url
-        elif url_key_env is not None and url_key_env != "":
-            url = url_key_env
+        elif (url_env := os.getenv("NEXTMV_ENDPOINT")):
+            url = url_env
         elif profile is not None and profile != "":
             url = _retrieve_endpoint_from_config(profile)
         else:

--- a/nextmv/nextmv/cloud/client.py
+++ b/nextmv/nextmv/cloud/client.py
@@ -583,24 +583,24 @@ class Client:
         str
             The resolved API endpoint URL.
         """
-        if self.url is not None and self.url != "":
-            return self.url
-
         url_key_env = os.getenv("NEXTMV_ENDPOINT")
-        if url_key_env is not None and url_key_env != "":
-            return url_key_env
-
-        if profile is not None and profile != "":
+        if self.url is not None and self.url != "":
+            url = self.url
+        elif url_key_env is not None and url_key_env != "":
+            url = url_key_env
+        elif profile is not None and profile != "":
             url = _retrieve_endpoint_from_config(profile)
-            return url
+        else:
+            # The fallback behavior is to attempt to retrieve the default endpoint
+            # from the config file. If everything fails, we return the hardcoded
+            # default endpoint.
+            try:
+                url = _retrieve_endpoint_from_config()
+            except (RuntimeError, ValueError):
+                url = "https://api.cloud.nextmv.io"
 
-        # The fallback behavior is to attempt to retrieve the default endpoint
-        # from the config file. If everything fails, we return the hardcoded
-        # default endpoint.
-        try:
-            url = _retrieve_endpoint_from_config()
-        except (RuntimeError, ValueError):
-            url = "https://api.cloud.nextmv.io"
+        if not url.startswith("https://") and not url.startswith("http://"):
+            url = f"https://{url}"
 
         return url
 

--- a/nextmv/nextmv/cloud/client.py
+++ b/nextmv/nextmv/cloud/client.py
@@ -553,11 +553,19 @@ class Client:
             The resolved profile name, or `None` if no profile is set.
         """
         profile_env = os.getenv("NEXTMV_PROFILE")
-        if profile_env is not None and profile_env != "":
-            return profile_env
+        if profile_env is not None:
+            profile_env = profile_env.strip()
+            if profile_env != "":
+                if profile_env.lower() == "default":
+                    return None
+                return profile_env
 
-        if self.profile is not None and self.profile != "":
-            return self.profile
+        if self.profile is not None:
+            profile = self.profile.strip()
+            if profile != "":
+                if profile.lower() == "default":
+                    return None
+                return profile
 
         return None
 

--- a/nextmv/nextmv/cloud/client.py
+++ b/nextmv/nextmv/cloud/client.py
@@ -16,6 +16,7 @@ get_size(obj)
 
 import os
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import IO, Any
 from urllib.parse import urljoin
 
@@ -33,6 +34,12 @@ be sent to the Nextmv Cloud API, specifically for lambda functions. It is set
 to 500 MiB.
 """
 
+# Some useful constants.
+_CONFIG_DIR = Path.home() / ".nextmv"
+_CONFIG_FILE = _CONFIG_DIR / "config.yaml"
+_API_KEY_KEY = "apikey"
+_ENDPOINT_KEY = "endpoint"
+
 
 @dataclass
 class Client:
@@ -45,63 +52,138 @@ class Client:
     from nextmv.cloud import Client
     ```
 
-    The API key will be searched, in order of precedence, in:
+    The `Client` class is configured mainly with an API key and an endpoint
+    URL. There are multiple ways to provide these configurations, and the
+    client will check for them in the following order of precedence:
 
-    1. The `api_key` argument in the constructor.
-    2. The `NEXTMV_API_KEY` environment variable.
-    3. The `~/.nextmv/config.yaml` file used by the Nextmv CLI.
+    1. The `api_key` and `url` attributes set directly on the client
+       instance.
+    2. The `NEXTMV_API_KEY` and `NEXTMV_ENDPOINT` environment variables.
+    3. If the `NEXTMV_PROFILE` environment variable is set, it is used to
+       look up the API key and endpoint for that profile in the configuration
+       file (`~/.nextmv/config.yaml`).
+    4. If the `profile` attribute is set on the client, it is used to look
+       up the API key and endpoint for that profile in the configuration file.
+    5. If the `profile` attribute is not set, the default profile is used to
+       look up the API key and endpoint in the configuration file.
+    6. If all of the above lookups fail, an exception is raised indicating that
+       the API key is missing, and the endpoint falls back to the hardcoded
+       default URL of `https://api.cloud.nextmv.io`.
 
-    Parameters
+    Attributes
     ----------
     api_key : str, optional
-        API key to use for authenticating with the Nextmv Cloud API. If not
-        provided, the client will look for the `NEXTMV_API_KEY` environment
-        variable.
+        API key to use for authenticating with the Nextmv Cloud API. Resolved
+        from the constructor argument, the `NEXTMV_API_KEY` environment
+        variable, or the configuration file (in that order). Raises
+        `ValueError` if no key is found anywhere.
     allowed_methods : list[str]
-        Allowed HTTP methods to use for retries in requests to the Nextmv
-        Cloud API. Defaults to ``["GET", "POST", "PUT", "DELETE"]``.
+        HTTP methods for which failed requests are eligible for retry.
+        Defaults to `["GET", "POST", "PUT", "DELETE"]`. Adjust this list to
+        restrict retries to idempotent methods only (e.g., `["GET"]`).
     backoff_factor : float
-        Exponential backoff factor to use for requests to the Nextmv Cloud
-        API. Defaults to ``1``.
+        Multiplier applied between retry attempts using exponential backoff.
+        A value of `1` means the successive delays will be 1s, 2s, 4s,
+        … (before jitter). Defaults to `1`.
     backoff_jitter : float
-        Jitter to use for requests to the Nextmv Cloud API when backing off.
-        Defaults to ``0.1``.
+        Random jitter (in seconds) added to each backoff delay to avoid
+        thundering-herd problems. Defaults to `0.1`.
     backoff_max : float
-        Maximum backoff time to use for requests to the Nextmv Cloud API, in
-        seconds. Defaults to ``60``.
+        Upper bound on the backoff delay, in seconds. No single wait between
+        retries will exceed this value. Defaults to `60`.
     configuration_file : str
-        Path to the configuration file used by the Nextmv CLI. Defaults to
-        ``"~/.nextmv/config.yaml"``.
+        **Deprecated** — no longer used. Kept for backwards compatibility.
+        Previously held the path to the Nextmv CLI configuration file.
     headers : dict[str, str], optional
-        Headers to use for requests to the Nextmv Cloud API. Automatically
-        set up with the API key.
+        HTTP headers sent with every request. Automatically populated during
+        `__post_init__` with `Authorization: Bearer <api_key>` and
+        `Content-Type: application/json`. Override by passing a custom dict
+        to individual :meth:`request` calls via the `headers` parameter.
     max_retries : int
-        Maximum number of retries to use for requests to the Nextmv Cloud
-        API. Defaults to ``10``.
+        Total number of retry attempts allowed per request. Defaults to
+        `10`. Set to `0` to disable retries.
+    profile : str, optional
+        Named profile to use when looking up credentials in the configuration
+        file (`~/.nextmv/config.yaml`). Overridden by the
+        `NEXTMV_PROFILE` environment variable when that variable is set.
     status_forcelist : list[int]
-        Status codes to retry for requests to the Nextmv Cloud API. Defaults
-        to ``[429]``.
+        HTTP status codes that trigger an automatic retry. Defaults to
+        `[429]` (Too Many Requests). Add codes such as `500`, `502`,
+        or `503` to also retry on server errors.
     timeout : float
-        Timeout to use for requests to the Nextmv Cloud API, in seconds.
-        Defaults to ``20``.
+        Maximum number of seconds to wait for the server to send a response.
+        Defaults to `20`. Increase for large payloads or slow connections.
     url : str, optional
-        URL of the Nextmv Cloud API. Defaults to
-        ``"https://api.cloud.nextmv.io"``.
+        Base URL of the Nextmv Cloud API. Resolved from the constructor
+        argument, the `NEXTMV_ENDPOINT` environment variable, or the
+        configuration file (in that order). Defaults to
+        `"https://api.cloud.nextmv.io"` when not set anywhere.
     console_url : str
-        URL of the Nextmv Cloud console. Defaults to
-        ``"https://cloud.nextmv.io"``.
+        URL of the Nextmv Cloud web console. Defaults to
+        `"https://cloud.nextmv.io"`. Not used for API requests; provided
+        for convenience when constructing deep-links into the console.
 
     Examples
     --------
+    Authenticate with an explicit API key:
+
     >>> client = Client(api_key="YOUR_API_KEY")
     >>> response = client.request(method="GET", endpoint="/v1/applications")
-    >>> print(response.json())
+    >>> print(response.status_code)
+    200
+
+    Authenticate via the `NEXTMV_API_KEY` environment variable (the
+    `api_key` argument can be omitted):
+
+    >>> import os
+    >>> os.environ["NEXTMV_API_KEY"] = "YOUR_API_KEY"
+    >>> client = Client()
+
+    Use a named profile from the configuration file:
+
+    >>> client = Client(profile="staging")
+
+    Override the profile with an environment variable:
+
+    >>> os.environ["NEXTMV_PROFILE"] = "production"
+    >>> client = Client()  # uses the "production" profile
+
+    Customise retry and timeout behaviour:
+
+    >>> client = Client(
+    ...     api_key="YOUR_API_KEY",
+    ...     max_retries=3,
+    ...     backoff_factor=0.5,
+    ...     backoff_jitter=0.05,
+    ...     backoff_max=30,
+    ...     status_forcelist=[429, 500, 502, 503],
+    ...     timeout=60,
+    ... )
+
+    Point the client at a self-hosted or staging API endpoint:
+
+    >>> client = Client(
+    ...     api_key="YOUR_API_KEY",
+    ...     url="https://staging.api.example.com",
+    ... )
     """
 
     api_key: str | None = None
-    """API key to use for authenticating with the Nextmv Cloud API. If not
-    provided, the client will look for the NEXTMV_API_KEY environment
-    variable."""
+    """
+    API key to use for authenticating with the Nextmv Cloud API.
+
+    The API key is determined in the following order of precedence:
+    1. This `api_key` attribute set on the client.
+    2. The `NEXTMV_API_KEY` environment variable.
+    3. If the `NEXTMV_PROFILE` environment variable is set, it is used to look
+    up the API key for that profile in the configuration file.
+    4. If the `profile` attribute is set on the client, it is used to look up
+    the API key for that profile in the configuration file.
+    5. If the `profile` attribute is not set, the default profile is used to
+    look up the API key in the configuration file.
+    6. If all of the above lookups fail, an exception is raised indicating that
+    the API key is missing.
+    """
     allowed_methods: list[str] = field(
         default_factory=lambda: ["GET", "POST", "PUT", "DELETE"],
     )
@@ -116,7 +198,12 @@ class Client:
     """Maximum backoff time to use for requests to the Nextmv Cloud API, in
     seconds."""
     configuration_file: str = "~/.nextmv/config.yaml"
-    """Path to the configuration file used by the Nextmv CLI."""
+    """
+    Deprecated. This attribute is no longer being used. Use the `profile`
+    attribute to specify different configurations instead.
+
+    Path to the configuration file used by the Nextmv CLI.
+    """
     headers: dict[str, str] | None = None
     """Headers to use for requests to the Nextmv Cloud API."""
     max_retries: int = 10
@@ -128,15 +215,34 @@ class Client:
     """Status codes to retry for requests to the Nextmv Cloud API."""
     timeout: float = 20
     """Timeout to use for requests to the Nextmv Cloud API."""
-    url: str | None = "https://api.cloud.nextmv.io"
+    url: str | None = None
     """
-    URL of the Nextmv Cloud API.
+    URL (endpoint) of the Nextmv Cloud API.
 
-    If set to `None` or to an empty string, it is
-    replaced with "https://api.cloud.nextmv.io" during client initialization.
+    The endpoint is determined in the following order of precedence:
+    1. This `url` attribute set on the client.
+    2. The `NEXTMV_ENDPOINT` environment variable.
+    3. If the `NEXTMV_PROFILE` environment variable is set, it is used to look
+    up the endpoint for that profile in the configuration file.
+    4. If the `profile` attribute is set on the client, it is used to look up
+    the endpoint for that profile in the configuration file.
+    5. If the `profile` attribute is not set, the default profile is used to
+    look up the endpoint in the configuration file.
+    6. If all of the above lookups fail, the hardcoded default URL of
+    `https://api.cloud.nextmv.io` is used.
     """
     console_url: str = "https://cloud.nextmv.io"
     """URL of the Nextmv Cloud console."""
+    profile: str | None = None
+    """
+    Profile to use from the configuration file. Profiles allow you to configure
+    multiple sets of API keys and endpoints in the configuration file and
+    select between them.
+
+    The profile is determined in the following order of precedence:
+    1. The `NEXTMV_PROFILE` environment variable.
+    2. This `profile` attribute set on the client.
+    """
 
     def __post_init__(self):
         """
@@ -157,49 +263,10 @@ class Client:
             selected profile.
         """
 
-        # Fallback for backwards compatibility with empty string
-        if not self.url:
-            self.url = "https://api.cloud.nextmv.io"
-
-        if self.api_key is not None and self.api_key != "":
-            self._set_headers_api_key(self.api_key)
-            return
-
-        if self.api_key == "":
-            raise ValueError("api_key cannot be empty")
-
-        api_key_env = os.getenv("NEXTMV_API_KEY")
-        if api_key_env is not None:
-            self.api_key = api_key_env
-            self._set_headers_api_key(api_key_env)
-            return
-
-        config_path = os.path.expanduser(self.configuration_file)
-        if not os.path.exists(config_path):
-            raise ValueError(
-                f"no API key set in constructor or NEXTMV_API_KEY env var, and {self.configuration_file} does not exist"
-            )
-
-        with open(config_path) as f:
-            config = yaml.safe_load(f)
-
-        profile = os.getenv("NEXTMV_PROFILE")
-        parent = config
-        if profile is not None:
-            parent = config.get(profile)
-            if parent is None:
-                raise ValueError(f"profile {profile} set via NEXTMV_PROFILE but not found in {self.configuration_file}")
-
-        api_key = parent.get("apikey")
-        if api_key is None:
-            raise ValueError(f"no apiKey found in {self.configuration_file}")
-        self.api_key = api_key
-
-        endpoint = parent.get("endpoint")
-        if endpoint is not None:
-            self.url = f"https://{endpoint}"
-
-        self._set_headers_api_key(api_key)
+        profile = self.__resolve_profile()
+        self.url = self.__resolve_endpoint(profile)
+        self.api_key = self.__resolve_api_key(profile)
+        self.__set_headers_api_key(self.api_key)
 
     def request(
         self,
@@ -254,24 +321,57 @@ class Client:
 
         Examples
         --------
+        List all applications:
+
         >>> client = Client(api_key="YOUR_API_KEY")
-        >>> # Get a list of applications
         >>> response = client.request(method="GET", endpoint="/v1/applications")
         >>> print(response.status_code)
         200
-        >>> # Create a new run
+        >>> apps = response.json()
+        >>> print([a["id"] for a in apps["items"]])
+        ['my-app', 'another-app']
+
+        Create a new run with a JSON payload:
+
         >>> run_payload = {
-        ...     "applicationId": "app_id",
-        ...     "instanceId": "instance_id",
-        ...     "input": {"value": 10}
+        ...     "applicationId": "my-app",
+        ...     "instanceId": "candidate",
+        ...     "input": {"value": 10},
         ... }
         >>> response = client.request(
         ...     method="POST",
         ...     endpoint="/v1/runs",
-        ...     payload=run_payload
+        ...     payload=run_payload,
         ... )
         >>> print(response.json()["id"])
         run_xxxxxxxxxxxx
+
+        Retrieve a specific run using query parameters:
+
+        >>> response = client.request(
+        ...     method="GET",
+        ...     endpoint="/v1/runs",
+        ...     query_params={"applicationId": "my-app", "limit": 5},
+        ... )
+        >>> print(len(response.json()["items"]))
+        5
+
+        Send a request with custom headers (e.g., to pass a request ID):
+
+        >>> response = client.request(
+        ...     method="GET",
+        ...     endpoint="/v1/applications",
+        ...     headers={**client.headers, "X-Request-Id": "abc-123"},
+        ... )
+
+        Send a JSON payload with custom serialization (pretty-printed):
+
+        >>> response = client.request(
+        ...     method="POST",
+        ...     endpoint="/v1/runs",
+        ...     payload={"applicationId": "my-app", "input": {}},
+        ...     json_configurations={"indent": 2},
+        ... )
         """
 
         if payload is not None and data is not None:
@@ -372,10 +472,27 @@ class Client:
 
         Examples
         --------
-        Assume `presigned_upload_url` is obtained from a previous API call.
+        Upload a dictionary as JSON (presigned URL obtained from a prior API
+        call):
+
         >>> client = Client(api_key="YOUR_API_KEY")
-        >>> input_data = {"value": 42, "items": [1, 2, 3]}
-        >>> client.upload_to_presigned_url(data=input_data, url="PRE_SIGNED_URL") # doctest: +SKIP
+        >>> input_data = {"stops": [{"id": "A"}, {"id": "B"}], "config": {"max_duration": 30}}
+        >>> client.upload_to_presigned_url(data=input_data, url="PRE_SIGNED_URL")  # doctest: +SKIP
+
+        Upload a raw JSON string:
+
+        >>> client.upload_to_presigned_url(  # doctest: +SKIP
+        ...     data='{"stops": [{"id": "A"}]}',
+        ...     url="PRE_SIGNED_URL",
+        ... )
+
+        Upload a pre-built tarball (e.g., a packaged application):
+
+        >>> client.upload_to_presigned_url(  # doctest: +SKIP
+        ...     data=None,
+        ...     url="PRE_SIGNED_URL",
+        ...     tar_file="/path/to/app.tar.gz",
+        ... )
         """
 
         upload_data: str | None = None
@@ -423,7 +540,128 @@ class Client:
                 f"status code {response.status_code} and message: {response.text}"
             ) from e
 
-    def _set_headers_api_key(self, api_key: str) -> None:
+    def __resolve_profile(self) -> str | None:
+        """
+        Resolves the active profile name.
+
+        Checks, in order of precedence: the `NEXTMV_PROFILE` environment
+        variable and then the `profile` attribute set on the client.
+
+        Returns
+        -------
+        str or None
+            The resolved profile name, or `None` if no profile is set.
+        """
+        profile_env = os.getenv("NEXTMV_PROFILE")
+        if profile_env is not None and profile_env != "":
+            return profile_env
+
+        if self.profile is not None and self.profile != "":
+            return self.profile
+
+        return None
+
+    def __resolve_endpoint(self, profile: str | None) -> str:
+        """
+        Resolves the API endpoint URL.
+
+        Checks, in order of precedence: the `url` attribute set on the
+        client, the `NEXTMV_ENDPOINT` environment variable, the endpoint
+        for the given profile in the configuration file, and finally the
+        default endpoint for the default profile in the configuration file.
+        Falls back to the hardcoded default URL if all other lookups fail.
+
+        Parameters
+        ----------
+        profile : str or None
+            The profile name to use when looking up the endpoint in the
+            configuration file. If `None` or empty, the default profile
+            is used.
+
+        Returns
+        -------
+        str
+            The resolved API endpoint URL.
+        """
+        if self.url is not None and self.url != "":
+            return self.url
+
+        url_key_env = os.getenv("NEXTMV_ENDPOINT")
+        if url_key_env is not None and url_key_env != "":
+            return url_key_env
+
+        if profile is not None and profile != "":
+            url = _retrieve_endpoint_from_config(profile)
+            return url
+
+        # The fallback behavior is to attempt to retrieve the default endpoint
+        # from the config file. If everything fails, we return the hardcoded
+        # default endpoint.
+        try:
+            url = _retrieve_endpoint_from_config()
+        except (RuntimeError, ValueError):
+            url = "https://api.cloud.nextmv.io"
+
+        return url
+
+    def __resolve_api_key(self, profile: str | None) -> str:
+        """
+        Resolves the API key.
+
+        Checks, in order of precedence: the `api_key` attribute set on the
+        client, the `NEXTMV_API_KEY` environment variable, the API key for
+        the given profile in the configuration file, and finally the API key
+        for the default profile in the configuration file.
+
+        Parameters
+        ----------
+        profile : str or None
+            The profile name to use when looking up the API key in the
+            configuration file. If `None` or empty, the default profile
+            is used.
+
+        Returns
+        -------
+        str
+            The resolved API key.
+
+        Raises
+        ------
+        RuntimeError
+            If no configuration file is found when falling back to the
+            configuration file lookup.
+        ValueError
+            If the API key is not set or is empty in the configuration file
+            for the resolved profile.
+        """
+        if self.api_key is not None and self.api_key != "":
+            return self.api_key
+
+        api_key_env = os.getenv("NEXTMV_API_KEY")
+        if api_key_env is not None and api_key_env != "":
+            return api_key_env
+
+        if profile is not None and profile != "":
+            api_key = _retrieve_key_from_config(profile)
+            return api_key
+
+        # The fallback behavior is to attempt to retrieve the default api key
+        # from the config file. If the key is missing, an exception is raised.
+        try:
+            api_key = _retrieve_key_from_config()
+        except (RuntimeError, ValueError) as e:
+            raise ValueError(
+                "API key is missing. Please set the API key in one of the following ways: "
+                "1. Pass it directly to the Client constructor. "
+                "2. Set the NEXTMV_API_KEY environment variable. "
+                "3. Set the API key in the configuration file for the default profile. "
+                "4. If using profiles, set the API key in the configuration file for the selected profile and ensure "
+                "the profile is selected via the NEXTMV_PROFILE environment variable or the Client constructor."
+            ) from e
+
+        return api_key
+
+    def __set_headers_api_key(self, api_key: str) -> None:
         """
         Sets the Authorization and Content-Type headers.
 
@@ -504,3 +742,115 @@ def get_size(obj: dict[str, Any] | IO[bytes] | str, json_configurations: dict[st
 
     else:
         raise TypeError("Unsupported type. Only dictionaries, file objects (IO[bytes]), and strings are supported.")
+
+
+def _load_config() -> dict[str, Any]:
+    """
+    Load the current configuration from the config file. Returns an empty
+    dictionary if no configuration file exists.
+
+    Returns
+    -------
+    dict[str, Any]
+        The current configuration as a dictionary.
+    """
+
+    if not _CONFIG_FILE.exists():
+        return {}
+
+    with _CONFIG_FILE.open() as file:
+        config = yaml.safe_load(file)
+
+    if config is None:
+        return {}
+    return config
+
+
+def _retrieve_key_from_config(profile: str | None = None) -> str:
+    """
+    Retrieves the API key for the given profile. If no profile is given, the
+    default profile is used. If the API key is missing, an exception is raised.
+    If the config is not available, an exception is raised.
+
+    Parameters
+    ----------
+    profile : str | None
+        The profile name to use. If None, the default profile is used.
+
+    Returns
+    -------
+    str
+        The API key for the selected profile or the default configuration.
+
+    Raises
+    ------
+    RuntimeError
+        If no configuration file is found.
+    ValueError
+        If the requested profile does not exist, or if the API key (for either
+        the selected profile or the default configuration) is not set or is
+        empty.
+    """
+
+    config = _load_config()
+    if config == {}:
+        raise RuntimeError(f"No configuration file at {_CONFIG_FILE} found.")
+
+    if profile is not None:
+        if profile not in config:
+            raise ValueError(f"Profile `{profile}` does not exist.")
+
+        api_key = config[profile].get(_API_KEY_KEY)
+        if api_key is None or api_key == "":
+            raise ValueError(f"API key for profile `{profile}` is not set or is empty.")
+    else:
+        api_key = config.get(_API_KEY_KEY)
+        if api_key is None or api_key == "":
+            raise ValueError("Default API key is not set or is empty.")
+
+    return api_key
+
+
+def _retrieve_endpoint_from_config(profile: str | None = None) -> str:
+    """
+    Retrieves the endpoint for the given profile. If no profile is given, the
+    default profile is used. If the endpoint is missing, an exception is
+    raised. If the config is not available, an exception is raised.
+
+    Parameters
+    ----------
+    profile : str | None
+        The profile name to use. If None, the default profile is used.
+
+    Returns
+    -------
+    str
+        The endpoint for the selected profile or the default configuration.
+
+    Raises
+    ------
+    RuntimeError
+        If no configuration file is found.
+    ValueError
+        If the requested profile does not exist, or if the endpoint (for either
+        the selected profile or the default configuration) is not set or is
+        empty.
+    """
+
+    config = _load_config()
+    if config == {}:
+        raise RuntimeError(f"No configuration file at {_CONFIG_FILE} found.")
+
+    if profile is not None:
+        if profile not in config:
+            raise ValueError(f"Profile `{profile}` does not exist.")
+
+        endpoint = config[profile].get(_ENDPOINT_KEY)
+        if endpoint is None or endpoint == "":
+            raise ValueError(f"Endpoint for profile `{profile}` is not set or is empty.")
+    else:
+        endpoint = config.get(_ENDPOINT_KEY)
+        if endpoint is None or endpoint == "":
+            raise ValueError("Default endpoint is not set or is empty.")
+
+    return f"https://{endpoint}"

--- a/nextmv/tests/cli/test_mcp.py
+++ b/nextmv/tests/cli/test_mcp.py
@@ -361,7 +361,7 @@ class TestGetClient(unittest.TestCase):
         self.assertEqual(client.url, "https://custom.api.io")
 
     @patch.dict("os.environ", {}, clear=True)
-    @patch("nextmv.cli.mcp.tools._helpers.build_client", side_effect=Exception("no config"))
+    @patch("nextmv.cli.mcp.tools._helpers.Client", side_effect=Exception("no config"))
     def test_get_client_no_key_no_config_raises(self, mock_build):
         """Test that _get_client raises when no API key or config is available."""
         from nextmv.cli.mcp.server import _get_client
@@ -456,19 +456,26 @@ class TestSaveToFile(unittest.TestCase):
 
         server = create_server()
         tool = server._tool_manager._tools["cloud_create_managed_input"]
-        asyncio.run(tool.run({
-            "app_id": "my-app",
-            "name": "test input",
-            "input": {"stops": [{"id": "s1"}]},
-        }))
+        asyncio.run(
+            tool.run(
+                {
+                    "app_id": "my-app",
+                    "name": "test input",
+                    "input": {"stops": [{"id": "s1"}]},
+                }
+            )
+        )
         mock_app.upload_url.assert_called_once()
         mock_app.upload_data.assert_called_once_with(
             upload_url=mock_upload_url,
             data={"stops": [{"id": "s1"}]},
         )
         mock_app.new_managed_input.assert_called_once_with(
-            id=None, name="test input", description=None,
-            run_id=None, upload_id="upl_123",
+            id=None,
+            name="test input",
+            description=None,
+            run_id=None,
+            upload_id="upl_123",
         )
 
     @patch("nextmv.cli.mcp.tools._helpers._get_app")
@@ -484,11 +491,15 @@ class TestSaveToFile(unittest.TestCase):
 
         server = create_server()
         tool = server._tool_manager._tools["cloud_create_input_set"]
-        asyncio.run(tool.run({
-            "app_id": "my-app",
-            "name": "test set",
-            "managed_input_ids": ["mi-1", "mi-2"],
-        }))
+        asyncio.run(
+            tool.run(
+                {
+                    "app_id": "my-app",
+                    "name": "test set",
+                    "managed_input_ids": ["mi-1", "mi-2"],
+                }
+            )
+        )
         call_kwargs = mock_app.new_input_set.call_args[1]
         self.assertEqual(len(call_kwargs["inputs"]), 2)
         self.assertEqual(call_kwargs["inputs"][0].id, "mi-1")
@@ -507,11 +518,15 @@ class TestSaveToFile(unittest.TestCase):
 
         server = create_server()
         tool = server._tool_manager._tools["cloud_create_input_set"]
-        asyncio.run(tool.run({
-            "app_id": "my-app",
-            "name": "test set",
-            "run_ids": ["run-1", "run-2"],
-        }))
+        asyncio.run(
+            tool.run(
+                {
+                    "app_id": "my-app",
+                    "name": "test set",
+                    "run_ids": ["run-1", "run-2"],
+                }
+            )
+        )
         call_kwargs = mock_app.new_input_set.call_args[1]
         self.assertEqual(call_kwargs["run_ids"], ["run-1", "run-2"])
         self.assertIsNone(call_kwargs["inputs"])
@@ -527,33 +542,37 @@ class TestSaveToFile(unittest.TestCase):
 
         server = create_server()
         tool = server._tool_manager._tools["cloud_create_scenario_test"]
-        asyncio.run(tool.run({
-            "app_id": "my-app",
-            "name": "test",
-            "scenarios": [
+        asyncio.run(
+            tool.run(
                 {
-                    "instance_id": "stable",
-                    "scenario_id": "s1",
-                    "scenario_input": {
-                        "input_set_id": "my-input-set",
-                    },
-                    "configuration": {
-                        "options": {"duration": "30", "objective": "cost"},
-                    },
-                },
-                {
-                    "instance_id": "stable",
-                    "scenario_id": "s2",
-                    "scenario_input": {
-                        "scenario_input_type": "input_set",
-                        "scenario_input_data": "other-set",
-                    },
-                    "configuration": [
-                        {"name": "duration", "values": ["10", "30"]},
+                    "app_id": "my-app",
+                    "name": "test",
+                    "scenarios": [
+                        {
+                            "instance_id": "stable",
+                            "scenario_id": "s1",
+                            "scenario_input": {
+                                "input_set_id": "my-input-set",
+                            },
+                            "configuration": {
+                                "options": {"duration": "30", "objective": "cost"},
+                            },
+                        },
+                        {
+                            "instance_id": "stable",
+                            "scenario_id": "s2",
+                            "scenario_input": {
+                                "scenario_input_type": "input_set",
+                                "scenario_input_data": "other-set",
+                            },
+                            "configuration": [
+                                {"name": "duration", "values": ["10", "30"]},
+                            ],
+                        },
                     ],
-                },
-            ],
-        }))
+                }
+            )
+        )
         call_kwargs = mock_app.new_scenario_test.call_args[1]
         scenarios = call_kwargs["scenarios"]
         self.assertEqual(len(scenarios), 2)
@@ -651,22 +670,22 @@ class TestProfiles(unittest.TestCase):
             self.assertIn("5678", profiles[1]["api_key"])
 
     @patch.dict("os.environ", {}, clear=True)
-    @patch("nextmv.cli.mcp.tools._helpers.build_client")
-    def test_get_client_uses_profile(self, mock_build_client):
-        """Test that _get_client passes the profile to build_client."""
+    @patch("nextmv.cli.mcp.tools._helpers.Client")
+    def test_get_client_uses_profile(self, mock_client):
+        """Test that _get_client passes the profile to Client."""
         from nextmv.cli.mcp.tools._helpers import session
 
-        mock_build_client.return_value = MagicMock()
+        mock_client.return_value = MagicMock()
 
         # Explicit profile override.
         session.get_client(profile="staging")
-        mock_build_client.assert_called_with(profile="staging")
+        mock_client.assert_called_with(profile="staging")
 
         # Session-level profile.
         session.profile = "prod"
         try:
             session.get_client()
-            mock_build_client.assert_called_with(profile="prod")
+            mock_client.assert_called_with(profile="prod")
         finally:
             session.profile = None
 
@@ -675,12 +694,12 @@ class TestProfiles(unittest.TestCase):
         """Test that env var is skipped when a profile is active."""
         from nextmv.cli.mcp.tools._helpers import session
 
-        with patch("nextmv.cli.mcp.tools._helpers.build_client") as mock_build:
-            mock_build.return_value = MagicMock()
+        with patch("nextmv.cli.mcp.tools._helpers.Client") as mock_client:
+            mock_client.return_value = MagicMock()
             session.profile = "staging"
             try:
                 session.get_client()
-                mock_build.assert_called_with(profile="staging")
+                mock_client.assert_called_with(profile="staging")
             finally:
                 session.profile = None
 
@@ -701,27 +720,32 @@ class TestBugFixes(unittest.TestCase):
 
         server = create_server()
         tool = server._tool_manager._tools["cloud_create_ensemble"]
-        asyncio.run(tool.run({
-            "app_id": "my-app",
-            "run_groups": [
-                {"id": "grp-1", "instance_id": "prod", "repetitions": 1, "options": {}},
-                {"id": "grp-2", "instance_id": "staging", "repetitions": 1, "options": {}},
-            ],
-            "rules": [
+        asyncio.run(
+            tool.run(
                 {
-                    "id": "min-cost",
-                    "statistics_path": "result.value",
-                    "objective": "minimize",
-                    "tolerance": 0.01,
-                    "index": 0,
-                },
-            ],
-            "name": "test ensemble",
-        }))
+                    "app_id": "my-app",
+                    "run_groups": [
+                        {"id": "grp-1", "instance_id": "prod", "repetitions": 1, "options": {}},
+                        {"id": "grp-2", "instance_id": "staging", "repetitions": 1, "options": {}},
+                    ],
+                    "rules": [
+                        {
+                            "id": "min-cost",
+                            "statistics_path": "result.value",
+                            "objective": "minimize",
+                            "tolerance": 0.01,
+                            "index": 0,
+                        },
+                    ],
+                    "name": "test ensemble",
+                }
+            )
+        )
         mock_app.new_ensemble_definition.assert_called_once()
         call_kwargs = mock_app.new_ensemble_definition.call_args[1]
         # run_groups should be RunGroup objects, not dicts.
         from nextmv.cloud.ensemble import EvaluationRule, RunGroup
+
         self.assertIsInstance(call_kwargs["run_groups"][0], RunGroup)
         self.assertIsInstance(call_kwargs["run_groups"][1], RunGroup)
         self.assertEqual(call_kwargs["run_groups"][0].id, "grp-1")
@@ -743,21 +767,26 @@ class TestBugFixes(unittest.TestCase):
 
         server = create_server()
         tool = server._tool_manager._tools["cloud_create_ensemble"]
-        asyncio.run(tool.run({
-            "app_id": "my-app",
-            "run_groups": [{"id": "grp-1", "instance_id": "prod"}],
-            "rules": [
+        asyncio.run(
+            tool.run(
                 {
-                    "id": "min-cost",
-                    "statistics_path": "result.value",
-                    "objective": "min",
-                    "tolerance": 0.01,
-                    "index": 0,
-                },
-            ],
-        }))
+                    "app_id": "my-app",
+                    "run_groups": [{"id": "grp-1", "instance_id": "prod"}],
+                    "rules": [
+                        {
+                            "id": "min-cost",
+                            "statistics_path": "result.value",
+                            "objective": "min",
+                            "tolerance": 0.01,
+                            "index": 0,
+                        },
+                    ],
+                }
+            )
+        )
         call_kwargs = mock_app.new_ensemble_definition.call_args[1]
         from nextmv.cloud.ensemble import RuleObjective
+
         self.assertEqual(call_kwargs["rules"][0].objective, RuleObjective.MINIMIZE)
 
     @patch("nextmv.cli.mcp.tools._helpers._get_app")
@@ -773,21 +802,26 @@ class TestBugFixes(unittest.TestCase):
 
         server = create_server()
         tool = server._tool_manager._tools["cloud_create_ensemble"]
-        asyncio.run(tool.run({
-            "app_id": "my-app",
-            "run_groups": [{"id": "grp-1", "instance_id": "prod"}],
-            "rules": [
+        asyncio.run(
+            tool.run(
                 {
-                    "id": "rule-1",
-                    "statistics_path": "result.value",
-                    "objective": "maximize",
-                    "tolerance": {"value": 5.0, "type": "absolute"},
-                    "index": 1,
-                },
-            ],
-        }))
+                    "app_id": "my-app",
+                    "run_groups": [{"id": "grp-1", "instance_id": "prod"}],
+                    "rules": [
+                        {
+                            "id": "rule-1",
+                            "statistics_path": "result.value",
+                            "objective": "maximize",
+                            "tolerance": {"value": 5.0, "type": "absolute"},
+                            "index": 1,
+                        },
+                    ],
+                }
+            )
+        )
         call_kwargs = mock_app.new_ensemble_definition.call_args[1]
         from nextmv.cloud.ensemble import RuleToleranceType
+
         rule = call_kwargs["rules"][0]
         self.assertEqual(rule.tolerance.value, 5.0)
         self.assertEqual(rule.tolerance.type, RuleToleranceType.ABSOLUTE)
@@ -801,19 +835,23 @@ class TestBugFixes(unittest.TestCase):
 
         server = create_server()
         tool = server._tool_manager._tools["cloud_create_ensemble"]
-        result = asyncio.run(tool.run({
-            "app_id": "my-app",
-            # Missing 'instance_id' in run group.
-            "run_groups": [{"id": "grp-1"}],
-            "rules": [
+        result = asyncio.run(
+            tool.run(
                 {
-                    "id": "r1",
-                    "statistics_path": "result.value",
-                    "objective": "min",
-                    "tolerance": 0.01,
-                },
-            ],
-        }))
+                    "app_id": "my-app",
+                    # Missing 'instance_id' in run group.
+                    "run_groups": [{"id": "grp-1"}],
+                    "rules": [
+                        {
+                            "id": "r1",
+                            "statistics_path": "result.value",
+                            "objective": "min",
+                            "tolerance": 0.01,
+                        },
+                    ],
+                }
+            )
+        )
         text = json.loads(result[0].text) if hasattr(result[0], "text") else str(result)
         self.assertIn("run_groups[0]", str(text))
         self.assertIn("Error", str(text))
@@ -827,12 +865,16 @@ class TestBugFixes(unittest.TestCase):
 
         server = create_server()
         tool = server._tool_manager._tools["cloud_create_ensemble"]
-        result = asyncio.run(tool.run({
-            "app_id": "my-app",
-            "run_groups": [{"id": "grp-1", "instance_id": "prod"}],
-            # Missing 'statistics_path' in rule.
-            "rules": [{"id": "r1", "objective": "min", "tolerance": 0.01}],
-        }))
+        result = asyncio.run(
+            tool.run(
+                {
+                    "app_id": "my-app",
+                    "run_groups": [{"id": "grp-1", "instance_id": "prod"}],
+                    # Missing 'statistics_path' in rule.
+                    "rules": [{"id": "r1", "objective": "min", "tolerance": 0.01}],
+                }
+            )
+        )
         text = json.loads(result[0].text) if hasattr(result[0], "text") else str(result)
         self.assertIn("rules[0]", str(text))
         self.assertIn("Error", str(text))
@@ -845,6 +887,7 @@ class TestBugFixes(unittest.TestCase):
         tool = server._tool_manager._tools["cloud_create_scenario_test"]
         # Verify the tool's function accepts content_type in its signature.
         import inspect
+
         sig = inspect.signature(tool.fn)
         self.assertIn("content_type", sig.parameters)
 
@@ -859,20 +902,24 @@ class TestBugFixes(unittest.TestCase):
 
         server = create_server()
         tool = server._tool_manager._tools["cloud_create_scenario_test"]
-        asyncio.run(tool.run({
-            "app_id": "my-app",
-            "scenarios": [
+        asyncio.run(
+            tool.run(
                 {
-                    "instance_id": "stable",
-                    "scenario_id": "s1",
-                    "scenario_input": {
-                        "input_set_id": "my-input-set",
-                    },
-                },
-            ],
-            "content_type": "multi-file",
-            "name": "multi-file test",
-        }))
+                    "app_id": "my-app",
+                    "scenarios": [
+                        {
+                            "instance_id": "stable",
+                            "scenario_id": "s1",
+                            "scenario_input": {
+                                "input_set_id": "my-input-set",
+                            },
+                        },
+                    ],
+                    "content_type": "multi-file",
+                    "name": "multi-file test",
+                }
+            )
+        )
 
         # Verify the SDK's new_scenario_test was called with content_type.
         mock_app.new_scenario_test.assert_called_once()
@@ -889,22 +936,27 @@ class TestBugFixes(unittest.TestCase):
 
         server = create_server()
         tool = server._tool_manager._tools["cloud_create_ensemble"]
-        result = asyncio.run(tool.run({
-            "app_id": "my-app",
-            "run_groups": [{"id": "grp-1", "instance_id": "prod"}],
-            "rules": [
+        result = asyncio.run(
+            tool.run(
                 {
-                    "id": "rule-missing-fields",
-                    # Missing statistics_path and objective.
-                },
-            ],
-        }))
+                    "app_id": "my-app",
+                    "run_groups": [{"id": "grp-1", "instance_id": "prod"}],
+                    "rules": [
+                        {
+                            "id": "rule-missing-fields",
+                            # Missing statistics_path and objective.
+                        },
+                    ],
+                }
+            )
+        )
         text = json.loads(result[0].text) if hasattr(result[0], "text") else str(result)
         self.assertIn("Error", str(text))
 
     @patch("nextmv.cli.mcp.tools._helpers._get_app")
     def test_cloud_create_scenario_test_content_type_multiple_inputs(
-        self, mock_get_app,
+        self,
+        mock_get_app,
     ):
         """Bug 2: content_type is passed to SDK for multi-input scenarios."""
         from nextmv.cli.mcp.server import create_server
@@ -915,17 +967,21 @@ class TestBugFixes(unittest.TestCase):
 
         server = create_server()
         tool = server._tool_manager._tools["cloud_create_scenario_test"]
-        asyncio.run(tool.run({
-            "app_id": "my-app",
-            "scenarios": [
+        asyncio.run(
+            tool.run(
                 {
-                    "instance_id": "stable",
-                    "scenario_id": "s1",
-                    "scenario_input": {"input_set_id": "my-input-set"},
-                },
-            ],
-            "content_type": "multi-file",
-        }))
+                    "app_id": "my-app",
+                    "scenarios": [
+                        {
+                            "instance_id": "stable",
+                            "scenario_id": "s1",
+                            "scenario_input": {"input_set_id": "my-input-set"},
+                        },
+                    ],
+                    "content_type": "multi-file",
+                }
+            )
+        )
 
         # Verify the SDK was called with content_type and proper scenarios.
         mock_app.new_scenario_test.assert_called_once()
@@ -966,10 +1022,14 @@ class TestMultiFileRunSupport(unittest.TestCase):
 
         server = create_server()
         tool = server._tool_manager._tools["local_run_submit"]
-        asyncio.run(tool.run({
-            "app_dir": "/some/app",
-            "input": {"stops": []},
-        }))
+        asyncio.run(
+            tool.run(
+                {
+                    "app_dir": "/some/app",
+                    "input": {"stops": []},
+                }
+            )
+        )
         mock_app.new_run.assert_called_once()
         call_kwargs = mock_app.new_run.call_args[1]
         self.assertEqual(call_kwargs["input"], {"stops": []})
@@ -988,11 +1048,15 @@ class TestMultiFileRunSupport(unittest.TestCase):
 
         server = create_server()
         tool = server._tool_manager._tools["local_run_submit"]
-        asyncio.run(tool.run({
-            "app_dir": "/some/app",
-            "input_dir_path": "/some/input-dir",
-            "content_format": "multi-file",
-        }))
+        asyncio.run(
+            tool.run(
+                {
+                    "app_dir": "/some/app",
+                    "input_dir_path": "/some/input-dir",
+                    "content_format": "multi-file",
+                }
+            )
+        )
         mock_app.new_run.assert_called_once()
         call_kwargs = mock_app.new_run.call_args[1]
         self.assertEqual(call_kwargs["input_dir_path"], "/some/input-dir")
@@ -1011,10 +1075,14 @@ class TestMultiFileRunSupport(unittest.TestCase):
 
         server = create_server()
         tool = server._tool_manager._tools["cloud_run_submit"]
-        asyncio.run(tool.run({
-            "app_id": "my-app",
-            "input": {"stops": []},
-        }))
+        asyncio.run(
+            tool.run(
+                {
+                    "app_id": "my-app",
+                    "input": {"stops": []},
+                }
+            )
+        )
         mock_app.new_run.assert_called_once()
         call_kwargs = mock_app.new_run.call_args[1]
         self.assertEqual(call_kwargs["input"], {"stops": []})
@@ -1033,11 +1101,15 @@ class TestMultiFileRunSupport(unittest.TestCase):
 
         server = create_server()
         tool = server._tool_manager._tools["cloud_run_submit"]
-        asyncio.run(tool.run({
-            "app_id": "my-app",
-            "input_dir_path": "/some/input-dir",
-            "content_format": "multi-file",
-        }))
+        asyncio.run(
+            tool.run(
+                {
+                    "app_id": "my-app",
+                    "input_dir_path": "/some/input-dir",
+                    "content_format": "multi-file",
+                }
+            )
+        )
         mock_app.new_run.assert_called_once()
         call_kwargs = mock_app.new_run.call_args[1]
         self.assertEqual(call_kwargs["input_dir_path"], "/some/input-dir")
@@ -1121,11 +1193,15 @@ class TestEnsembleRunTools(unittest.TestCase):
 
         server = create_server()
         tool = server._tool_manager._tools["cloud_ensemble_run"]
-        result = asyncio.run(tool.run({
-            "app_id": "my-app",
-            "ensemble_id": "ens-1",
-            "input": {"stops": []},
-        }))
+        result = asyncio.run(
+            tool.run(
+                {
+                    "app_id": "my-app",
+                    "ensemble_id": "ens-1",
+                    "input": {"stops": []},
+                }
+            )
+        )
         text = json.loads(result[0].text) if hasattr(result[0], "text") else str(result)
         self.assertIn("Data saved to", str(text))
         mock_app.new_run_with_result.assert_called_once()
@@ -1143,11 +1219,15 @@ class TestEnsembleRunTools(unittest.TestCase):
 
         server = create_server()
         tool = server._tool_manager._tools["cloud_ensemble_run_submit"]
-        result = asyncio.run(tool.run({
-            "app_id": "my-app",
-            "ensemble_id": "ens-1",
-            "input": {"stops": []},
-        }))
+        result = asyncio.run(
+            tool.run(
+                {
+                    "app_id": "my-app",
+                    "ensemble_id": "ens-1",
+                    "input": {"stops": []},
+                }
+            )
+        )
         text = json.loads(result[0].text) if hasattr(result[0], "text") else str(result)
         self.assertIn("run-ens-42", str(text))
         mock_app.new_run.assert_called_once()
@@ -1159,11 +1239,15 @@ class TestEnsembleRunTools(unittest.TestCase):
 
         server = create_server()
         tool = server._tool_manager._tools["cloud_ensemble_run"]
-        result = asyncio.run(tool.run({
-            "app_id": "",
-            "ensemble_id": "ens-1",
-            "input": {"stops": []},
-        }))
+        result = asyncio.run(
+            tool.run(
+                {
+                    "app_id": "",
+                    "ensemble_id": "ens-1",
+                    "input": {"stops": []},
+                }
+            )
+        )
         text = json.loads(result[0].text) if hasattr(result[0], "text") else str(result)
         self.assertIn("app_id", str(text))
         mock_get_app.assert_not_called()
@@ -1175,11 +1259,15 @@ class TestEnsembleRunTools(unittest.TestCase):
 
         server = create_server()
         tool = server._tool_manager._tools["cloud_ensemble_run_submit"]
-        result = asyncio.run(tool.run({
-            "app_id": "my-app",
-            "ensemble_id": "   ",
-            "input": {"stops": []},
-        }))
+        result = asyncio.run(
+            tool.run(
+                {
+                    "app_id": "my-app",
+                    "ensemble_id": "   ",
+                    "input": {"stops": []},
+                }
+            )
+        )
         text = json.loads(result[0].text) if hasattr(result[0], "text") else str(result)
         self.assertIn("ensemble_id", str(text))
         mock_get_app.assert_not_called()
@@ -1199,9 +1287,7 @@ class TestCloudRunCache(unittest.TestCase):
         from nextmv.cli.mcp.tools._helpers import _cloud_run_dir
 
         result = _cloud_run_dir("api.cloud.nextmv.io", "run-123")
-        expected = os.path.join(
-            str(os.path.expanduser("~")), ".nextmv", "runs", "api.cloud.nextmv.io", "run-123"
-        )
+        expected = os.path.join(str(os.path.expanduser("~")), ".nextmv", "runs", "api.cloud.nextmv.io", "run-123")
         self.assertEqual(result, expected)
 
     def test_cloud_run_file_exists_returns_path(self):
@@ -1364,9 +1450,7 @@ class TestCloudRunCache(unittest.TestCase):
             return_value=run_dir,
         ):
             # Only solution present, no metrics/statistics/assets.
-            _extract_cloud_run_outputs(
-                {"output": {"solution": {"x": 1}}}, "ep", "run-partial"
-            )
+            _extract_cloud_run_outputs({"output": {"solution": {"x": 1}}}, "ep", "run-partial")
 
             # solution.json contains the full output dict.
             sol_path = os.path.join(run_dir, "outputs", "solutions", "solution.json")
@@ -1389,9 +1473,7 @@ class TestCloudRunCache(unittest.TestCase):
             "nextmv.cli.mcp.tools._helpers._cloud_run_dir",
             return_value=run_dir,
         ):
-            _extract_cloud_run_outputs(
-                {"output": {"solution": {}, "assets": []}}, "ep", "run-empty-sol"
-            )
+            _extract_cloud_run_outputs({"output": {"solution": {}, "assets": []}}, "ep", "run-empty-sol")
 
             # Even empty solution should be written (full output dict).
             sol_path = os.path.join(run_dir, "outputs", "solutions", "solution.json")
@@ -1485,12 +1567,15 @@ class TestCloudRunCache(unittest.TestCase):
 
         run_dir = os.path.join(self.tmp_dir, "run-bad-visual")
 
-        with patch(
-            "nextmv.cli.mcp.tools._helpers._cloud_run_dir",
-            return_value=run_dir,
-        ), patch(
-            "nextmv.local.executor.process_run_visuals",
-            side_effect=RuntimeError("plotly exploded"),
+        with (
+            patch(
+                "nextmv.cli.mcp.tools._helpers._cloud_run_dir",
+                return_value=run_dir,
+            ),
+            patch(
+                "nextmv.local.executor.process_run_visuals",
+                side_effect=RuntimeError("plotly exploded"),
+            ),
         ):
             # Should not raise despite visual generation failure.
             _extract_cloud_run_outputs(
@@ -1692,8 +1777,17 @@ class TestCloudRunCache(unittest.TestCase):
                 return d
             return run_dir
 
-        def fake_new_run(*, input, input_dir_path, configuration, instance_id,
-                         run_options, polling_options, managed_input_id, output_dir_path):
+        def fake_new_run(
+            *,
+            input,
+            input_dir_path,
+            configuration,
+            instance_id,
+            run_options,
+            polling_options,
+            managed_input_id,
+            output_dir_path,
+        ):
             # Simulate SDK extracting tar.gz into output_dir_path.
             if output_dir_path:
                 os.makedirs(output_dir_path, exist_ok=True)
@@ -1709,11 +1803,15 @@ class TestCloudRunCache(unittest.TestCase):
         ):
             server = create_server()
             tool = server._tool_manager._tools["cloud_run"]
-            result = asyncio.run(tool.run({
-                "app_id": "my-app",
-                "input_dir_path": "/some/csvs",
-                "content_format": "csv-archive",
-            }))
+            result = asyncio.run(
+                tool.run(
+                    {
+                        "app_id": "my-app",
+                        "input_dir_path": "/some/csvs",
+                        "content_format": "csv-archive",
+                    }
+                )
+            )
             text = json.loads(result[0].text) if hasattr(result[0], "text") else str(result)
             self.assertIn("Downloaded:", str(text))
 
@@ -1864,10 +1962,15 @@ class TestMCPOptionalDependency(unittest.TestCase):
 
         runner = CliRunner()
 
-        with patch(
-            "nextmv.cli.main.go_cli_exists", return_value=False,
-        ), patch(
-            "nextmv.cli.main.load_config", return_value={},
+        with (
+            patch(
+                "nextmv.cli.main.go_cli_exists",
+                return_value=False,
+            ),
+            patch(
+                "nextmv.cli.main.load_config",
+                return_value={},
+            ),
         ):
             result = runner.invoke(app, ["--help"])
             self.assertEqual(result.exit_code, 0)
@@ -1960,15 +2063,19 @@ class TestVisualGenerationWarning(unittest.TestCase):
 
         run_dir = os.path.join(self.tmp_dir, "run-warn")
 
-        with patch(
-            "nextmv.cli.mcp.tools._helpers._cloud_run_dir",
-            return_value=run_dir,
-        ), patch(
-            "nextmv.cli.mcp.tools._helpers.process_run_visuals",
-            side_effect=RuntimeError("plotly exploded"),
-        ), patch(
-            "nextmv.cli.mcp.tools._helpers.log",
-        ) as mock_log:
+        with (
+            patch(
+                "nextmv.cli.mcp.tools._helpers._cloud_run_dir",
+                return_value=run_dir,
+            ),
+            patch(
+                "nextmv.cli.mcp.tools._helpers.process_run_visuals",
+                side_effect=RuntimeError("plotly exploded"),
+            ),
+            patch(
+                "nextmv.cli.mcp.tools._helpers.log",
+            ) as mock_log,
+        ):
             _extract_cloud_run_outputs(
                 {"output": {"solution": {"x": 1}}},
                 "ep",
@@ -2042,8 +2149,10 @@ class TestSDKContentType(unittest.TestCase):
             instance_id="inst-1",
         )
 
-        with patch.object(type(app), "instance", return_value=mock_instance), \
-             patch.object(type(app), "input_set", return_value=mock_input_set):
+        with (
+            patch.object(type(app), "instance", return_value=mock_instance),
+            patch.object(type(app), "input_set", return_value=mock_input_set),
+        ):
             app.new_scenario_test(
                 scenarios=[scenario],
                 content_type="multi-file",

--- a/nextmv/tests/cli/test_mcp.py
+++ b/nextmv/tests/cli/test_mcp.py
@@ -362,7 +362,7 @@ class TestGetClient(unittest.TestCase):
 
     @patch.dict("os.environ", {}, clear=True)
     @patch("nextmv.cli.mcp.tools._helpers.Client", side_effect=Exception("no config"))
-    def test_get_client_no_key_no_config_raises(self, mock_build):
+    def test_get_client_no_key_no_config_raises(self, mock_client):
         """Test that _get_client raises when no API key or config is available."""
         from nextmv.cli.mcp.server import _get_client
 

--- a/nextmv/tests/cloud/test_client.py
+++ b/nextmv/tests/cloud/test_client.py
@@ -1,35 +1,351 @@
 import os
 import unittest
+from unittest.mock import patch
 
 from nextmv.cloud import Client
 
 
-class TestClient(unittest.TestCase):
-    def test_api_key(self):
-        client1 = Client(api_key="foo")
-        self.assertEqual(client1.api_key, "foo")
+class TestResolveProfile(unittest.TestCase):
+    """Tests for Client.__resolve_profile (exercised via __post_init__)."""
 
-        os.environ["NEXTMV_API_KEY"] = "bar"
-        client2 = Client()
-        self.assertEqual(client2.api_key, "bar")
-        os.environ.pop("NEXTMV_API_KEY")
+    def test_env_var_used_as_profile(self):
+        """NEXTMV_PROFILE env var is used as the active profile."""
+        config = {"my-profile": {"apikey": "k", "endpoint": "api.example.io"}}
+        with patch("nextmv.cloud.client._load_config", return_value=config):
+            with patch.dict(os.environ, {"NEXTMV_PROFILE": "my-profile"}) as env:
+                env.pop("NEXTMV_API_KEY", None)
+                env.pop("NEXTMV_ENDPOINT", None)
+                client = Client()
+                self.assertEqual(client.api_key, "k")
 
-        with self.assertRaises(ValueError):
-            Client(api_key="")
+    def test_env_var_overrides_profile_attribute(self):
+        """NEXTMV_PROFILE env var takes precedence over the profile attribute."""
+        config = {
+            "env-profile": {"apikey": "env-key", "endpoint": "api.env.io"},
+            "attr-profile": {"apikey": "attr-key", "endpoint": "api.attr.io"},
+        }
+        with patch("nextmv.cloud.client._load_config", return_value=config):
+            with patch.dict(os.environ, {"NEXTMV_PROFILE": "env-profile"}) as env:
+                env.pop("NEXTMV_API_KEY", None)
+                env.pop("NEXTMV_ENDPOINT", None)
+                client = Client(profile="attr-profile")
+                self.assertEqual(client.api_key, "env-key")
 
-        with self.assertRaises(ValueError):
-            Client(configuration_file="")
+    def test_profile_attribute_used_when_env_var_absent(self):
+        """profile attribute is used when NEXTMV_PROFILE is not set."""
+        config = {"my-profile": {"apikey": "k", "endpoint": "api.example.io"}}
+        with patch("nextmv.cloud.client._load_config", return_value=config):
+            with patch.dict(os.environ) as env:
+                env.pop("NEXTMV_PROFILE", None)
+                env.pop("NEXTMV_API_KEY", None)
+                env.pop("NEXTMV_ENDPOINT", None)
+                client = Client(profile="my-profile")
+                self.assertEqual(client.api_key, "k")
 
-        os.environ["NEXTMV_PROFILE"] = "i-like-turtles"
-        with self.assertRaises(ValueError):
-            Client()
+    def test_empty_env_var_falls_back_to_profile_attribute(self):
+        """Empty NEXTMV_PROFILE falls back to the profile attribute."""
+        config = {"my-profile": {"apikey": "k", "endpoint": "api.example.io"}}
+        with patch("nextmv.cloud.client._load_config", return_value=config):
+            with patch.dict(os.environ, {"NEXTMV_PROFILE": ""}) as env:
+                env.pop("NEXTMV_API_KEY", None)
+                env.pop("NEXTMV_ENDPOINT", None)
+                client = Client(profile="my-profile")
+                self.assertEqual(client.api_key, "k")
 
-    def test_headers(self):
-        client1 = Client(api_key="foo")
-        self.assertIsNotNone(client1.headers)
+    def test_no_profile_uses_default_config(self):
+        """When neither profile source is set, the default config entry is used."""
+        config = {"apikey": "default-key"}
+        with patch("nextmv.cloud.client._load_config", return_value=config):
+            with patch.dict(os.environ) as env:
+                env.pop("NEXTMV_PROFILE", None)
+                env.pop("NEXTMV_API_KEY", None)
+                env.pop("NEXTMV_ENDPOINT", None)
+                client = Client()
+                self.assertEqual(client.api_key, "default-key")
 
-        os.environ["NEXTMV_API_KEY"] = "bar"
-        client2 = Client()
-        self.assertEqual(client2.api_key, "bar")
-        self.assertIsNotNone(client2.headers)
-        os.environ.pop("NEXTMV_API_KEY")
+    def test_nonexistent_profile_raises_value_error(self):
+        """A profile that is not present in the config file raises ValueError."""
+        config = {"other-profile": {"apikey": "k", "endpoint": "api.example.io"}}
+        with patch("nextmv.cloud.client._load_config", return_value=config):
+            with patch.dict(os.environ, {"NEXTMV_PROFILE": "missing-profile"}) as env:
+                env.pop("NEXTMV_API_KEY", None)
+                env.pop("NEXTMV_ENDPOINT", None)
+                with self.assertRaises(ValueError):
+                    Client()
+
+
+class TestResolveEndpoint(unittest.TestCase):
+    """Tests for Client.__resolve_endpoint (exercised via __post_init__)."""
+
+    def test_url_attribute_takes_highest_precedence(self):
+        """url attribute is used even when NEXTMV_ENDPOINT is set."""
+        with patch.dict(
+            os.environ,
+            {"NEXTMV_API_KEY": "k", "NEXTMV_ENDPOINT": "https://env.example.com"},
+        ) as env:
+            env.pop("NEXTMV_PROFILE", None)
+            client = Client(url="https://attr.example.com")
+            self.assertEqual(client.url, "https://attr.example.com")
+
+    def test_empty_url_attribute_falls_through_to_env_var(self):
+        """An empty url attribute is ignored; NEXTMV_ENDPOINT is used instead."""
+        with patch.dict(
+            os.environ,
+            {"NEXTMV_API_KEY": "k", "NEXTMV_ENDPOINT": "https://env.example.com"},
+        ) as env:
+            env.pop("NEXTMV_PROFILE", None)
+            client = Client(url="")
+            self.assertEqual(client.url, "https://env.example.com")
+
+    def test_env_var_used_when_url_attribute_absent(self):
+        """NEXTMV_ENDPOINT is used when no url attribute is provided."""
+        with patch.dict(
+            os.environ,
+            {"NEXTMV_API_KEY": "k", "NEXTMV_ENDPOINT": "https://env.example.com"},
+        ) as env:
+            env.pop("NEXTMV_PROFILE", None)
+            client = Client()
+            self.assertEqual(client.url, "https://env.example.com")
+
+    def test_env_var_takes_precedence_over_config(self):
+        """NEXTMV_ENDPOINT takes precedence over the endpoint stored in config."""
+        config = {"apikey": "k", "endpoint": "api.config.io"}
+        with patch("nextmv.cloud.client._load_config", return_value=config):
+            with patch.dict(
+                os.environ,
+                {"NEXTMV_API_KEY": "k", "NEXTMV_ENDPOINT": "https://env.example.com"},
+            ) as env:
+                env.pop("NEXTMV_PROFILE", None)
+                client = Client()
+                self.assertEqual(client.url, "https://env.example.com")
+
+    def test_profile_endpoint_from_config(self):
+        """When a profile is active, its endpoint is resolved from the config."""
+        config = {"my-profile": {"apikey": "k", "endpoint": "api.profile.io"}}
+        with patch("nextmv.cloud.client._load_config", return_value=config):
+            with patch.dict(os.environ) as env:
+                env.pop("NEXTMV_PROFILE", None)
+                env.pop("NEXTMV_API_KEY", None)
+                env.pop("NEXTMV_ENDPOINT", None)
+                client = Client(profile="my-profile")
+                self.assertEqual(client.url, "https://api.profile.io")
+
+    def test_default_endpoint_from_config(self):
+        """When no profile is active, the default endpoint is read from config."""
+        config = {"apikey": "k", "endpoint": "api.default.io"}
+        with patch("nextmv.cloud.client._load_config", return_value=config):
+            with patch.dict(os.environ) as env:
+                env.pop("NEXTMV_PROFILE", None)
+                env.pop("NEXTMV_API_KEY", None)
+                env.pop("NEXTMV_ENDPOINT", None)
+                client = Client()
+                self.assertEqual(client.url, "https://api.default.io")
+
+    def test_fallback_to_hardcoded_default_when_no_config(self):
+        """Falls back to the hardcoded default URL when the config file is absent."""
+        with patch("nextmv.cloud.client._load_config", return_value={}):
+            with patch.dict(os.environ, {"NEXTMV_API_KEY": "k"}) as env:
+                env.pop("NEXTMV_PROFILE", None)
+                env.pop("NEXTMV_ENDPOINT", None)
+                client = Client()
+                self.assertEqual(client.url, "https://api.cloud.nextmv.io")
+
+    def test_missing_endpoint_for_profile_raises_value_error(self):
+        """A profile with no endpoint key raises ValueError."""
+        config = {"my-profile": {"apikey": "k"}}  # no endpoint
+        with patch("nextmv.cloud.client._load_config", return_value=config):
+            with patch.dict(os.environ) as env:
+                env.pop("NEXTMV_PROFILE", None)
+                env.pop("NEXTMV_API_KEY", None)
+                env.pop("NEXTMV_ENDPOINT", None)
+                with self.assertRaises(ValueError):
+                    Client(profile="my-profile")
+
+    def test_empty_endpoint_for_profile_raises_value_error(self):
+        """A profile with an empty endpoint raises ValueError."""
+        config = {"my-profile": {"apikey": "k", "endpoint": ""}}
+        with patch("nextmv.cloud.client._load_config", return_value=config):
+            with patch.dict(os.environ) as env:
+                env.pop("NEXTMV_PROFILE", None)
+                env.pop("NEXTMV_API_KEY", None)
+                env.pop("NEXTMV_ENDPOINT", None)
+                with self.assertRaises(ValueError):
+                    Client(profile="my-profile")
+
+    def test_profile_takes_precedence_over_default_config_endpoint(self):
+        """A named profile's endpoint overrides the top-level default endpoint."""
+        config = {
+            "endpoint": "api.default.io",
+            "apikey": "default-k",
+            "my-profile": {"apikey": "profile-k", "endpoint": "api.profile.io"},
+        }
+        with patch("nextmv.cloud.client._load_config", return_value=config):
+            with patch.dict(os.environ) as env:
+                env.pop("NEXTMV_PROFILE", None)
+                env.pop("NEXTMV_API_KEY", None)
+                env.pop("NEXTMV_ENDPOINT", None)
+                client = Client(profile="my-profile")
+                self.assertEqual(client.url, "https://api.profile.io")
+
+
+class TestResolveApiKey(unittest.TestCase):
+    """Tests for Client.__resolve_api_key (exercised via __post_init__)."""
+
+    def test_api_key_attribute_takes_highest_precedence(self):
+        """api_key attribute is used even when NEXTMV_API_KEY is set."""
+        with patch.dict(os.environ, {"NEXTMV_API_KEY": "env-key"}) as env:
+            env.pop("NEXTMV_PROFILE", None)
+            client = Client(api_key="attr-key")
+            self.assertEqual(client.api_key, "attr-key")
+
+    def test_empty_api_key_attribute_falls_through_to_env_var(self):
+        """An empty api_key attribute is ignored; NEXTMV_API_KEY is used instead."""
+        with patch.dict(os.environ, {"NEXTMV_API_KEY": "env-key"}) as env:
+            env.pop("NEXTMV_PROFILE", None)
+            client = Client(api_key="")
+            self.assertEqual(client.api_key, "env-key")
+
+    def test_env_var_used_when_no_api_key_attribute(self):
+        """NEXTMV_API_KEY env var is used when no api_key attribute is provided."""
+        with patch.dict(os.environ, {"NEXTMV_API_KEY": "env-key"}) as env:
+            env.pop("NEXTMV_PROFILE", None)
+            client = Client()
+            self.assertEqual(client.api_key, "env-key")
+
+    def test_env_var_takes_precedence_over_config(self):
+        """NEXTMV_API_KEY takes precedence over the key stored in config."""
+        config = {"apikey": "config-key"}
+        with patch("nextmv.cloud.client._load_config", return_value=config):
+            with patch.dict(os.environ, {"NEXTMV_API_KEY": "env-key"}) as env:
+                env.pop("NEXTMV_PROFILE", None)
+                client = Client()
+                self.assertEqual(client.api_key, "env-key")
+
+    def test_profile_api_key_from_config(self):
+        """When a profile is active, its api_key is resolved from the config."""
+        config = {"my-profile": {"apikey": "profile-key", "endpoint": "api.example.io"}}
+        with patch("nextmv.cloud.client._load_config", return_value=config):
+            with patch.dict(os.environ) as env:
+                env.pop("NEXTMV_API_KEY", None)
+                env.pop("NEXTMV_PROFILE", None)
+                env.pop("NEXTMV_ENDPOINT", None)
+                client = Client(profile="my-profile")
+                self.assertEqual(client.api_key, "profile-key")
+
+    def test_default_api_key_from_config(self):
+        """When no profile is active, the default api_key is read from config."""
+        config = {"apikey": "default-key"}
+        with patch("nextmv.cloud.client._load_config", return_value=config):
+            with patch.dict(os.environ) as env:
+                env.pop("NEXTMV_API_KEY", None)
+                env.pop("NEXTMV_PROFILE", None)
+                env.pop("NEXTMV_ENDPOINT", None)
+                client = Client()
+                self.assertEqual(client.api_key, "default-key")
+
+    def test_profile_takes_precedence_over_default_config_api_key(self):
+        """A named profile's api_key overrides the top-level default api_key."""
+        config = {
+            "apikey": "default-key",
+            "my-profile": {"apikey": "profile-key", "endpoint": "api.profile.io"},
+        }
+        with patch("nextmv.cloud.client._load_config", return_value=config):
+            with patch.dict(os.environ) as env:
+                env.pop("NEXTMV_API_KEY", None)
+                env.pop("NEXTMV_PROFILE", None)
+                env.pop("NEXTMV_ENDPOINT", None)
+                client = Client(profile="my-profile")
+                self.assertEqual(client.api_key, "profile-key")
+
+    def test_all_sources_absent_raises_value_error(self):
+        """Raises ValueError with a helpful message when no API key is found."""
+        with patch("nextmv.cloud.client._load_config", return_value={}):
+            with patch.dict(os.environ) as env:
+                env.pop("NEXTMV_API_KEY", None)
+                env.pop("NEXTMV_PROFILE", None)
+                with self.assertRaises(ValueError) as ctx:
+                    Client()
+                self.assertIn("API key is missing", str(ctx.exception))
+
+    def test_missing_api_key_for_profile_raises_value_error(self):
+        """A profile with no apikey raises ValueError."""
+        config = {"my-profile": {"endpoint": "api.example.io"}}  # no apikey
+        with patch("nextmv.cloud.client._load_config", return_value=config):
+            with patch.dict(os.environ) as env:
+                env.pop("NEXTMV_API_KEY", None)
+                env.pop("NEXTMV_PROFILE", None)
+                env.pop("NEXTMV_ENDPOINT", None)
+                with self.assertRaises(ValueError):
+                    Client(profile="my-profile")
+
+    def test_empty_api_key_for_profile_raises_value_error(self):
+        """A profile with an empty apikey raises ValueError."""
+        config = {"my-profile": {"apikey": "", "endpoint": "api.example.io"}}
+        with patch("nextmv.cloud.client._load_config", return_value=config):
+            with patch.dict(os.environ) as env:
+                env.pop("NEXTMV_API_KEY", None)
+                env.pop("NEXTMV_PROFILE", None)
+                env.pop("NEXTMV_ENDPOINT", None)
+                with self.assertRaises(ValueError):
+                    Client(profile="my-profile")
+
+    def test_missing_default_api_key_in_config_raises_value_error(self):
+        """Config file without a top-level apikey raises ValueError."""
+        config = {"endpoint": "api.default.io"}  # no apikey
+        with patch("nextmv.cloud.client._load_config", return_value=config):
+            with patch.dict(os.environ) as env:
+                env.pop("NEXTMV_API_KEY", None)
+                env.pop("NEXTMV_PROFILE", None)
+                env.pop("NEXTMV_ENDPOINT", None)
+                with self.assertRaises(ValueError) as ctx:
+                    Client()
+                self.assertIn("API key is missing", str(ctx.exception))
+
+
+class TestSetHeadersApiKey(unittest.TestCase):
+    """Tests for Client.__set_headers_api_key (exercised via __post_init__)."""
+
+    def test_authorization_header_uses_bearer_scheme(self):
+        """Authorization header is set to 'Bearer <api_key>'."""
+        client = Client(api_key="my-secret-key")
+        self.assertEqual(client.headers["Authorization"], "Bearer my-secret-key")
+
+    def test_content_type_header_is_application_json(self):
+        """Content-Type header is always set to 'application/json'."""
+        client = Client(api_key="my-secret-key")
+        self.assertEqual(client.headers["Content-Type"], "application/json")
+
+    def test_headers_dict_is_not_none(self):
+        """headers attribute is a non-None dict after __post_init__."""
+        client = Client(api_key="my-secret-key")
+        self.assertIsNotNone(client.headers)
+        self.assertIsInstance(client.headers, dict)
+
+    def test_headers_reflect_api_key_from_env_var(self):
+        """Authorization header uses the API key resolved from NEXTMV_API_KEY."""
+        with patch.dict(os.environ, {"NEXTMV_API_KEY": "env-key"}) as env:
+            env.pop("NEXTMV_PROFILE", None)
+            client = Client()
+            self.assertEqual(client.headers["Authorization"], "Bearer env-key")
+
+    def test_headers_reflect_api_key_from_config(self):
+        """Authorization header uses the API key resolved from the config file."""
+        config = {"apikey": "config-key"}
+        with patch("nextmv.cloud.client._load_config", return_value=config):
+            with patch.dict(os.environ) as env:
+                env.pop("NEXTMV_API_KEY", None)
+                env.pop("NEXTMV_PROFILE", None)
+                env.pop("NEXTMV_ENDPOINT", None)
+                client = Client()
+                self.assertEqual(client.headers["Authorization"], "Bearer config-key")
+
+    def test_headers_reflect_api_key_from_profile_config(self):
+        """Authorization header uses the API key resolved from a named profile."""
+        config = {"my-profile": {"apikey": "profile-key", "endpoint": "api.example.io"}}
+        with patch("nextmv.cloud.client._load_config", return_value=config):
+            with patch.dict(os.environ) as env:
+                env.pop("NEXTMV_API_KEY", None)
+                env.pop("NEXTMV_PROFILE", None)
+                env.pop("NEXTMV_ENDPOINT", None)
+                client = Client(profile="my-profile")
+                self.assertEqual(client.headers["Authorization"], "Bearer profile-key")


### PR DESCRIPTION
# Description

- Makes the `client` attribute optional when initializing a `cloud.Application`. To understand the default behavior of a `cloud.Client`, read the next bullet.
- Refactors the post-initialization logic of a `cloud.Client`.  Here is a summary of how to work with a `Client`. The `Client` class is configured mainly with an API key and an endpoint URL. There are multiple ways to provide these configurations, and the client will check for them in the following order of precedence:
    1. The `api_key` and `url` attributes set directly on the client
       instance.
    2. The `NEXTMV_API_KEY` and `NEXTMV_ENDPOINT` environment variables.
    3. If the `NEXTMV_PROFILE` environment variable is set, it is used to
       look up the API key and endpoint for that profile in the configuration
       file (`~/.nextmv/config.yaml`).
    4. If the `profile` attribute is set on the client, it is used to look
       up the API key and endpoint for that profile in the configuration file.
    5. If the `profile` attribute is not set, the default profile is used to
       look up the API key and endpoint in the configuration file.
    6. If all of the above lookups fail, an exception is raised indicating that
       the API key is missing, and the endpoint falls back to the hardcoded
       default URL of `https://api.cloud.nextmv.io`.
- Due to the above, you can now use `NEXTMV_API_KEY` and `NEXTMV_ENDPOINT` environment variables in _any_ CLI command, and it will override whatever you have specified in the profile.