### PR TITLE
Fixes init for pyinstaller releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,25 +64,32 @@ jobs:
         working-directory: nextmv/
 
       - name: build binary with PyInstaller
+        # We force bash to get more consistent behavior across platforms
+        shell: bash
         # Binary will be located at dist/nextmv (or dist/nextmv.exe on Windows)
-        run: pyinstaller --name nextmv --onefile --console nextmv/cli/main.py
+        run: |
+          pyinstaller \
+            --name nextmv \
+            --onefile \
+            --add-data "nextmv/templates:nextmv/templates" \
+            --console nextmv/cli/main.py
         working-directory: nextmv/
 
       - name: rename binary for distribution
-        shell: bash # Force bash shell for consistent behavior across OSes
+        shell: bash
         run: |
           mv dist/nextmv${{ matrix.ext }} dist/nextmv-${{ matrix.os }}-${{ matrix.arch }}${{ matrix.ext }}
         working-directory: nextmv/
 
       - name: determine exact version being released
-        shell: bash # Force bash shell for consistent behavior across OSes
+        shell: bash
         run: |
           VERSION="nextmv-$(cat nextmv/nextmv/__about__.py | grep __version__ | cut -d '"' -f 2)"
           echo "VERSION=$VERSION" >> $GITHUB_ENV
           echo "VERSION=$VERSION"
 
       - name: attach binary to GitHub release
-        shell: bash # Force bash shell for consistent behavior across OSes
+        shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,10 +68,16 @@ jobs:
         shell: bash
         # Binary will be located at dist/nextmv (or dist/nextmv.exe on Windows)
         run: |
+          if [ "${{ matrix.os }}" = "windows" ]; then
+            ADD_DATA_SEPARATOR=";"
+          else
+            ADD_DATA_SEPARATOR=":"
+          fi
+
           pyinstaller \
             --name nextmv \
             --onefile \
-            --add-data "nextmv/templates:nextmv/templates" \
+            --add-data "nextmv/templates${ADD_DATA_SEPARATOR}nextmv/templates" \
             --console nextmv/cli/main.py
         working-directory: nextmv/
 

--- a/nextmv/nextmv/__about__.py
+++ b/nextmv/nextmv/__about__.py
@@ -1,1 +1,1 @@
-__version__ = "v1.6.0"
+__version__ = "v1.6.1.dev0"

--- a/nextmv/nextmv/local/application.py
+++ b/nextmv/nextmv/local/application.py
@@ -361,6 +361,9 @@ class Application(BaseModel):
         # Get the path to the initial app structure template.
         current_file_dir = os.path.dirname(os.path.abspath(__file__))
         template = f"{manifest_type.value}_{content_format.value}_{example}"
+        # Note: we are deliberately including the templates directory in the pyinstaller
+        # release, as it otherwise would not be included and the initialize function would
+        # break. Make sure to keep this in mind if changing the location of the templates.
         initial_app_structure_path = os.path.join(current_file_dir, "..", "templates", template)
         initial_app_structure_path = os.path.normpath(initial_app_structure_path)
 


### PR DESCRIPTION
# Description

Fixes the `nextmv init` command for pyinstaller releases. Previously, the templates were not bundled correctly, causing the init command to fail when trying to copy them.

## Changes

- Fixes the `nextmv init` command for pyinstaller releases (like `winget`).