### PR TITLE
Warn the user with conflicting profile and API key/endpoint configs

### DIFF
--- a/nextmv/nextmv/cli/main.py
+++ b/nextmv/nextmv/cli/main.py
@@ -13,6 +13,7 @@ about the features used here. An example of Rich markup can be found in the
 epilog of the Typer application defined below.
 """
 
+import os
 import sys
 from typing import Annotated
 
@@ -30,6 +31,7 @@ from nextmv.cli.manifest import app as manifest_app
 from nextmv.cli.message import confirmation, error, info, success, warning
 from nextmv.cli.version import app as version_app
 from nextmv.cli.version import version_callback
+from nextmv.cloud.client import retrieve_endpoint_from_config, retrieve_key_from_config
 
 # Disable dim text for the extended help of commands.
 rich_utils.STYLE_HELPTEXT = ""
@@ -91,11 +93,12 @@ def callback(
     if ctx.invoked_subcommand in ignored_commands:
         return
 
-    handle_go_cli()
-    handle_config_existence(ctx)
+    _handle_go_cli()
+    _handle_config_existence(ctx)
+    _handle_env_vars_and_profile(ctx)
 
 
-def handle_go_cli() -> None:
+def _handle_go_cli() -> None:
     """
     Handle the presence of the deprecated Go CLI by notifying the user.
 
@@ -103,14 +106,14 @@ def handle_go_cli() -> None:
     remove it to avoid conflicts with the Python CLI.
     """
 
-    exists = go_cli_exists()
+    exists = _go_cli_exists()
     if exists:
         delete = confirmation(
             "Do you want to delete the [italic red]deprecated[/italic red] Nextmv CLI "
             f"at [magenta]{GO_CLI_PATH}[/magenta] now?"
         )
         if delete:
-            remove_go_cli()
+            _remove_go_cli()
             return
 
         info(
@@ -121,7 +124,7 @@ def handle_go_cli() -> None:
         )
 
 
-def handle_config_existence(ctx: typer.Context) -> None:
+def _handle_config_existence(ctx: typer.Context) -> None:
     """
     Check if configuration exists and show an error if it does not.
 
@@ -136,7 +139,90 @@ def handle_config_existence(ctx: typer.Context) -> None:
         error("No configuration found. Please run [code]nextmv configuration create[/code].")
 
 
