### PR TITLE
Allows empty ID for accept test, name for input set. Allow API key prompt on CLI config

### DIFF
--- a/nextmv/nextmv/cli/cloud/acceptance/create.py
+++ b/nextmv/nextmv/cli/cloud/acceptance/create.py
@@ -80,7 +80,7 @@ app = typer.Typer()
             }},
             "statistic": "mean"
         }}'
-        nextmv cloud acceptance create --app-id hare-app --acceptance-test-id test-123 \\
+        nextmv cloud acceptance create --app-id hare-app \\
             --candidate-instance-id candidate-123 --baseline-instance-id baseline-456 \\
             --metrics "$METRIC" --input-set-id input-set-123[/dim]
 
@@ -103,7 +103,7 @@ app = typer.Typer()
             }},
             "statistic": "p95"
         }}'
-        nextmv cloud acceptance create --app-id hare-app --acceptance-test-id test-123 \\
+        nextmv cloud acceptance create --app-id hare-app \\
             --candidate-instance-id candidate-123 --baseline-instance-id baseline-456 \\
             --metrics "$METRIC1" --metrics "$METRIC2" --input-set-id input-set-123[/dim]
 
@@ -128,7 +128,7 @@ app = typer.Typer()
                 "statistic": "p95"
             }}
         ]'
-        nextmv cloud acceptance create --app-id hare-app --acceptance-test-id test-123 \\
+        nextmv cloud acceptance create --app-id hare-app \\
             --candidate-instance-id candidate-123 --baseline-instance-id baseline-456 \\
             --metrics "$METRICS" --input-set-id input-set-123[/dim]
 
@@ -142,7 +142,7 @@ app = typer.Typer()
             }},
             "statistic": "mean"
         }}'
-        nextmv cloud acceptance create --app-id hare-app --acceptance-test-id test-123 \\
+        nextmv cloud acceptance create --app-id hare-app \\
             --candidate-instance-id candidate-123 --baseline-instance-id baseline-456 \\
             --metrics "$METRIC" --input-set-id input-set-123 --wait[/dim]
 
@@ -156,7 +156,7 @@ app = typer.Typer()
             }},
             "statistic": "mean"
         }}'
