### PR TITLE
Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/actions/build-binary/action.yml
+++ b/.github/actions/build-binary/action.yml
@@ -20,7 +20,7 @@ runs:
   using: composite
   steps:
     - name: setup Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
       with:
         python-version: "3.13"
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -18,10 +18,10 @@ jobs:
       NEXTMV_API_KEY: ${{ secrets.API_KEY_PROD }}
     steps:
       - name: git clone
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
         with:
           version: "0.9.29"
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -16,10 +16,10 @@ jobs:
         package: ["nextmv", "nextmv-gurobipy", "nextmv-scikit-learn"]
     steps:
       - name: git clone
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
         with:
           version: "0.9.29"
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
 
     steps:
       - name: checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: build and zip binary
         id: build-binary
@@ -94,12 +94,12 @@ jobs:
       id-token: write # This is required for trusted publishing to PyPI
     steps:
       - name: git clone ${{ github.ref_name }}
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: ${{ github.ref_name }}
 
       - name: set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
 
       - name: install dependencies
         run: |
@@ -111,7 +111,7 @@ jobs:
         working-directory: ./nextmv
 
       - name: python - publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
         with:
           packages-dir: ./nextmv/dist
 
@@ -153,12 +153,12 @@ jobs:
       id-token: write # This is required for trusted publishing to PyPI
     steps:
       - name: git clone ${{ github.ref_name }}
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: ${{ github.ref_name }}
 
       - name: set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
 
       - name: install dependencies
         run: |
@@ -170,7 +170,7 @@ jobs:
         working-directory: ./nextmv-gurobipy
 
       - name: python - publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
         with:
           packages-dir: ./nextmv-gurobipy/dist
 
@@ -212,10 +212,10 @@ jobs:
       id-token: write # This is required for trusted publishing to PyPI
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
 
       - name: Install dependencies
         run: |
@@ -227,7 +227,7 @@ jobs:
         working-directory: ./nextmv-scikit-learn
 
       - name: Publish package
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
         with:
           packages-dir: ./nextmv-scikit-learn/dist
 

--- a/.github/workflows/single-binary-build.yml
+++ b/.github/workflows/single-binary-build.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: build and zip binary
         uses: ./.github/actions/build-binary

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -24,10 +24,10 @@ jobs:
         package: ["nextmv", "nextmv-gurobipy", "nextmv-scikit-learn"]
     steps:
       - name: git clone
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
         with:
           version: "0.9.29"
           python-version: ${{ matrix.python-version }}


### PR DESCRIPTION
# Description

Pins all workflow actions to their latest version via shas for improved security (avoiding supply chain attacks).

## Changes

- `actions/setup-python`: `v6` → `v6.2.0` (`a309ff8b426b...`)
- `actions/checkout`: `v6` → `v6.0.2` (`de0fac2e4500...`)
- `astral-sh/setup-uv`: `v7` → `v8.1.0` (`08807647e706...`)
- `pypa/gh-action-pypi-publish`: `release/v1` → `v1.14.0` (`cef221092ed1...`)
