### PR TITLE
Improves binary release performance

### DIFF
--- a/.github/actions/build-binary/action.yml
+++ b/.github/actions/build-binary/action.yml
@@ -1,0 +1,61 @@
+name: Build and zip binary
+description: >
+  Sets up Python, installs dependencies, builds the nextmv binary with
+  PyInstaller, and zips the output directory for distribution.
+
+inputs:
+  os:
+    description: Target OS label (linux, macos, windows)
+    required: true
+  arch:
+    description: Target architecture label (x64, arm64)
+    required: true
+
+outputs:
+  zip-name:
+    description: File name of the produced zip archive
+    value: ${{ steps.zip.outputs.zip-name }}
+
+runs:
+  using: composite
+  steps:
+    - name: setup Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: "3.13"
+
+    - name: install dependencies
+      shell: bash
+      run: |
+        python -m pip install --upgrade pip
+        pip install pyinstaller uv
+        pip install .
+      working-directory: nextmv/
+
+    - name: build binary with PyInstaller
+      shell: bash
+      # Binary will be located at nextmv/dist/nextmv/nextmv (or nextmv/dist/nextmv/nextmv.exe on Windows)
+      run: ./.github/scripts/build-single-binary.sh
+
+    - name: zip binary directory for distribution
+      id: zip
+      shell: python
+      run: |
+        import zipfile, os, pathlib
+
+        os_label   = "${{ inputs.os }}"
+        arch_label = "${{ inputs.arch }}"
+        zip_name   = f"nextmv-{os_label}-{arch_label}.zip"
+
+        src_dir  = pathlib.Path("nextmv/dist/nextmv")
+        zip_path = pathlib.Path("nextmv/dist") / zip_name
+
+        with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
+            for file in src_dir.rglob("*"):
+                zf.write(file, file.relative_to(src_dir))
+
+        print(f"Created {zip_path} ({zip_path.stat().st_size} bytes)")
+
+        # Expose the zip name as a step output
+        with open(os.environ["GITHUB_OUTPUT"], "a") as fh:
+            fh.write(f"zip-name={zip_name}\n")

--- a/.github/scripts/build-single-binary.sh
+++ b/.github/scripts/build-single-binary.sh
@@ -22,7 +22,7 @@ echo "Bundling uv binary from: $UV_BIN"
 # Run PyInstaller
 uv run --with pyinstaller pyinstaller \
     --name nextmv \
-    --onefile \
+    --onedir \
     --clean \
     --add-data "nextmv/templates${ADD_DATA_SEPARATOR}nextmv/templates" \
     --add-data "nextmv/local/executor.py${ADD_DATA_SEPARATOR}nextmv/local" \

--- a/.github/workflows/release-winget.yml
+++ b/.github/workflows/release-winget.yml
@@ -68,6 +68,6 @@ jobs:
         run: |
           wingetcreate update Nextmv.CLI \
             --version "$VERSION" \
-            --urls "https://github.com/nextmv-io/nextmv-py/releases/download/nextmv-v${VERSION}/nextmv-windows-x64.exe|x64|portable" \
+            --urls "https://github.com/nextmv-io/nextmv-py/releases/download/nextmv-v${VERSION}/nextmv-windows-x64.zip|x64|zip" \
             --submit \
             --token "$WINGET_TOKEN"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: build and zip binary
+        id: build-binary
         uses: ./.github/actions/build-binary
         with:
           os: ${{ matrix.os }}
@@ -77,7 +78,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release upload $VERSION dist/nextmv-${{ matrix.os }}-${{ matrix.arch }}.zip --clobber
+          gh release upload $VERSION dist/${{ steps.build-binary.outputs.zip-name }} --clobber
         working-directory: nextmv/
 
   # Unfortunately, PyPI publishing does not support reusable workflows, so we

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,29 +59,11 @@ jobs:
       - name: checkout repository
         uses: actions/checkout@v6
 
-      - name: setup Python
-        uses: actions/setup-python@v6
+      - name: build and zip binary
+        uses: ./.github/actions/build-binary
         with:
-          python-version: "3.13"
-
-      - name: install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install pyinstaller uv
-          pip install .
-        working-directory: nextmv/
-
-      - name: build binary with PyInstaller
-        shell: bash
-        # Binary will be located at nextmv/dist/nextmv/nextmv (or nextmv/dist/nextmv/nextmv.exe on Windows)
-        run: ./.github/scripts/build-single-binary.sh
-
-      - name: zip binary directory for distribution
-        shell: bash
-        run: |
-          cd dist/nextmv
-          zip -r ../nextmv-${{ matrix.os }}-${{ matrix.arch }}.zip *
-        working-directory: nextmv/
+          os: ${{ matrix.os }}
+          arch: ${{ matrix.arch }}
 
       - name: determine exact version being released
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,13 +73,14 @@ jobs:
 
       - name: build binary with PyInstaller
         shell: bash