-        nextmv cloud acceptance create --app-id hare-app --acceptance-test-id test-123 \\
+        nextmv cloud acceptance create --app-id hare-app \\
             --candidate-instance-id candidate-123 --baseline-instance-id baseline-456 \\
             --metrics "$METRIC" --input-set-id input-set-123 --output results.json[/dim]
     """
@@ -164,17 +164,6 @@ app = typer.Typer()
 def create(
     app_id: AppIDOption,
     # Options for acceptance test configuration.
-    acceptance_test_id: Annotated[
-        str,
-        typer.Option(
-            "--acceptance-test-id",
-            "-t",
-            help="ID for the acceptance test.",
-            envvar="NEXTMV_ACCEPTANCE_TEST_ID",
-            metavar="ACCEPTANCE_TEST_ID",
-            rich_help_panel="Acceptance test configuration",
-        ),
-    ],
     baseline_instance_id: Annotated[
         str,
         typer.Option(
@@ -207,6 +196,17 @@ def create(
             rich_help_panel="Acceptance test configuration",
         ),
     ],
+    acceptance_test_id: Annotated[
+        str | None,
+        typer.Option(
+            "--acceptance-test-id",
+            "-t",
+            help="An optional ID for the acceptance test. If not provided, a random ID will be generated.",
+            envvar="NEXTMV_ACCEPTANCE_TEST_ID",
+            metavar="ACCEPTANCE_TEST_ID",
+            rich_help_panel="Acceptance test configuration",
+        ),
+    ] = None,
     description: Annotated[
         str | None,
         typer.Option(
@@ -233,7 +233,7 @@ def create(
         typer.Option(
             "--name",
             "-n",
-            help="Name of the acceptance test. If not provided, the ID will be used as the name.",
+            help="Optional name of the acceptance test. If not provided, the ID will be used as the name.",
             metavar="NAME",
             rich_help_panel="Acceptance test configuration",
         ),

--- a/nextmv/nextmv/cli/cloud/batch/create.py
+++ b/nextmv/nextmv/cli/cloud/batch/create.py
@@ -26,7 +26,7 @@ def create(
         typer.Option(
             "--batch-experiment-id",
             "-b",
-            help="ID for the batch experiment. Will be generated if not provided.",
+            help="Optional ID for the batch experiment. Will be generated if not provided.",
             envvar="NEXTMV_BATCH_EXPERIMENT_ID",
             metavar="BATCH_EXPERIMENT_ID",
             rich_help_panel="Batch experiment configuration",
@@ -57,7 +57,7 @@ def create(
         typer.Option(
             "--name",
             "-n",
-            help="Name of the batch experiment. If not provided, the ID will be used as the name.",
+            help="Optional name of the batch experiment. If not provided, the ID will be used as the name.",
             metavar="NAME",
             rich_help_panel="Batch experiment configuration",
         ),
@@ -180,7 +180,7 @@ def create(
             "instance_id": "warren-planner-v1"
         }'
         nextmv cloud batch create --app-id hare-app --batch-experiment-id bunny-hop-test \\
-            --name "Spring Meadow Routes" --input-set-id spring-gardens --runs "$RUN"[/dim]
+            --input-set-id spring-gardens --runs "$RUN"[/dim]
 
     - Create with multiple runs by repeating the flag.
         $ [dim]RUN1='{
@@ -191,8 +191,7 @@ def create(
             "input_id": "lettuce-field-2",
             "instance_id": "hop-optimizer"
         }'
-        nextmv cloud batch create --app-id hare-app --batch-experiment-id lettuce-routes \\
-            --name "Lettuce Delivery Optimization" --input-set-id veggie-gardens \\
+        nextmv cloud batch create --app-id hare-app --input-set-id veggie-gardens \\
             --runs "$RUN1" --runs "$RUN2"[/dim]
 
     - Create with multiple runs in a single [magenta]json[/magenta] array.
@@ -206,16 +205,14 @@ def create(
                 "version_id": "tunnel-planner-v3"
             }
         ]'
-        nextmv cloud batch create --app-id hare-app --batch-experiment-id warren-expansion \\
-            --name "Warren Construction Plans" --input-set-id burrow-sites --runs "$RUNS"[/dim]
+        nextmv cloud batch create --app-id hare-app --input-set-id burrow-sites --runs "$RUNS"[/dim]
 
     - Create a batch experiment and wait for it to complete.
         $ [dim]RUN='{
             "input_id": "carrot-harvest",
             "instance_id": "foraging-route"
         }'
-        nextmv cloud batch create --app-id hare-app --batch-experiment-id harvest-time \\
-            --name "Autumn Carrot Collection" --input-set-id harvest-season \\
+        nextmv cloud batch create --app-id hare-app --input-set-id harvest-season \\
             --runs "$RUN" --wait[/dim]
 
     - Create a batch experiment and save the results to a file, waiting for completion.
@@ -223,8 +220,7 @@ def create(
             "input_id": "predator-zones",
             "instance_id": "safe-hopper"
         }'
-        nextmv cloud batch create --app-id hare-app --batch-experiment-id safety-analysis \\
-            --name "Fox Avoidance Routes" --input-set-id danger-zones \\
+        nextmv cloud batch create --app-id hare-app --input-set-id danger-zones \\
             --runs "$RUN" --output bunny-safety-results.json[/dim]
 
     - Create a batch experiment with option sets.
@@ -242,8 +238,7 @@ def create(
             "fast-hops": {"max_speed": "10", "caution_level": "low"},
             "careful-hops": {"max_speed": "5", "caution_level": "high"}
         }'
-        nextmv cloud batch create --app-id hare-app --batch-experiment-id hop-comparison \\
-            --name "Speed vs Safety Analysis" --input-set-id garden-paths \\
+        nextmv cloud batch create --app-id hare-app --input-set-id garden-paths \\
             --runs "$RUN1" --runs "$RUN2" --option-sets "$OPTION_SETS"[/dim]
     """
 

