### PR TITLE
Use instance created during `init` for run execution

### DIFF
--- a/nextmv/nextmv/cli/cloud/app/push.py
+++ b/nextmv/nextmv/cli/cloud/app/push.py
@@ -198,7 +198,7 @@ def handle_push(
     update_instance_id: str | None,
     create_defined: bool,
     create_instance_id: str | None,
-) -> None:
+) -> str:
     """
     Handle the core push flow: push the application, create a version, and link it to an instance.
 
@@ -226,6 +226,12 @@ def handle_push(
         Whether --create-instance-id was provided.
     create_instance_id : str | None
         The instance ID to create.
+
+    Returns
+    -------
+    str
+        The instance ID that was linked to the version, or an empty string if
+        no instance was linked.
     """
 
     # Do the normal push first.
@@ -247,7 +253,7 @@ def handle_push(
         now=now,
     )
     if not should_continue:
-        return
+        return ""
 
     # If the override for updating an instance was used, we update the instance
     # and we are done.
@@ -260,7 +266,7 @@ def handle_push(
             instance_id=update_instance_id,
         )
 
-        return
+        return update_instance_id
 
     # If the override for creating a new instance was used, we create the
     # instance and we are done.
@@ -274,15 +280,17 @@ def handle_push(
             now=now,
         )
 
-        return
+        return create_instance_id
 
     # If no overrides are used, we handle instance prompting.