-        # Binary will be located at nextmv/dist/nextmv (or nextmv/dist/nextmv.exe on Windows)
+        # Binary will be located at nextmv/dist/nextmv/nextmv (or nextmv/dist/nextmv/nextmv.exe on Windows)
         run: ./.github/scripts/build-single-binary.sh
 
-      - name: rename binary for distribution
+      - name: zip binary directory for distribution
         shell: bash
         run: |
-          mv dist/nextmv${{ matrix.ext }} dist/nextmv-${{ matrix.os }}-${{ matrix.arch }}${{ matrix.ext }}
+          cd dist/nextmv
+          zip -r ../nextmv-${{ matrix.os }}-${{ matrix.arch }}.zip *
         working-directory: nextmv/
 
       - name: determine exact version being released
@@ -94,7 +95,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release upload $VERSION dist/nextmv-${{ matrix.os }}-${{ matrix.arch }}${{ matrix.ext }} --clobber
+          gh release upload $VERSION dist/nextmv-${{ matrix.os }}-${{ matrix.arch }}.zip --clobber
         working-directory: nextmv/
 
   # Unfortunately, PyPI publishing does not support reusable workflows, so we

--- a/.github/workflows/single-binary-build.yml
+++ b/.github/workflows/single-binary-build.yml
@@ -39,29 +39,11 @@ jobs:
       - name: checkout repository
         uses: actions/checkout@v6
 
-      - name: setup Python
-        uses: actions/setup-python@v6
+      - name: build and zip binary
+        uses: ./.github/actions/build-binary
         with:
-          python-version: "3.13"
-
-      - name: install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install pyinstaller uv
-          pip install .
-        working-directory: nextmv/
-
-      - name: build binary with PyInstaller
-        shell: bash
-        # Binary will be located at nextmv/dist/nextmv/nextmv (or nextmv/dist/nextmv/nextmv.exe on Windows)
-        run: ./.github/scripts/build-single-binary.sh
-
-      - name: test zip binary directory for distribution
-        shell: bash
-        run: |
-          cd dist/nextmv
-          zip -r ../nextmv-${{ matrix.os }}-${{ matrix.arch }}.zip *
-        working-directory: nextmv/
+          os: ${{ matrix.os }}
+          arch: ${{ matrix.arch }}
 
       - name: smoketest binary
         env:

--- a/.github/workflows/single-binary-build.yml
+++ b/.github/workflows/single-binary-build.yml
@@ -56,6 +56,13 @@ jobs:
         # Binary will be located at nextmv/dist/nextmv/nextmv (or nextmv/dist/nextmv/nextmv.exe on Windows)
         run: ./.github/scripts/build-single-binary.sh
 
+      - name: test zip binary directory for distribution
+        shell: bash
+        run: |
+          cd dist/nextmv
+          zip -r ../nextmv-${{ matrix.os }}-${{ matrix.arch }}.zip *
+        working-directory: nextmv/
+
       - name: smoketest binary
         env:
           NEXTMV_API_KEY: ${{ secrets.NEXTMV_API_KEY }}

--- a/.github/workflows/single-binary-build.yml
+++ b/.github/workflows/single-binary-build.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: build binary with PyInstaller
         shell: bash
-        # Binary will be located at nextmv/dist/nextmv (or nextmv/dist/nextmv.exe on Windows)
+        # Binary will be located at nextmv/dist/nextmv/nextmv (or nextmv/dist/nextmv/nextmv.exe on Windows)
         run: ./.github/scripts/build-single-binary.sh
 
       - name: smoketest binary
@@ -69,4 +69,4 @@ jobs:
           # Use Python to run command with timeout since timeout is not available on macOS.
           python -c "import subprocess; import os; subprocess.run(['.' + os.environ['BINARY'], 'local', 'run', 'create', '-i', 'input.json', '--wait'], timeout=30)"
         shell: bash
-        working-directory: nextmv/dist
+        working-directory: nextmv/dist/nextmv

--- a/nextmv/nextmv/__about__.py
+++ b/nextmv/nextmv/__about__.py
@@ -1,1 +1,1 @@
-__version__ = "v1.7.4.dev0"
+__version__ = "v1.7.4.dev1"

--- a/nextmv/nextmv/__about__.py
+++ b/nextmv/nextmv/__about__.py
@@ -1,1 +1,1 @@
-__version__ = "v1.7.3"
+__version__ = "v1.7.4.dev0"

--- a/nextmv/nextmv/__about__.py
+++ b/nextmv/nextmv/__about__.py
@@ -1,1 +1,1 @@
-__version__ = "v1.7.4.dev1"
+__version__ = "v1.7.4.dev2"


### PR DESCRIPTION
# Description

Moves the new binary release to `--onedir` packaging over `--onefile`. This should improve performance significantly, since previous releases required the CLI binary to self-extract _before each_ invocation.

> [!NOTE]
> This PR can already be merged, but I will likely do follow-up PRs to shift winget release from portable binary to .zip release.

## Changes

- Changes pyinstaller packaging to `--onedir`.
- Changes release artifacts from single binary to portable .zip file.