--- a/nextmv/nextmv/cli/cloud/ensemble/create.py
+++ b/nextmv/nextmv/cli/cloud/ensemble/create.py
@@ -203,7 +203,7 @@ def create(
         typer.Option(
             "--name",
             "-n",
-            help="A name for the ensemble definition.",
+            help="Optional name for the ensemble definition. If not provided, the ID will be used as the name.",
             metavar="NAME",
         ),
     ] = None,

--- a/nextmv/nextmv/cli/cloud/input_set/create.py
+++ b/nextmv/nextmv/cli/cloud/input_set/create.py
@@ -123,11 +123,11 @@ def create(
     - Create an input set for application [magenta]hare-app[/magenta] from runs.
       A random input set ID will be generated if one is not provided.
         $ [dim]nextmv cloud input-set create --app-id hare-app \\
-            --run-ids run-1 --run-ids run-2 --run-ids run-3"[/dim]
+            --run-ids run-1 --run-ids run-2 --run-ids run-3[/dim]
 
     - Create an input set with a specific ID and name.
         $ [dim]nextmv cloud input-set create --app-id hare-app --input-set-id hare-input-set \\
-            --name "Hare Input Set" --run-ids run-1 --run-ids run-2 --run-ids run-3"[/dim]
+            --name "Hare Input Set" --run-ids run-1 --run-ids run-2 --run-ids run-3[/dim]
 
     - Create an input set using existing managed inputs.
         $ [dim]nextmv cloud input-set create --app-id hare-app \\

--- a/nextmv/nextmv/cli/cloud/input_set/create.py
+++ b/nextmv/nextmv/cli/cloud/input_set/create.py
@@ -21,15 +21,25 @@ app = typer.Typer()
 @app.command()
 def create(
     app_id: AppIDOption,
-    name: Annotated[
-        str,
+    description: Annotated[
+        str | None,
         typer.Option(
-            "--name",
-            "-n",
-            help="A name for the input set.",
-            metavar="NAME",
+            "--description",
+            "-d",
+            help="An optional description for the input set.",
+            metavar="DESCRIPTION",
         ),
-    ],
+    ] = None,
+    end_time: Annotated[
+        datetime | None,
+        typer.Option(
+            "--end-time",
+            formats=["%Y-%m-%dT%H:%M:%S%z"],
+            help="End time for filtering runs in [magenta]RFC 3339[/magenta] format. "
+            "Object format: [dim]'2024-01-01T00:00:00Z'[/dim]",
+            metavar="END_TIME",
+        ),
+    ] = None,
     input_set_id: Annotated[
         str | None,
         typer.Option(
@@ -49,13 +59,31 @@ def create(
             metavar="INSTANCE_ID",
         ),
     ] = None,
-    description: Annotated[
+    managed_inputs: Annotated[
         str | None,
         typer.Option(
-            "--description",
-            "-d",
-            help="An optional description for the input set.",
-            metavar="DESCRIPTION",
+            "--managed-inputs",
+            help="Managed inputs for the input set. Data should be valid [magenta]json[/magenta]. Object "
+            "format: [dim][{'id': 'id', 'name': 'name', 'description': 'description'}][/dim].",
+            metavar="MANAGED_INPUTS",
+        ),
+    ] = None,
+    maximum_runs: Annotated[
+        int | None,
+        typer.Option(
+            "--maximum-runs",
+            "-m",
+            help="Maximum number of runs to include (max [magenta]20[/magenta]).",
+            metavar="MAXIMUM_RUNS",
+        ),
+    ] = 20,
+    name: Annotated[
+        str | None,
+        typer.Option(
+            "--name",
+            "-n",
+            help="An optional name for the input set. If not provided, the ID will be used as the name.",
+            metavar="NAME",
         ),
     ] = None,
     run_ids: Annotated[
@@ -77,34 +105,6 @@ def create(
             metavar="START_TIME",
         ),
     ] = None,
-    end_time: Annotated[
-        datetime | None,
-        typer.Option(
-            "--end-time",
-            formats=["%Y-%m-%dT%H:%M:%S%z"],
-            help="End time for filtering runs in [magenta]RFC 3339[/magenta] format. "
-            "Object format: [dim]'2024-01-01T00:00:00Z'[/dim]",
-            metavar="END_TIME",
-        ),
-    ] = None,
-    maximum_runs: Annotated[
-        int | None,
-        typer.Option(
-            "--maximum-runs",
-            "-m",
-            help="Maximum number of runs to include (max [magenta]20[/magenta]).",
-            metavar="MAXIMUM_RUNS",
-        ),
-    ] = 20,
-    managed_inputs: Annotated[
-        str | None,
-        typer.Option(
-            "--managed-inputs",
-            help="Managed inputs for the input set. Data should be valid [magenta]json[/magenta]. Object "
-            "format: [dim][{'id': 'id', 'name': 'name', 'description': 'description'}][/dim].",
-            metavar="MANAGED_INPUTS",
-        ),
-    ] = None,
     profile: ProfileOption = None,
 ) -> None:
     """
@@ -123,18 +123,18 @@ def create(
     - Create an input set for application [magenta]hare-app[/magenta] from runs.
       A random input set ID will be generated if one is not provided.
         $ [dim]nextmv cloud input-set create --app-id hare-app \\
-            --name "Hare Input Set" --run-ids run-1 --run-ids run-2 --run-ids run-3"[/dim]
+            --run-ids run-1 --run-ids run-2 --run-ids run-3"[/dim]
 
-    - Create an input set with a specific ID.
+    - Create an input set with a specific ID and name.
         $ [dim]nextmv cloud input-set create --app-id hare-app --input-set-id hare-input-set \\
             --name "Hare Input Set" --run-ids run-1 --run-ids run-2 --run-ids run-3"[/dim]
 
     - Create an input set using existing managed inputs.
-        $ [dim]nextmv cloud input-set create --app-id hare-app --name "Hare Input Set" \\
+        $ [dim]nextmv cloud input-set create --app-id hare-app \\
             --managed-inputs '[{"id": "hare-input-1", "name": "hare input", "description": "hare description"}]'[/dim]
 
     - Create an input set from runs using a specific instance and time range.
-        $ [dim]nextmv cloud input-set create --app-id hare-app --name "Hare Input Set" \\
+        $ [dim]nextmv cloud input-set create --app-id hare-app \\
             --instance-id hare-instance --start-time "2024-01-01T00:00:00Z" \\
             --end-time "2024-01-31T23:59:59Z"[/dim]
     """
@@ -156,8 +156,8 @@ def create(
             managed_input_list.append(i)
 
     input_set = cloud_app.new_input_set(
-        input_set_id,
-        name,
+        id=input_set_id,
+        name=name,
         description=description,
         instance_id=instance_id,
         run_ids=run_ids,

--- a/nextmv/nextmv/cli/cloud/instance/create.py
+++ b/nextmv/nextmv/cli/cloud/instance/create.py
@@ -55,7 +55,7 @@ def create(
         typer.Option(
             "--name",
             "-n",
-            help="A name for the instance. If a name is not provided, the instance ID will be used as the name.",
+            help="Optional name for the instance. If a name is not provided, the instance ID will be used as the name.",
             metavar="NAME",
         ),
     ] = None,

--- a/nextmv/nextmv/cli/cloud/managed_input/create.py
+++ b/nextmv/nextmv/cli/cloud/managed_input/create.py
@@ -54,7 +54,7 @@ def create(
         typer.Option(
             "--name",
             "-n",
-            help="A name for the managed input. If not provided, the ID will be used as the name.",
+            help="Optional name for the managed input. If not provided, the ID will be used as the name.",
             metavar="NAME",
         ),
     ] = None,
@@ -99,14 +99,12 @@ def create(
     [bold][underline]Examples[/underline][/bold]
 
     - Create a managed input from an upload.
-        $ [dim]nextmv cloud managed-input create --app-id hare-app --name "Test Input 1" \
-            --upload-id upl_123456789[/dim]
+        $ [dim]nextmv cloud managed-input create --app-id hare-app --upload-id upl_123456789[/dim]
 
     - Create a managed input from a run.
-        $ [dim]nextmv cloud managed-input create --app-id hare-app --name "Baseline Run" \
-            --run-id run_123456789[/dim]
+        $ [dim]nextmv cloud managed-input create --app-id hare-app --run-id run_123456789[/dim]
 
-    - Create a managed input with a specific ID and description.
+    - Create a managed input with a specific ID, name, and description.
         $ [dim]nextmv cloud managed-input create --app-id hare-app --name "Test Input" \\
             --managed-input-id inp_custom --description "Test case for validation" --upload-id upl_123456789[/dim]
 

--- a/nextmv/nextmv/cli/cloud/marketplace/subscription/create.py
+++ b/nextmv/nextmv/cli/cloud/marketplace/subscription/create.py
@@ -35,8 +35,8 @@ def create(
 
     Subscribe to a marketplace application by providing the subscription ID,
     which combines the partner ID and application ID in the format
-    [dim]<PARTNER_ID>-<APP_ID>[/dim]. This allows you to access and use the
-    marketplace application in your account.
+    [magenta]<PARTNER_ID>-<APP_ID>[/magenta]. This allows you to access and use
+    the marketplace application in your account.
 
     [bold][underline]Examples[/underline][/bold]
 

--- a/nextmv/nextmv/cli/cloud/scenario/create.py
+++ b/nextmv/nextmv/cli/cloud/scenario/create.py
@@ -48,7 +48,7 @@ def create(
         typer.Option(
             "--name",
             "-n",
-            help="Name of the scenario test. If not provided, the ID will be used as the name.",
+            help="Optional name of the scenario test. If not provided, the ID will be used as the name.",
             metavar="NAME",
             rich_help_panel="Scenario test configuration",
         ),
@@ -172,7 +172,7 @@ def create(
                 }
             }
         }'
-        nextmv cloud scenario create --app-id hare-app --name "Spring Meadow Routes" --scenarios "$SCENARIO"[/dim]
+        nextmv cloud scenario create --app-id hare-app --scenarios "$SCENARIO"[/dim]
 
     - Create with multiple scenarios by repeating the flag.
         $ [dim]SCENARIO1='{
@@ -195,8 +195,7 @@ def create(
                 }
             }
         }'
-        nextmv cloud scenario create --app-id hare-app --name "Lettuce Delivery Optimization" \\
-            --scenarios "$SCENARIO1" --scenarios "$SCENARIO2"[/dim]
+        nextmv cloud scenario create --app-id hare-app --scenarios "$SCENARIO1" --scenarios "$SCENARIO2"[/dim]
 
     - Create with multiple scenarios in a single [magenta]json[/magenta] array.
         $ [dim]SCENARIOS='[
@@ -221,8 +220,7 @@ def create(
                 }
             }
         ]'
-        nextmv cloud scenario create --app-id hare-app --name "Warren Construction Plans" \\
-            --scenarios "$SCENARIOS"[/dim]
+        nextmv cloud scenario create --app-id hare-app --scenarios "$SCENARIOS"[/dim]
 
     - Create a scenario test and wait for it to complete.
         $ [dim]SCENARIO='{
@@ -235,7 +233,7 @@ def create(
                 }
             }
         }'
