### PR TITLE
Fix stale 'Licensed Work' line in gurobipy / scikit-learn LICENSE files

### DIFF
--- a/nextmv-gurobipy/LICENSE
+++ b/nextmv-gurobipy/LICENSE
@@ -5,7 +5,7 @@ Business Source License 1.1
 Parameters
 
 Licensor:             nextmv.io inc
-Licensed Work:        nextroute
+Licensed Work:        nextmv-gurobipy
 
 Change Date:          Four years from the date the Licensed Work is published.
 Change License:       GPLv3

--- a/nextmv-scikit-learn/LICENSE
+++ b/nextmv-scikit-learn/LICENSE
@@ -5,7 +5,7 @@ Business Source License 1.1
 Parameters
 
 Licensor:             nextmv.io inc
-Licensed Work:        nextroute
+Licensed Work:        nextmv-scikit-learn
 
 Change Date:          Four years from the date the Licensed Work is published.
 Change License:       GPLv3


### PR DESCRIPTION
## Summary

Two subpackage `LICENSE` files (BUSL-1.1) have a stale copy-paste on line 8:

- `nextmv-gurobipy/LICENSE`: `Licensed Work: nextroute` → `nextmv-gurobipy`
- `nextmv-scikit-learn/LICENSE`: `Licensed Work: nextroute` → `nextmv-scikit-learn`

The rest of each file is correct; only the `Licensed Work:` parameter in the BUSL header was wrong, presumably copy-pasted from nextroute's LICENSE when these subpackages were initialized.

## Why it matters

The BUSL-1.1 grant references "the Licensed Work" throughout the license body, and that phrase is defined by line 8. The grant was legally operative either way (a reasonable reader would identify the Licensed Work from the containing directory), but the metadata is now accurate.

## Context

Surfaced during an open-source security diligence review that parses each subpackage's LICENSE file independently.