### PR TITLE
Allows defining local only options

### DIFF
--- a/nextmv/nextmv/cloud/application/__init__.py
+++ b/nextmv/nextmv/cloud/application/__init__.py
@@ -811,6 +811,9 @@ class Application(
 
         if manifest.configuration is not None and manifest.configuration.options is not None:
             options = manifest.configuration.options.to_dict()
+            # Ignore local_only options since they are not meant to be used on the platform
+            if "items" in options:
+                options["items"] = [item for item in options["items"] if not item.get("local_only", False)]
             if "format" in options and isinstance(options["format"], list):
                 # the endpoint expects a dictionary with a template key having a list of strings
                 # the app.yaml however defines format as a list of strings, so we need to convert it here

--- a/nextmv/nextmv/manifest.py
+++ b/nextmv/nextmv/manifest.py
@@ -511,6 +511,8 @@ class ManifestOption(BaseModel):
         The description of the option.
     required : bool, default=False
         Whether the option is required or not.
+    local_only : bool, default=False
+        Whether the option is only used locally and should not be sent to Nextmv Cloud.
     additional_attributes : Optional[dict[str, Any]], default=None
         Optional additional attributes for the option. The Nextmv Cloud may
         perform validation on these attributes. For example, the maximum
@@ -551,6 +553,8 @@ class ManifestOption(BaseModel):
     """The description of the option"""
     required: bool = False
     """Whether the option is required or not"""
+    local_only: bool = False
+    """Whether the option is only used locally and should not be sent to Nextmv Cloud."""
     additional_attributes: dict[str, Any] | None = None
     """Optional additional attributes for the option."""
     ui: ManifestOptionUI | None = None

--- a/nextmv/nextmv/manifest.py
+++ b/nextmv/nextmv/manifest.py
@@ -560,6 +560,21 @@ class ManifestOption(BaseModel):
     ui: ManifestOptionUI | None = None
     """Optional UI attributes for the option."""
 
+    def model_post_init(self, __context) -> None:
+        """
+        Validations done after parsing the model.
+
+        Raises
+        ------
+        ValueError
+            If validation fails. A descriptive error message is provided in this case.
+        """
+
+        # It does not make sense to define options as required AND them being local only,
+        # since this would make Platform runs via UI cumbersome to impossible.
+        if self.required and self.local_only:
+            raise ValueError(f"Option '{self.name}' cannot be both required and local only.")
+
     @classmethod
     def from_option(cls, option: Option) -> "ManifestOption":
         """

--- a/nextmv/tests/cloud/app.yaml
+++ b/nextmv/tests/cloud/app.yaml
@@ -64,6 +64,12 @@ configuration:
           control_type: select
           hidden_from:
             - operator
+      - name: a local only parameter
+        option_type: string
+        default: local_default
+        description: a local only description
+        required: false
+        local_only: true
   content:
     format: "multi-file"
     multi-file:

--- a/nextmv/tests/test_manifest.py
+++ b/nextmv/tests/test_manifest.py
@@ -189,7 +189,7 @@ class TestManifest(unittest.TestCase):
     def test_extract_options(self):
         manifest = Manifest.from_yaml("tests/cloud")
         options = manifest.extract_options(should_parse=False)
-        self.assertEqual(len(options.options), 5)
+        self.assertEqual(len(options.options), 6)
 
         found = {
             "string": False,
@@ -498,6 +498,57 @@ class TestManifestOption(unittest.TestCase):
                 self.assertEqual(option.default, manifest_option.default)
                 self.assertEqual(option.description, manifest_option.description)
                 self.assertEqual(option.required, manifest_option.required)
+
+
+class TestManifestOptionLocalOnly(unittest.TestCase):
+    def test_local_only_defaults_to_false(self):
+        option = ManifestOption(name="my_option", option_type="string", default="val")
+        self.assertFalse(option.local_only)
+
+    def test_local_only_can_be_set_to_true(self):
+        option = ManifestOption(name="my_option", option_type="int", default=0, local_only=True)
+        self.assertTrue(option.local_only)
+
+    def test_required_and_local_only_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            ManifestOption(name="my_option", option_type="string", default="val", required=True, local_only=True)
+        self.assertIn("my_option", str(ctx.exception))
+        self.assertIn("required", str(ctx.exception).lower())
+        self.assertIn("local only", str(ctx.exception).lower())
+
+    def test_local_only_round_trips_through_dict(self):
+        original = ManifestOption(name="my_option", option_type="float", default=1.5, local_only=True)
+        as_dict = original.to_dict()
+        self.assertTrue(as_dict["local_only"])
+        restored = ManifestOption.from_dict(as_dict)
+        self.assertTrue(restored.local_only)
+
+    def test_non_local_only_round_trips_through_dict(self):
+        original = ManifestOption(name="my_option", option_type="bool", default=False, local_only=False)
+        as_dict = original.to_dict()
+        self.assertFalse(as_dict["local_only"])
+        restored = ManifestOption.from_dict(as_dict)
+        self.assertFalse(restored.local_only)
+
+    def test_local_only_loaded_from_yaml(self):
+        manifest = Manifest.from_yaml("tests/cloud")
+        items = manifest.configuration.options.items
+        local_only_items = [item for item in items if item.local_only]
+        self.assertEqual(len(local_only_items), 1)
+        item = local_only_items[0]
+        self.assertEqual(item.name, "a local only parameter")
+        self.assertEqual(item.option_type, "string")
+        self.assertEqual(item.default, "local_default")
+        self.assertFalse(item.required)
+        self.assertTrue(item.local_only)
+
+    def test_other_options_are_not_local_only(self):
+        manifest = Manifest.from_yaml("tests/cloud")
+        items = manifest.configuration.options.items
+        non_local_only_items = [item for item in items if not item.local_only]
+        # All items except the one explicitly marked local_only should have local_only=False.
+        for item in non_local_only_items:
+            self.assertFalse(item.local_only, msg=f"Option '{item.name}' should not be local_only")
 
 
 class TestWriteSampleManifest(unittest.TestCase):


### PR DESCRIPTION
# Description

Allows defining `local_only` options via the app manifest. These options are only useful locally and won't get pushed up to the Nextmv Platform. Typical examples are `--input` to define other input files where on Nextmv Platform the platform is taking care of it.

## Changes

- Introduces `local_only` app options.
  - Options with `local_only: true` will get skipped when pushing the app to the Nextmv Platform.
  - However, the options will be available via CLI args when running locally.
  - Example:

      ```jsonc
      configuration:
        options:
          items:
            - name: input
              description: Path to input data file, default is stdin.
              option_type: string
              default: ""
              required: false
              local_only: true
      // ...
      ```