-        nextmv cloud scenario create --app-id hare-app --name "Autumn Carrot Collection" --scenarios "$SCENARIO" \\
+        nextmv cloud scenario create --app-id hare-app --scenarios "$SCENARIO" \\
             --wait[/dim]
 
     - Create a scenario test and save the results to a file, waiting for completion.
@@ -249,7 +247,7 @@ def create(
                 }
             }
         }'
-        nextmv cloud scenario create --app-id hare-app --name "Fox Avoidance Routes" --scenarios "$SCENARIO" \\
+        nextmv cloud scenario create --app-id hare-app --scenarios "$SCENARIO" \\
             --output bunny-safety-results.json[/dim]
 
     - Create a scenario test with configuration options.
@@ -269,7 +267,7 @@ def create(
                 }
             ]
         }'
-        nextmv cloud scenario create --app-id hare-app --name "Speed Analysis" --scenarios "$SCENARIO"[/dim]
+        nextmv cloud scenario create --app-id hare-app --scenarios "$SCENARIO"[/dim]
     """
 
     cloud_app, _ = build_cloud_app(app_id=app_id, profile=profile)

--- a/nextmv/nextmv/cli/cloud/secrets/create.py
+++ b/nextmv/nextmv/cli/cloud/secrets/create.py
@@ -45,7 +45,7 @@ def create(
         typer.Option(
             "--name",
             "-n",
-            help="A name for the secrets collection.",
+            help="An optional name for the secrets collection. If not provided, the ID will be used as the name.",
             metavar="NAME",
         ),
     ] = None,

--- a/nextmv/nextmv/cli/cloud/shadow/create.py
+++ b/nextmv/nextmv/cli/cloud/shadow/create.py
@@ -56,7 +56,7 @@ def create(
         typer.Option(
             "--name",
             "-n",
-            help="Name of the shadow test. If not provided, the ID will be used as the name.",
+            help="Optional name of the shadow test. If not provided, the ID will be used as the name.",
             metavar="NAME",
         ),
     ] = None,
@@ -65,7 +65,7 @@ def create(
         typer.Option(
             "--shadow-test-id",
             "-s",
-            help="ID for the shadow test. Will be generated if not provided.",
+            help="Optional ID for the shadow test. Will be generated if not provided.",
             envvar="NEXTMV_SHADOW_TEST_ID",
             metavar="SHADOW_TEST_ID",
         ),

--- a/nextmv/nextmv/cli/cloud/switchback/create.py
+++ b/nextmv/nextmv/cli/cloud/switchback/create.py
@@ -73,7 +73,7 @@ def create(
         typer.Option(
             "--name",
             "-n",
-            help="Name of the switchback test. If not provided, the ID will be used as the name.",
+            help="Optional name of the switchback test. If not provided, the ID will be used as the name.",
             metavar="NAME",
         ),
     ] = None,
@@ -115,19 +115,16 @@ def create(
     [bold][underline]Examples[/underline][/bold]
 
     - Create a switchback test alternating between two bunny instances.
-        $ [dim]nextmv cloud switchback create --app-id hare-app --switchback-test-id bunny-switch-hop \\
-            --name "Bunny Switch Hop" --baseline-instance-id fluffy-bunny-baseline \\
+        $ [dim]nextmv cloud switchback create --app-id hare-app --baseline-instance-id fluffy-bunny-baseline \\
             --candidate-instance-id speedy-cottontail --unit-duration-minutes 15 --units 10[/dim]
 
     - Create a switchback test with a scheduled start time.
-        $ [dim]nextmv cloud switchback create --app-id hare-app --switchback-test-id sunrise-switch \\
-            --name "Sunrise Switch Test" --baseline-instance-id wise-old-rabbit \\
+        $ [dim]nextmv cloud switchback create --app-id hare-app --baseline-instance-id wise-old-rabbit \\
             --candidate-instance-id burrow-master --unit-duration-minutes 30 --units 8 \\
             --start '2026-01-23T10:00:00Z'[/dim]
 
     - Create a switchback test with a description.
-        $ [dim]nextmv cloud switchback create --app-id hare-app --switchback-test-id carrot-switch \\
-            --name "Carrot Switch" --baseline-instance-id fluffy-bunny-baseline \\
+        $ [dim]nextmv cloud switchback create --app-id hare-app --baseline-instance-id fluffy-bunny-baseline \\
             --candidate-instance-id hopping-candidate-ears --unit-duration-minutes 20 --units 12 \\
             --description "Which bunny hops best for carrots?"[/dim]
     """

