### PR TITLE
Avoid showing assets for JSON runs to keep terminal more compact

### DIFF
--- a/nextmv/nextmv/cli/cloud/run/get.py
+++ b/nextmv/nextmv/cli/cloud/run/get.py
@@ -8,7 +8,7 @@ from typing import Annotated
 import typer
 
 from nextmv.cli.configuration.config import build_cloud_app
-from nextmv.cli.message import in_progress, print_json, success
+from nextmv.cli.message import in_progress, info, print_json, success
 from nextmv.cli.options import AppIDOption, ProfileOption, RunIDOption
 from nextmv.cloud.application import Application
 from nextmv.content_format import ContentFormat
@@ -176,6 +176,16 @@ def handle_outputs(
     # Handle the case where output is embedded directly in the result: json and text.
     if content_format == ContentFormat.JSON:
         if output is None or output == "":
+            # To avoid overflowing the terminal with a huge output, we trim the assets.
+            res_output = run_result.output
+            if isinstance(res_output, dict) and "assets" in res_output.keys():
+                info(
+                    "Removed [magenta]assets[/magenta] from output for cleaner display, "
+                    "use --output to save the full output."
+                )
+                del res_output["assets"]
+                run_result.output = res_output
+
             print_json(run_result.to_dict())
         else:
             with open(output, "w") as f:

--- a/nextmv/nextmv/cli/local/run/get.py
+++ b/nextmv/nextmv/cli/local/run/get.py
@@ -188,6 +188,16 @@ def handle_outputs(
     # Handle the case where output is embedded directly in the result: json and text.
     if content_format == ContentFormat.JSON:
         if output is None or output == "":
+            # To avoid overflowing the terminal with a huge output, we trim the assets.
+            res_output = run_result.output
+            if isinstance(res_output, dict) and "assets" in res_output.keys():
+                info(
+                    "Removed [magenta]assets[/magenta] from output for cleaner display, "
+                    "use --output to save the full output."
+                )
+                del res_output["assets"]
+                run_result.output = res_output
+
             print_json(run_result.to_dict())
         else:
             with open(output, "w") as f:


### PR DESCRIPTION
# Description

When using `nextmv cloud/local run create/get` with a `json` app that produces assets, the output typically showed the full JSON result with the assets bundled in the response:

<img width="518" height="573" alt="image" src="https://github.com/user-attachments/assets/d88f86e0-e988-4b5a-bb04-fb563f879360" />

This doesn't produce much value, as it is mostly illegible information.

Now, a `json` output containing assets is trimmed by default. People can still use `--output` to save the full output to a file.

<img width="726" height="623" alt="image" src="https://github.com/user-attachments/assets/61de724d-5563-4d61-af0e-512304dc201f" />