### PR TITLE
Fixes release workflow invocation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ jobs:
     uses: nextmv-io/release/.github/workflows/release.yml@develop
     permissions:
       contents: write
+      pull-requests: write
     with:
       BRANCH: ${{ github.ref_name }}
       REPOSITORY: nextmv-py
@@ -158,6 +159,7 @@ jobs:
     uses: nextmv-io/release/.github/workflows/release.yml@develop
     permissions:
       contents: write
+      pull-requests: write
     with:
       BRANCH: ${{ github.ref_name }}
       REPOSITORY: nextmv-py
@@ -216,6 +218,7 @@ jobs:
     uses: nextmv-io/release/.github/workflows/release.yml@develop
     permissions:
       contents: write
+      pull-requests: write
     with:
       BRANCH: ${{ github.ref_name }}
       REPOSITORY: nextmv-py

--- a/nextmv/nextmv/__about__.py
+++ b/nextmv/nextmv/__about__.py
@@ -1,1 +1,1 @@
-__version__ = "v1.6.2"
+__version__ = "v1.6.3.dev0"


### PR DESCRIPTION
# Description

Grants the release workflow the `pull-request: write` permission it requests again. This should fix the currently broken release workflow.