--- a/nextmv/nextmv/cli/cloud/version/create.py
+++ b/nextmv/nextmv/cli/cloud/version/create.py
@@ -39,7 +39,7 @@ def create(
         typer.Option(
             "--name",
             "-n",
-            help="A name for the version. If a name is not provided, the version ID will be used as the name.",
+            help="Pptional name for the version. If a name is not provided, the version ID will be used as the name.",
             metavar="NAME",
         ),
     ] = None,

--- a/nextmv/nextmv/cli/cloud/version/create.py
+++ b/nextmv/nextmv/cli/cloud/version/create.py
@@ -39,7 +39,7 @@ def create(
         typer.Option(
             "--name",
             "-n",
-            help="Pptional name for the version. If a name is not provided, the version ID will be used as the name.",
+            help="Optional name for the version. If a name is not provided, the version ID will be used as the name.",
             metavar="NAME",
         ),
     ] = None,

--- a/nextmv/nextmv/cli/configuration/create.py
+++ b/nextmv/nextmv/cli/configuration/create.py
@@ -5,6 +5,7 @@ This module defines the configuration create command for the Nextmv CLI.
 from typing import Annotated
 
 import typer
+from rich.prompt import Prompt
 
 from nextmv.cli.configuration.config import (
     API_KEY_KEY,
@@ -23,7 +24,7 @@ app = typer.Typer()
 @app.command()
 def create(
     api_key: Annotated[
-        str,
+        str | None,
         typer.Option(
             "--api-key",
             "-a",
@@ -32,7 +33,7 @@ def create(
             envvar="NEXTMV_API_KEY",
             metavar="NEXTMV_API_KEY",
         ),
-    ],
+    ] = None,
     endpoint: Annotated[  # Hidden because it is meant for internal use.
         str | None,
         typer.Option(
@@ -60,6 +61,9 @@ def create(
     [bold][underline]Examples[/underline][/bold]
 
     - Default configuration.
+        $ [dim]nextmv configuration create[/dim]
+
+    - Default configuration without prompting for an API key.
         $ [dim]nextmv configuration create --api-key NEXTMV_API_KEY[/dim]
 
     - Configure a profile named [magenta]hare[/magenta].
@@ -76,6 +80,13 @@ def create(
         endpoint = endpoint[len("http://") :]
 
     config = load_config()
+
+    if not api_key:
+        api_key = Prompt.ask(
+            "Please enter your Nextmv API key to create the configuration",
+            case_sensitive=True,
+            password=True,
+        )
 
     if profile is None:
         config[API_KEY_KEY] = api_key

--- a/nextmv/nextmv/cli/configuration/create.py
+++ b/nextmv/nextmv/cli/configuration/create.py
@@ -15,7 +15,7 @@ from nextmv.cli.configuration.config import (
     obscure_api_key,
     save_config,
 )
-from nextmv.cli.message import error, message, success
+from nextmv.cli.message import error, message, success, warning
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -81,12 +81,18 @@ def create(
 
     config = load_config()
 
-    if not api_key:
-        api_key = Prompt.ask(
-            "Please enter your Nextmv API key to create the configuration",
-            case_sensitive=True,
-            password=True,
-        )
+    if api_key is None or not api_key.strip():
+        while True:
+            api_key_prompt = Prompt.ask(
+                "Please enter your Nextmv API key to create the configuration",
+                case_sensitive=True,
+                password=True,
+            )
+            api_key = api_key_prompt.strip()
+            if api_key:
+                break
+
+            warning("API key cannot be empty. Please try again.")
 
     if profile is None:
         config[API_KEY_KEY] = api_key

--- a/nextmv/tests/cli/test_configuration.py
+++ b/nextmv/tests/cli/test_configuration.py
@@ -47,7 +47,7 @@ class TestConfigureCommand(unittest.TestCase):
     def test_configure_no_args_shows_error(self):
         """Test that running configuration create without arguments shows an error."""
         result = self.runner.invoke(self.app, ["configuration", "create"])
-        self.assertEqual(result.exit_code, 2)
+        self.assertEqual(result.exit_code, 1)
 
     @patch("nextmv.cli.configuration.create.save_config")
     @patch("nextmv.cli.configuration.create.load_config")


### PR DESCRIPTION
# Description

- Ensures all `nextmv cloud <entity> create` commands allow ignoring id and name, and have them be randomly generated.
- Allows prompting the user for their API key on `nextmv configuration create`.