-def go_cli_exists() -> bool:
+def _handle_env_vars_and_profile(ctx: typer.Context) -> None:  # noqa: C901 # At the edge, breaking it reduces readability.
+    """
+    Warn when environment variables conflict with profile settings.
+
+    Checks NEXTMV_API_KEY, NEXTMV_ENDPOINT, and NEXTMV_PROFILE against the
+    active profile (from --profile/-p or NEXTMV_PROFILE) and emits warnings
+    when values differ or both a profile env var and flag are set simultaneously.
+
+    Parameters
+    ----------
+    ctx : typer.Context
+        The Typer context object.
+    """
+
+    api_key = os.getenv("NEXTMV_API_KEY")
+    api_key_set = api_key is not None
+
+    endpoint_var = os.getenv("NEXTMV_ENDPOINT")
+    endpoint_set = endpoint_var is not None
+
+    profile_var = os.getenv("NEXTMV_PROFILE")
+    profile_var_set = profile_var is not None
+
+    profile_opts = {"--profile", "-p"}
+    profile_opt_set = not profile_opts.isdisjoint(sys.argv)
+
+    # First, check if we don't have to warn or inform of anything.
+    override_not_used = not api_key_set and not endpoint_set
+    if override_not_used and not profile_var_set and not profile_opt_set:
+        return
+
+    # Get the value of the profile option, if set.
+    profile_from_opt = None
+    if profile_opt_set:
+        profile_from_opt = next(
+            (sys.argv[i + 1] for i, arg in enumerate(sys.argv[:-1]) if arg in profile_opts),
+            None,
+        )
+
+    # Determine the profile to use based on the environment variable and option.
+    profile = None
+    profile_name = "default"
+    if profile_var_set:
+        profile = profile_var
+        profile_name = profile_var
+    elif profile_opt_set:
+        profile = profile_from_opt
+        profile_name = profile_from_opt
+
+    # Warn if conflicting profile specifications are found.
+    if profile_var_set and profile_opt_set and profile_var != profile_from_opt:
+        warning(
+            "Both the [magenta]NEXTMV_PROFILE[/magenta] environment variable and the [magenta]--profile/-p[/magenta] "
+            "option are set with [italic]different[/italic] values. This may cause an unexpected behavior. "
+            "The env var takes precedence."
+        )
+
+    # Warn if API key specs are conflicting.
+    if api_key_set:
+        conf_key = retrieve_key_from_config(profile=profile)
+        if conf_key != api_key:
+            warning(
+                "The [magenta]NEXTMV_API_KEY[/magenta] environment variable is set, "
+                "and its value [italic]differs[/italic] "
+                f"from the API key of the [magenta]{profile_name}[/magenta] profile. "
+                "This may cause an unexpected behavior. The env var takes precedence."
+            )
+
+    # Warn if endpoint specs are conflicting.
+    if endpoint_set:
+        if not endpoint_var.startswith("https://") and not endpoint_var.startswith("http://"):
+            endpoint = f"https://{endpoint_var}"
+
+        conf_endpoint = retrieve_endpoint_from_config(profile=profile)
+        if conf_endpoint != endpoint:
+            warning(
+                "The [magenta]NEXTMV_ENDPOINT[/magenta] environment variable is set, "
+                "and its value [italic]differs[/italic] "
+                f"from the endpoint of the [magenta]{profile_name}[/magenta] profile. "
+                "This may cause an unexpected behavior. The env var takes precedence."
+            )
+
+
+def _go_cli_exists() -> bool:
     """
     Check if the Go CLI is installed by looking for the 'nextmv' executable
     under the config dir.
@@ -158,7 +244,7 @@ def go_cli_exists() -> bool:
     return exists
 
 
-def remove_go_cli() -> None:
+def _remove_go_cli() -> None:
     """
     Remove the Go CLI executable if it exists and notify about PATH cleanup.
     """

--- a/nextmv/nextmv/cli/main.py
+++ b/nextmv/nextmv/cli/main.py
@@ -88,13 +88,16 @@ def callback(
     if "--help" in sys.argv or "-h" in sys.argv:
         return
 
-    # Skip checks for certain commands.
-    ignored_commands = {"configuration", "mcp", "local", "init", "manifest", "version"}
+    # Skip checks for certain commands entirely.
+    ignored_commands = {"configuration", "mcp", "manifest", "version"}
     if ctx.invoked_subcommand in ignored_commands:
         return
 
-    _handle_go_cli()
-    _handle_config_existence(ctx)
+    # 'init' and 'local' don't require the go CLI or config checks.
+    if ctx.invoked_subcommand not in {"init", "local"}:
+        _handle_go_cli()
+        _handle_config_existence(ctx)
+
     _handle_env_vars_and_profile(ctx)
 
 
@@ -152,6 +155,10 @@ def _handle_env_vars_and_profile(ctx: typer.Context) -> None:  # noqa: C901 # At
     ctx : typer.Context
         The Typer context object.
     """
+
+    # Only applies to: 'cloud ...', 'community ...', 'init', and 'local app sync'.
+    if ctx.invoked_subcommand == "local" and "sync" not in sys.argv:
+        return
 
     api_key = os.getenv("NEXTMV_API_KEY")
     api_key_set = api_key is not None

--- a/nextmv/nextmv/cloud/client.py
+++ b/nextmv/nextmv/cloud/client.py
@@ -603,16 +603,16 @@ class Client:
         """
         if self.url is not None and self.url != "":
             url = self.url
-        elif (url_env := os.getenv("NEXTMV_ENDPOINT")):
+        elif url_env := os.getenv("NEXTMV_ENDPOINT"):
             url = url_env
         elif profile is not None and profile != "":
-            url = _retrieve_endpoint_from_config(profile)
+            url = retrieve_endpoint_from_config(profile)
         else:
             # The fallback behavior is to attempt to retrieve the default endpoint
             # from the config file. If everything fails, we return the hardcoded
             # default endpoint.
             try:
-                url = _retrieve_endpoint_from_config()
+                url = retrieve_endpoint_from_config()
             except (RuntimeError, ValueError):
                 url = "https://api.cloud.nextmv.io"
 
@@ -659,13 +659,13 @@ class Client:
             return api_key_env
 
         if profile is not None and profile != "":
-            api_key = _retrieve_key_from_config(profile)
+            api_key = retrieve_key_from_config(profile)
             return api_key
 
         # The fallback behavior is to attempt to retrieve the default api key
         # from the config file. If the key is missing, an exception is raised.
         try:
-            api_key = _retrieve_key_from_config()
+            api_key = retrieve_key_from_config()
         except (RuntimeError, ValueError) as e:
             raise ValueError(
                 "API key is missing. Please set the API key in one of the following ways: "
@@ -783,7 +783,7 @@ def _load_config() -> dict[str, Any]:
     return config
 
 
-def _retrieve_key_from_config(profile: str | None = None) -> str:
+def retrieve_key_from_config(profile: str | None = None) -> str:
     """
     Retrieves the API key for the given profile. If no profile is given, the
     default profile is used. If the API key is missing, an exception is raised.