-    _handle_instance_prompting(
+    instance_id = _handle_instance_prompting(
         cloud_app=cloud_app,
         app_id=app_id,
         version_id=version_id,
         now=now,
     )
+
+    return instance_id
 
 
 def _handle_version_creation(
@@ -363,7 +371,7 @@ def _handle_instance_prompting(
     app_id: str,
     version_id: str,
     now: datetime,
-) -> None:
+) -> str:
     """
     Handle interactive prompting for linking a version to an instance after a push.
 
@@ -379,7 +387,13 @@ def _handle_instance_prompting(
     version_id : str
         The version ID to link to an instance.
     now : datetime
-        The current datetime, used for instance description if a new instance is created.
+        The current datetime, used for instance description if a new instance
+        is created.
+
+    Returns
+    -------
+    str
+        The instance ID that was linked to the version, or an empty string if no instance was linked.
     """
 
     # If this is not an interactive terminal, do not ask for instance linking,
@@ -387,7 +401,7 @@ def _handle_instance_prompting(
     if not sys.stdin.isatty():
         info("Non-interactive terminal detected. Skipping instance linking.")
 
-        return
+        return ""
 
     # Prompt the user for an instance ID to link the new version to.
     instance_id = Prompt.ask(
@@ -397,7 +411,7 @@ def _handle_instance_prompting(
     )
     if instance_id == "":
         info("No instance ID provided. Skipping instance linking.")
-        return
+        return ""
 
     # Based on whether the instance exists or not, ask the user if they want to
     # update or create it.
@@ -413,7 +427,7 @@ def _handle_instance_prompting(
 
         if not should_update:
             info(f"Will not update instance [magenta]{instance_id}[/magenta].")
-            return
+            return ""
 
         _update_instance(
             cloud_app=cloud_app,
@@ -422,7 +436,7 @@ def _handle_instance_prompting(
             instance_id=instance_id,
         )
 
-        return
+        return instance_id
 
     # If the instance does not exist, ask if we want to create it.
     should_create = confirmation(
@@ -433,7 +447,7 @@ def _handle_instance_prompting(
 
     if not should_create:
         info(f"Will not create instance [magenta]{instance_id}[/magenta].")
-        return
+        return ""
 
     _create_instance(
         cloud_app=cloud_app,
@@ -442,6 +456,8 @@ def _handle_instance_prompting(
         instance_id=instance_id,
         now=now,
     )
+
+    return instance_id
 
 
 def _update_instance(

--- a/nextmv/nextmv/cli/init.py
+++ b/nextmv/nextmv/cli/init.py
@@ -118,11 +118,11 @@ def init() -> None:
             commands.extend(cmds4)
             rule()
 
-            cmd5 = _handle_app_push(cloud_app)
+            instance_id, cmd5 = _handle_app_push(cloud_app)
             commands.append(cmd5)
             rule()
 
-            cloud_run_id, cmd6 = _handle_cloud_run_create(cloud_app, local_app, template)
+            cloud_run_id, cmd6 = _handle_cloud_run_create(cloud_app, local_app, template, instance_id)
             commands.append(cmd6)
             rule()
 
@@ -685,7 +685,7 @@ def _handle_app_sync() -> tuple[cloud.Application, list[ExecutedCommand]]:
     return cloud_app, commands
 
 
-def _handle_app_push(cloud_app: cloud.Application) -> ExecutedCommand:
+def _handle_app_push(cloud_app: cloud.Application) -> tuple[str, ExecutedCommand]:
     """
     Prompt the user to push their application to Nextmv Cloud.
 
@@ -701,8 +701,9 @@ def _handle_app_push(cloud_app: cloud.Application) -> ExecutedCommand:
 
     Returns
     -------
-    ExecutedCommand
-        The command that was executed to push the app to Nextmv Cloud.
+    tuple[str, ExecutedCommand]
+        The instance ID returned by the push command and the command that was
+        executed to perform the push.
 
     Raises
     ------
@@ -736,7 +737,7 @@ def _handle_app_push(cloud_app: cloud.Application) -> ExecutedCommand:
     # Actually execute the command to push the app to Nextmv Cloud.
     str_cmd = f"nextmv cloud app push --app-id {cloud_app.id}"
     in_progress(f"Pushing application with command: [code]{str_cmd}[/code]")
-    handle_push(
+    instance_id = handle_push(
         cloud_app=cloud_app,
         app_id=cloud_app.id,
         app_dir=None,
@@ -750,13 +751,14 @@ def _handle_app_push(cloud_app: cloud.Application) -> ExecutedCommand:
         create_instance_id=None,
     )
 
-    return ExecutedCommand(cmd=str_cmd, explanation="Push the application to Nextmv Cloud")
+    return instance_id, ExecutedCommand(cmd=str_cmd, explanation="Push the application to Nextmv Cloud")
 
 
 def _handle_cloud_run_create(
     cloud_app: cloud.Application,
     local_app: local.Application,
     is_template: bool,
+    instance_id: str,
 ) -> tuple[str, ExecutedCommand]:
     """
     Prompt the user to start a run for their Cloud application.
@@ -773,6 +775,9 @@ def _handle_cloud_run_create(
         The local application to use as input for the run.
     is_template : bool
         Whether the local application is a template.
+    instance_id : str
+        The instance ID returned by the push command, which can be used as
+        input for the run.
 
     Returns
     -------
@@ -815,6 +820,9 @@ def _handle_cloud_run_create(
 
     # Actually execute the command to start the Cloud run.
     command = ["nextmv", "cloud", "run", "create", "--app-id", cloud_app.id, "--input", dirpath]
+    if instance_id:
+        command.extend(["--instance-id", instance_id])
+
     str_cmd = " ".join(command)
     in_progress(f"Starting [italic]remote[/italic] run with command: [code]{str_cmd}[/code]")
     result = _cli_call(command)


### PR DESCRIPTION
# Description

Uses the instance that is created during the `init` process to start the remote run, as opposed to always using `latest`.

## Examples

1. Created the `prod` instance, and it is used to create the run.

   <img width="843" height="237" alt="image" src="https://github.com/user-attachments/assets/6400b22e-3b33-4f47-ac65-22d5509bb511" />

1. Didn't create a version or instance, `latest` is used as the default.

   <img width="773" height="197" alt="image" src="https://github.com/user-attachments/assets/8b842ec6-9c08-4f36-9d54-ac6a432fb5d7" />

1. Created a version but didn't create an instance, `latest` is used as the default.

   <img width="800" height="244" alt="image" src="https://github.com/user-attachments/assets/61ec6223-9c36-4696-ba29-d2b2ef1847dc" />

1. _Updated_ the `prod` instance, and it is used to create the run.

   <img width="853" height="276" alt="image" src="https://github.com/user-attachments/assets/b63da879-c728-4d64-b039-3f2b1e1bbde8" />