@@ -828,7 +828,7 @@ def _retrieve_key_from_config(profile: str | None = None) -> str:
     return api_key
 
 
-def _retrieve_endpoint_from_config(profile: str | None = None) -> str:
+def retrieve_endpoint_from_config(profile: str | None = None) -> str:
     """
     Retrieves the endpoint for the given profile. If no profile is given, the
     default profile is used. If the endpoint is missing, an exception is

--- a/nextmv/tests/cli/test_configuration.py
+++ b/nextmv/tests/cli/test_configuration.py
@@ -8,6 +8,8 @@ import unittest
 from pathlib import Path
 from unittest.mock import mock_open, patch
 
+from typer.testing import CliRunner
+
 from nextmv.cli.configuration.config import (
     API_KEY_KEY,
     CONFIG_DIR,
@@ -19,8 +21,7 @@ from nextmv.cli.configuration.config import (
     obscure_api_key,
     save_config,
 )
-from nextmv.cli.main import app, go_cli_exists, remove_go_cli
-from typer.testing import CliRunner
+from nextmv.cli.main import _go_cli_exists, _remove_go_cli, app
 
 
 class TestConfigureCommand(unittest.TestCase):
@@ -269,7 +270,7 @@ class TestGoCliExists(unittest.TestCase):
         """Test that go_cli_exists returns True when the Go CLI file exists."""
         mock_exists.return_value = True
 
-        result = go_cli_exists()
+        result = _go_cli_exists()
 
         self.assertTrue(result)
 
@@ -278,7 +279,7 @@ class TestGoCliExists(unittest.TestCase):
         """Test that go_cli_exists returns False when the Go CLI file does not exist."""
         mock_exists.return_value = False
 
-        result = go_cli_exists()
+        result = _go_cli_exists()
 
         self.assertFalse(result)
 
@@ -293,7 +294,7 @@ class TestRemoveGoCli(unittest.TestCase):
         """Test that remove_go_cli deletes the file when it exists."""
         mock_exists.return_value = True
 
-        remove_go_cli()
+        _remove_go_cli()
 
         mock_unlink.assert_called_once()
 
@@ -303,7 +304,7 @@ class TestRemoveGoCli(unittest.TestCase):
         """Test that remove_go_cli does not attempt to delete when file does not exist."""
         mock_exists.return_value = False
 
-        remove_go_cli()
+        _remove_go_cli()
 
         mock_unlink.assert_not_called()
 

--- a/nextmv/tests/cli/test_configuration.py
+++ b/nextmv/tests/cli/test_configuration.py
@@ -8,8 +8,6 @@ import unittest
 from pathlib import Path
 from unittest.mock import mock_open, patch
 
-from typer.testing import CliRunner
-
 from nextmv.cli.configuration.config import (
     API_KEY_KEY,
     CONFIG_DIR,
@@ -22,6 +20,7 @@ from nextmv.cli.configuration.config import (
     save_config,
 )
 from nextmv.cli.main import _go_cli_exists, _remove_go_cli, app
+from typer.testing import CliRunner
 
 
 class TestConfigureCommand(unittest.TestCase):

--- a/nextmv/tests/cli/test_main.py
+++ b/nextmv/tests/cli/test_main.py
@@ -16,7 +16,7 @@ class TestCallback(unittest.TestCase):
         self.runner = CliRunner()
         self.app = app
 
-    @patch("nextmv.cli.main.go_cli_exists")
+    @patch("nextmv.cli.main._go_cli_exists")
     @patch("nextmv.cli.main.load_config")
     def test_callback_skips_config_check_for_configure(self, mock_load_config, mock_go_cli_exists):
         """Test that the callback skips config check when running configuration."""
@@ -28,7 +28,7 @@ class TestCallback(unittest.TestCase):
         self.assertEqual(result.exit_code, 0)
         self.assertIn("Configure the CLI", result.output)
 
-    @patch("nextmv.cli.main.go_cli_exists")
+    @patch("nextmv.cli.main._go_cli_exists")
     @patch("nextmv.cli.main.load_config")
     def test_callback_shows_error_when_no_config(self, mock_load_config, mock_go_cli_exists):
         """Test that the callback shows error when no config exists for other commands."""
@@ -38,7 +38,7 @@ class TestCallback(unittest.TestCase):
         result = self.runner.invoke(self.app, ["version"])
         self.assertEqual(result.exit_code, 0)
 
-    @patch("nextmv.cli.main.go_cli_exists")
+    @patch("nextmv.cli.main._go_cli_exists")
     @patch("nextmv.cli.main.load_config")
     def test_callback_allows_command_when_config_exists(self, mock_load_config, mock_go_cli_exists):
         """Test that the callback allows commands when config exists."""
@@ -56,7 +56,7 @@ class TestHandleGoCli(unittest.TestCase):
         self.runner = CliRunner()
         self.app = app
 
-    @patch("nextmv.cli.main.go_cli_exists")
+    @patch("nextmv.cli.main._go_cli_exists")
     @patch("nextmv.cli.main.load_config")
     def test_no_prompt_when_go_cli_not_exists(self, mock_load_config, mock_go_cli_exists):
         """Test that no prompt is shown when Go CLI does not exist."""

--- a/nextmv/tests/cli/test_mcp.py
+++ b/nextmv/tests/cli/test_mcp.py
@@ -26,7 +26,7 @@ class TestMCPServeCommand(unittest.TestCase):
     def setUp(self):
         self.runner = CliRunner()
 
-    @patch("nextmv.cli.main.go_cli_exists")
+    @patch("nextmv.cli.main._go_cli_exists")
     @patch("nextmv.cli.main.load_config")
     def test_mcp_help(self, mock_load_config, mock_go_cli_exists):
         """Test that `nextmv mcp --help` shows the MCP help text."""
@@ -37,7 +37,7 @@ class TestMCPServeCommand(unittest.TestCase):
         self.assertEqual(result.exit_code, 0)
         self.assertIn("Model Context Protocol", result.output)
 
-    @patch("nextmv.cli.main.go_cli_exists")
+    @patch("nextmv.cli.main._go_cli_exists")
     @patch("nextmv.cli.main.load_config")
     def test_mcp_serve_help(self, mock_load_config, mock_go_cli_exists):
         """Test that `nextmv mcp serve --help` shows serve help text."""
@@ -51,7 +51,7 @@ class TestMCPServeCommand(unittest.TestCase):
         self.assertIn("--transport", output)
         self.assertIn("--port", output)
 
-    @patch("nextmv.cli.main.go_cli_exists")
+    @patch("nextmv.cli.main._go_cli_exists")
     @patch("nextmv.cli.main.load_config")
     def test_mcp_skips_config_check(self, mock_load_config, mock_go_cli_exists):
         """Test that `nextmv mcp` skips config existence check."""
@@ -1964,7 +1964,7 @@ class TestMCPOptionalDependency(unittest.TestCase):
 
         with (
             patch(
-                "nextmv.cli.main.go_cli_exists",
+                "nextmv.cli.main._go_cli_exists",
                 return_value=False,
             ),
             patch(


### PR DESCRIPTION
# Description

Adds new logic to the main callback of the CLI to analyze the state of profiles, API key override and endpoint override. If a conflicting configuration is found, a warning is emitted.


Worst case scenario:

```bash
$ NEXTMV_PROFILE=carrot NEXTMV_API_KEY=$DIFFERENT_NEXTMV_API_KEY NEXTMV_ENDPOINT=api.different.endpoint nextmv cloud app list --profile lettuce
🚧  Warning: Both the NEXTMV_PROFILE environment variable and the --profile/-p option are set with different values. This may cause an unexpected behavior. The env var takes precedence.
🚧  Warning: The NEXTMV_API_KEY environment variable is set, and its value differs from the API key of the carrot profile. This may cause an unexpected behavior. The env var takes precedence.
🚧  Warning: The NEXTMV_ENDPOINT environment variable is set, and its value differs from the endpoint of the carrot profile. This may cause an unexpected behavior. The env var takes precedence.
⏳ Listing applications...
```