### PR TITLE
Caches Python dependencies for pushing, adds `nextmv cache` command tree in CLI, `cache.py` module to SDK

### DIFF
--- a/nextmv/CONTRIBUTING.md
+++ b/nextmv/CONTRIBUTING.md
@@ -346,8 +346,8 @@ guidelines:
     ] = None,
   ```
 
-- When indenting, prefer to use two spaces as opposed to a tab (`\t`) or 4
-  spaces.
+- When indenting, prefer to use four spaces as opposed to a tab (`\t`) or
+  less/more spacing.
 
 #### CLI - User prompts
 

--- a/nextmv/CONTRIBUTING.md
+++ b/nextmv/CONTRIBUTING.md
@@ -346,6 +346,9 @@ guidelines:
     ] = None,
   ```
 
+- When indenting, prefer to use two spaces as opposed to a tab (`\t`) or 4
+  spaces.
+
 #### CLI - User prompts
 
 The `message.py` file provides three interactive prompt functions: `confirmation`,

--- a/nextmv/nextmv/__about__.py
+++ b/nextmv/nextmv/__about__.py
@@ -1,1 +1,1 @@
-__version__ = "v1.7.4.dev5"
+__version__ = "v1.8.0.dev0"

--- a/nextmv/nextmv/__about__.py
+++ b/nextmv/nextmv/__about__.py
@@ -1,1 +1,1 @@
-__version__ = "v1.8.0.dev0"
+__version__ = "v1.8.0.dev1"

--- a/nextmv/nextmv/cache.py
+++ b/nextmv/nextmv/cache.py
@@ -33,6 +33,8 @@ _DEPS_CACHE_DIR = _CACHE_DIR / "deps"
 """Directory storing per-package dependency tarballs."""
 _CACHE_INFO_FILE = "cache_info.json"
 """Name of the metadata file stored alongside each cached entry."""
+_DEP_TARBALL_NAME = "installed.tar.gz"
+"""Name of the per-package tarball containing installed files for a single package."""
 _MAX_DEPS = 2000
 """Maximum number of individual package tarballs to keep in the cache."""
 _MAX_DEP_BYTES = 5 * 1024**3
@@ -63,6 +65,12 @@ def get_cache() -> dict[str, Any]:
                 with open(info_file) as f:
                     info = json.load(f)
 
+                tarball = entry_dir / _DEP_TARBALL_NAME
+                try:
+                    tarball_size = format_bytes(tarball.stat().st_size)
+                except OSError:
+                    tarball_size = ""
+
                 dependencies.append(
                     {
                         "key": entry_dir.name,
@@ -71,13 +79,14 @@ def get_cache() -> dict[str, Any]:
                         "last_used_at": info.get("last_used_at", ""),
                         "python_version": info.get("python_version", ""),
                         "platform": info.get("platform", ""),
+                        "size": tarball_size,
                     }
                 )
             except Exception:
                 pass
 
     if dependencies:
-        dependencies.sort(key=lambda d: (d["last_used_at"], d["name"], d["version"]))
+        dependencies.sort(key=lambda d: (d["last_used_at"], d["name"], d["version"]), reverse=True)
 
     return {
         "num_dependencies": num_deps,
@@ -100,10 +109,7 @@ def clear_cache() -> tuple[int, int]:
         return 0, 0
 
     num_deps, total_bytes = _cache_stats()
-
-    if _CACHE_DIR.exists():
-        shutil.rmtree(str(_CACHE_DIR))
-
+    shutil.rmtree(str(_CACHE_DIR))
     _create_cache()
 
     return num_deps, total_bytes
@@ -165,7 +171,7 @@ def get_cached_dep(pkg_key: str) -> Path | None:
 
     entry_dir = _DEPS_CACHE_DIR / pkg_key
     info_file = entry_dir / _CACHE_INFO_FILE
-    installed_tar = entry_dir / "installed.tar.gz"
+    installed_tar = entry_dir / _DEP_TARBALL_NAME
 
     if not installed_tar.is_file() or not info_file.is_file():
         return None
@@ -225,7 +231,7 @@ def store_dep(
 
     with tempfile.TemporaryDirectory(dir=_DEPS_CACHE_DIR, prefix=f"{pkg_key}-tmp-", ignore_cleanup_errors=True) as _tmp:
         tmp_entry = Path(_tmp)
-        shutil.copy2(str(tar_path), tmp_entry / "installed.tar.gz")
+        shutil.copy2(str(tar_path), tmp_entry / _DEP_TARBALL_NAME)
         now = _now_iso()
         info = {
             "created_at": now,
@@ -300,6 +306,11 @@ def _create_cache() -> None:
 
     _DEPS_CACHE_DIR.mkdir(parents=True, exist_ok=True)
 
+    # Remove leftover staging dirs from previous crashed/killed runs.
+    for entry in _DEPS_CACHE_DIR.iterdir():
+        if entry.is_dir() and "-tmp-" in entry.name:
+            shutil.rmtree(str(entry), ignore_errors=True)
+
 
 def _evict_lru(max_entries: int = _MAX_DEPS, max_bytes: int = _MAX_DEP_BYTES) -> int:
     """
@@ -324,7 +335,7 @@ def _evict_lru(max_entries: int = _MAX_DEPS, max_bytes: int = _MAX_DEP_BYTES) ->
 
     entries = []
     for entry_dir in _DEPS_CACHE_DIR.iterdir():
-        if not entry_dir.is_dir():
+        if not entry_dir.is_dir() or "-tmp-" in entry_dir.name:
             continue
 
         info_file = entry_dir / _CACHE_INFO_FILE

--- a/nextmv/nextmv/cache.py
+++ b/nextmv/nextmv/cache.py
@@ -21,6 +21,7 @@ import hashlib
 import json
 import os
 import shutil
+import tarfile
 import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
@@ -96,10 +97,10 @@ def get_cached_deps(key: str) -> Path | None:
     """
 
     entry_dir = _DEPS_CACHE_DIR / key
-    deps_dir = entry_dir / "deps"
+    deps_tar = entry_dir / "deps.tar.gz"
     info_file = entry_dir / _CACHE_INFO_FILE
 
-    if not deps_dir.is_dir() or not info_file.is_file():
+    if not deps_tar.is_file() or not info_file.is_file():
         return None
 
     # Update last_used_at for true LRU tracking.
@@ -113,7 +114,7 @@ def get_cached_deps(key: str) -> Path | None:
         # A failure to update the timestamp is non-fatal; still serve the hit.
         pass
 
-    return deps_dir
+    return deps_tar
 
 
 def store_deps(
@@ -162,8 +163,13 @@ def store_deps(
     # the directory no longer exists when the context manager tries to clean up.
     with tempfile.TemporaryDirectory(dir=_DEPS_CACHE_DIR, prefix=f"{key}-tmp-", ignore_cleanup_errors=True) as _tmp:
         tmp_entry = Path(_tmp)
-        tmp_deps = tmp_entry / "deps"
-        shutil.copytree(str(installed_deps_dir), str(tmp_deps))
+        tmp_deps_tar = tmp_entry / "deps.tar.gz"
+        dep_arcname = os.path.join(".nextmv", "python", "deps")
+        num_files = 0
+        with tarfile.open(str(tmp_deps_tar), "w:gz") as tar:
+            tar.add(str(installed_deps_dir), arcname=dep_arcname)
+            num_files = len(tar.getmembers())
+
         now = _now_iso()
         info = {
             "created_at": now,
@@ -171,6 +177,7 @@ def store_deps(
             "python_version": python_version,
             "platform": platform,
             "lockfile": lockfile_content,
+            "num_files": num_files,
         }
         metadata_path = tmp_entry / _CACHE_INFO_FILE
         _write_json_atomic(path=metadata_path, data=info)

--- a/nextmv/nextmv/cache.py
+++ b/nextmv/nextmv/cache.py
@@ -3,14 +3,16 @@ Module with the cache interface and operations for working with dependencies.
 
 Functions
 ---------
+get_cache
+    Get general information about the cache, including number of dependencies and total size.
+clear_cache
+    Delete the entire cache directory and recreate it empty.
 dep_cache_key
     Return a SHA-256 hex digest that uniquely identifies a single package.
 get_cached_dep
     Return the path to the cached per-package `installed.tar.gz` on a hit.
 store_dep
     Store a per-package `installed.tar.gz` into the cache and run LRU eviction.
-clear_cache
-    Delete the entire cache directory and recreate it empty.
 format_bytes
     Return a human-friendly string representation of a byte count.
 """
@@ -23,6 +25,7 @@ import shutil
 import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any
 
 _CACHE_DIR = Path.home() / ".nextmv" / "cache"
 """Root directory for all Nextmv cache data."""
@@ -34,6 +37,53 @@ _MAX_DEPS = 2000
 """Maximum number of individual package tarballs to keep in the cache."""
 _MAX_DEP_BYTES = 5 * 1024**3
 """Maximum total cache size in bytes (5 GiB)."""
+
+
+def get_cache() -> dict[str, Any]:
+    """
+    Gets general information about the cache.
+
+    Returns
+    -------
+    dict[str, Any]
+        A dictionary containing information about the cache, such as the number of
+        dependencies cached and the total size of the cache in bytes.
+    """
+
+    num_deps, total_bytes = _cache_stats()
+
+    dependencies = []
+    if _DEPS_CACHE_DIR.is_dir():
+        for entry_dir in _DEPS_CACHE_DIR.iterdir():
+            if not entry_dir.is_dir():
+                continue
+
+            info_file = entry_dir / _CACHE_INFO_FILE
+            try:
+                with open(info_file) as f:
+                    info = json.load(f)
+
+                dependencies.append(
+                    {
+                        "key": entry_dir.name,
+                        "name": info.get("name", ""),
+                        "version": info.get("version", ""),
+                        "last_used_at": info.get("last_used_at", ""),
+                        "python_version": info.get("python_version", ""),
+                        "platform": info.get("platform", ""),
+                    }
+                )
+            except Exception:
+                pass
+
+    if dependencies:
+        dependencies.sort(key=lambda d: (d["last_used_at"], d["name"], d["version"]))
+
+    return {
+        "num_dependencies": num_deps,
+        "total_size": format_bytes(total_bytes),
+        "dependencies": dependencies,
+    }
 
 
 def clear_cache() -> tuple[int, int]:
@@ -49,14 +99,7 @@ def clear_cache() -> tuple[int, int]:
     if not _CACHE_DIR.exists():
         return 0, 0
 
-    num_deps = 0
-    total_bytes = 0
-
-    if _DEPS_CACHE_DIR.is_dir():
-        for entry_dir in _DEPS_CACHE_DIR.iterdir():
-            if entry_dir.is_dir():
-                num_deps += 1
-                total_bytes += _dir_size(entry_dir)
+    num_deps, total_bytes = _cache_stats()
 
     if _CACHE_DIR.exists():
         shutil.rmtree(str(_CACHE_DIR))
@@ -131,6 +174,7 @@ def get_cached_dep(pkg_key: str) -> Path | None:
     try:
         with open(info_file) as f:
             info = json.load(f)
+
         info["last_used_at"] = _now_iso()
         _write_json_atomic(path=info_file, data=info)
     except Exception:
@@ -142,6 +186,8 @@ def get_cached_dep(pkg_key: str) -> Path | None:
 def store_dep(
     pkg_key: str,
     tar_path: Path,
+    name: str,
+    version: str,
     python_version: str,
     platform: str,
     max_entries: int = _MAX_DEPS,
@@ -160,6 +206,10 @@ def store_dep(
         The cache key returned by :func:`dep_cache_key`.
     tar_path : Path
         Path to the `installed.tar.gz` to cache.
+    name : str
+        The package name (e.g. `"pydantic-core"`).
+    version : str
+        The pinned version string (e.g. `"2.23.4"`).
     python_version : str
         The target Python version string (e.g. `"3.11"`).
     platform : str
@@ -180,6 +230,8 @@ def store_dep(
         info = {
             "created_at": now,
             "last_used_at": now,
+            "name": name,
+            "version": version,
             "python_version": python_version,
             "platform": platform,
         }
@@ -215,6 +267,30 @@ def format_bytes(size: int) -> str:
         return f"{size / (1024 * 1024):.2f} MiB"
     else:
         return f"{size / (1024 * 1024 * 1024):.2f} GiB"
+
+
+def _cache_stats() -> tuple[int, int]:
+    """
+    Return the number of cached dependency entries and their total size in bytes.
+
+    Returns
+    -------
+    tuple[int, int]
+        A tuple of (num_deps, total_bytes).
+    """
+
+    num_deps = 0
+    total_bytes = 0
+
+    if not _DEPS_CACHE_DIR.is_dir():
+        return num_deps, total_bytes
+
+    for entry_dir in _DEPS_CACHE_DIR.iterdir():
+        if entry_dir.is_dir():
+            num_deps += 1
+            total_bytes += _dir_size(entry_dir)
+
+    return num_deps, total_bytes
 
 
 def _create_cache() -> None:
@@ -256,6 +332,7 @@ def _evict_lru(max_entries: int = _MAX_DEPS, max_bytes: int = _MAX_DEP_BYTES) ->
         try:
             with open(info_file) as f:
                 info = json.load(f)
+
             last_used = datetime.fromisoformat(info["last_used_at"])
         except Exception:
             last_used = datetime.min.replace(tzinfo=timezone.utc)

--- a/nextmv/nextmv/cache.py
+++ b/nextmv/nextmv/cache.py
@@ -3,16 +3,12 @@ Module with the cache interface and operations for working with dependencies.
 
 Functions
 ---------
-create_cache
-    Create the cache directories if they do not already exist.
-cache_key
-    Return a SHA-256 hex digest that uniquely identifies a dependency set.
-get_cached_deps
-    Return the path to the cached `deps` directory on a hit.
-store_deps
-    Copy an installed dependency tree into the cache and run LRU eviction.
-evict_lru
-    Remove the least-recently-used cache entries until both caps are satisfied.
+dep_cache_key
+    Return a SHA-256 hex digest that uniquely identifies a single package.
+get_cached_dep
+    Return the path to the cached per-package `installed.tar.gz` on a hit.
+store_dep
+    Store a per-package `installed.tar.gz` into the cache and run LRU eviction.
 clear_cache
     Delete the entire cache directory and recreate it empty.
 """
@@ -20,20 +16,21 @@ clear_cache
 import hashlib
 import json
 import os
+import re
 import shutil
-import tarfile
 import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
 
 _CACHE_DIR = Path.home() / ".nextmv" / "cache"
+"""Root directory for all Nextmv cache data."""
 _DEPS_CACHE_DIR = _CACHE_DIR / "deps"
+"""Directory storing per-package dependency tarballs."""
 _CACHE_INFO_FILE = "cache_info.json"
-
-_DEFAULT_MAX_ENTRIES = 200
-"""Maximum number of dependency sets to keep in the cache."""
-
-_DEFAULT_MAX_BYTES = 1 * 1024**3
+"""Name of the metadata file stored alongside each cached entry."""
+_MAX_DEPS = 500
+"""Maximum number of individual package tarballs to keep in the cache."""
+_MAX_DEP_BYTES = 1 * 1024**3
 """Maximum total cache size in bytes (1 GiB)."""
 
 
@@ -48,18 +45,20 @@ def clear_cache() -> None:
     _create_cache()
 
 
-def cache_key(lockfile_content: str, python_version: str, platform: str) -> str:
+def dep_cache_key(name: str, version: str, python_version: str, platform: str) -> str:
     """
-    Return a SHA-256 hex digest that uniquely identifies a dependency set.
+    Return a SHA-256 hex digest that uniquely identifies a single package wheel.
 
-    The key is derived from the fully-pinned lockfile content combined with the
-    target Python version and platform.  Any change to resolved packages or the
-    target environment produces a different key.
+    The key is derived from the normalised package name, version, target Python
+    version, and platform.  Name normalisation follows PEP 503 so that
+    `pydantic-core` and `pydantic_core` map to the same key.
 
     Parameters
     ----------
-    lockfile_content : str
-        The fully-pinned lockfile produced by `uv pip compile`.
+    name : str
+        The package name as it appears in the lockfile or wheel filename.
+    version : str
+        The pinned version string (e.g. `"2.23.4"`).
     python_version : str
         The target Python version string (e.g. `"3.11"`).
     platform : str
@@ -71,116 +70,99 @@ def cache_key(lockfile_content: str, python_version: str, platform: str) -> str:
         A 64-character lowercase hex SHA-256 digest.
     """
 
-    raw = f"{lockfile_content}|{python_version}|{platform}"
+    normalized = re.sub(r"[-_.]+", "_", name.lower())
+    raw = f"{normalized}=={version}|{python_version}|{platform}"
+
     return hashlib.sha256(raw.encode()).hexdigest()
 
 
-def get_cached_deps(key: str) -> Path | None:
+def get_cached_dep(pkg_key: str) -> Path | None:
     """
-    Return the path to the cached `deps` directory on a hit.
+    Return the path to the cached `installed.tar.gz` for *pkg_key*, or `None`
+    on a miss.
 
-    On a cache hit, `last_used_at` in the entry's `cache_info.json` is
-    updated to the current UTC time so that the LRU eviction order reflects
-    actual recency of use.  The caller is responsible for placing the returned
-    directory wherever the consuming logic expects it.
+    The tarball contains the installed files for a single package archived under
+    `.nextmv/python/deps/`, ready to be concatenated with other per-package
+    tarballs to form the final `deps.tar.gz` (valid per RFC 1952).
+
+    On a cache hit `last_used_at` in the entry's `cache_info.json` is
+    updated to the current UTC time for LRU tracking.
 
     Parameters
     ----------
-    key : str
-        The cache key returned by `cache_key`.
+    pkg_key : str
+        The cache key returned by :func:`dep_cache_key`.
 
     Returns
     -------
     Path or None
-        Path to the `deps` directory for the cached entry, or `None` when
-        no entry exists for the given key.
+        Path to the `installed.tar.gz` file, or `None` when no entry exists.
     """
 
-    entry_dir = _DEPS_CACHE_DIR / key
-    deps_tar = entry_dir / "deps.tar.gz"
+    entry_dir = _DEPS_CACHE_DIR / pkg_key
     info_file = entry_dir / _CACHE_INFO_FILE
+    installed_tar = entry_dir / "installed.tar.gz"
 
-    if not deps_tar.is_file() or not info_file.is_file():
+    if not installed_tar.is_file() or not info_file.is_file():
         return None
 
     # Update last_used_at for true LRU tracking.
     try:
         with open(info_file) as f:
             info = json.load(f)
-
         info["last_used_at"] = _now_iso()
         _write_json_atomic(path=info_file, data=info)
     except Exception:
-        # A failure to update the timestamp is non-fatal; still serve the hit.
         pass
 
-    return deps_tar
+    return installed_tar
 
 
-def store_deps(
-    key: str,
-    installed_deps_dir: str | Path,
+def store_dep(
+    pkg_key: str,
+    tar_path: Path,
     python_version: str,
     platform: str,
-    lockfile_content: str,
-    max_entries: int = _DEFAULT_MAX_ENTRIES,
-    max_bytes: int = _DEFAULT_MAX_BYTES,
+    max_entries: int = _MAX_DEPS,
+    max_bytes: int = _MAX_DEP_BYTES,
 ) -> None:
     """
-    Copy an installed dependency tree into the cache and run LRU eviction.
+    Store a per-package `installed.tar.gz` in the cache and run LRU eviction.
 
-    The `installed_deps_dir` must be the `.nextmv/python/deps` directory
-    produced by `uv pip install`.  The copy is performed atomically via a
-    sibling temporary directory followed by a rename, so concurrent readers
-    never observe a partial write.
+    The tarball must contain the installed files for a single package archived
+    under `.nextmv/python/deps/`.  The copy is performed atomically via a
+    sibling temporary directory followed by a rename.
 
     Parameters
     ----------
-    key : str
-        The cache key returned by `cache_key`.
-    installed_deps_dir : str or Path
-        Path to the directory of installed packages produced by
-        `uv pip install`.
+    pkg_key : str
+        The cache key returned by :func:`dep_cache_key`.
+    tar_path : Path
+        Path to the `installed.tar.gz` to cache.
     python_version : str
         The target Python version string (e.g. `"3.11"`).
     platform : str
         The target platform string (e.g. `"aarch64-unknown-linux-gnu"`).
-    lockfile_content : str
-        The fully-pinned lockfile stored in `cache_info.json` for
-        informational purposes.
     max_entries : int, optional
-        Maximum number of entries allowed in the cache.  Defaults to
-        `DEFAULT_MAX_ENTRIES`.
+        Maximum number of package tarball entries to retain.
     max_bytes : int, optional
-        Maximum total cache size in bytes.  Defaults to `DEFAULT_MAX_BYTES`.
+        Maximum total cache size in bytes.
     """
 
     _create_cache()
-    entry_dir = _DEPS_CACHE_DIR / key
+    entry_dir = _DEPS_CACHE_DIR / pkg_key
 
-    # Write to a sibling temp directory first, then rename for atomicity.
-    # ignore_cleanup_errors=True handles the case where rename succeeded and
-    # the directory no longer exists when the context manager tries to clean up.
-    with tempfile.TemporaryDirectory(dir=_DEPS_CACHE_DIR, prefix=f"{key}-tmp-", ignore_cleanup_errors=True) as _tmp:
+    with tempfile.TemporaryDirectory(dir=_DEPS_CACHE_DIR, prefix=f"{pkg_key}-tmp-", ignore_cleanup_errors=True) as _tmp:
         tmp_entry = Path(_tmp)
-        tmp_deps_tar = tmp_entry / "deps.tar.gz"
-        dep_arcname = os.path.join(".nextmv", "python", "deps")
-        num_files = 0
-        with tarfile.open(str(tmp_deps_tar), "w:gz") as tar:
-            tar.add(str(installed_deps_dir), arcname=dep_arcname)
-            num_files = len(tar.getmembers())
-
+        shutil.copy2(str(tar_path), tmp_entry / "installed.tar.gz")
         now = _now_iso()
         info = {
             "created_at": now,
             "last_used_at": now,
             "python_version": python_version,
             "platform": platform,
-            "lockfile": lockfile_content,
-            "num_files": num_files,
         }
-        metadata_path = tmp_entry / _CACHE_INFO_FILE
-        _write_json_atomic(path=metadata_path, data=info)
+        _write_json_atomic(path=tmp_entry / _CACHE_INFO_FILE, data=info)
 
         # Rename into place; if the key already exists (race), keep existing.
         if not entry_dir.exists():
@@ -197,25 +179,17 @@ def _create_cache() -> None:
     _DEPS_CACHE_DIR.mkdir(parents=True, exist_ok=True)
 
 
-def _evict_lru(
-    max_entries: int = _DEFAULT_MAX_ENTRIES,
-    max_bytes: int = _DEFAULT_MAX_BYTES,
-) -> int:
+def _evict_lru(max_entries: int = _MAX_DEPS, max_bytes: int = _MAX_DEP_BYTES) -> int:
     """
-    Remove the least-recently-used (LRU) cache entries until both caps are satisfied.
-
-    Entries are sorted by `last_used_at` ascending (oldest first) and deleted
-    one by one until the total entry count is at most `max_entries` AND the
-    total disk usage is at most `max_bytes`.
+    Remove the least-recently-used L2 (per-package tarball) cache entries until
+    both caps are satisfied.
 
     Parameters
     ----------
     max_entries : int, optional
-        Maximum number of entries to retain.  Defaults to
-        `DEFAULT_MAX_ENTRIES`.
+        Maximum number of package tarball entries to retain.
     max_bytes : int, optional
-        Maximum total cache size in bytes to retain.  Defaults to
-        `DEFAULT_MAX_BYTES`.
+        Maximum total L2 cache size in bytes.
 
     Returns
     -------
@@ -232,23 +206,22 @@ def _evict_lru(
             continue
 
         info_file = entry_dir / _CACHE_INFO_FILE
+        # If the info file has problems, treat the entry as very old.
         try:
             with open(info_file) as f:
                 info = json.load(f)
-
             last_used = datetime.fromisoformat(info["last_used_at"])
         except Exception:
-            # Treat unreadable entries as very old so they are evicted first.
             last_used = datetime.min.replace(tzinfo=timezone.utc)
 
-        entry = {
-            "last_used": last_used,
-            "dir": entry_dir,
-            "size": _dir_size(entry_dir),
-        }
-        entries.append(entry)
+        entries.append(
+            {
+                "last_used": last_used,
+                "dir": entry_dir,
+                "size": _dir_size(entry_dir),
+            }
+        )
 
-    # Sort oldest to newest by last_used_at.
     entries.sort(key=lambda e: e["last_used"])
 
     total = sum(e["size"] for e in entries)
@@ -265,6 +238,11 @@ def _evict_lru(
 def _now_iso() -> str:
     """
     Return the current UTC time as an ISO-8601 string.
+
+    Returns
+    -------
+    str
+        Current UTC time as an ISO-8601 string.
     """
 
     return datetime.now(tz=timezone.utc).isoformat()
@@ -273,7 +251,18 @@ def _now_iso() -> str:
 def _dir_size(path: Path) -> int:
     """
     Return the total size in bytes of all files under path.
+
+    Parameters
+    ----------
+    path : Path
+        The directory path to calculate the size of.
+
+    Returns
+    -------
+    int
+        Total size in bytes of all files under path.
     """
+
     total = 0
     for root, _, files in os.walk(path):
         for fname in files:
@@ -281,20 +270,23 @@ def _dir_size(path: Path) -> int:
                 total += os.path.getsize(os.path.join(root, fname))
             except OSError:
                 pass
+
     return total
 
 
 def _write_json_atomic(path: Path, data: dict) -> None:
     """
     Write data as JSON to path atomically via a sibling temporary file.
+
+    Parameters
+    ----------
+    path : Path
+        The path to write the JSON data to.
+    data : dict
+        The data to write as JSON.
     """
 
-    with tempfile.NamedTemporaryFile(
-        mode="w",
-        dir=path.parent,
-        prefix=".tmp-",
-        delete=False,
-    ) as f:
+    with tempfile.NamedTemporaryFile(mode="w", dir=path.parent, prefix=".tmp-", delete=False) as f:
         json.dump(data, f, indent=2)
         tmp = Path(f.name)
 

--- a/nextmv/nextmv/cache.py
+++ b/nextmv/nextmv/cache.py
@@ -11,6 +11,8 @@ store_dep
     Store a per-package `installed.tar.gz` into the cache and run LRU eviction.
 clear_cache
     Delete the entire cache directory and recreate it empty.
+format_bytes
+    Return a human-friendly string representation of a byte count.
 """
 
 import hashlib
@@ -34,15 +36,34 @@ _MAX_DEP_BYTES = 5 * 1024**3
 """Maximum total cache size in bytes (5 GiB)."""
 
 
-def clear_cache() -> None:
+def clear_cache() -> tuple[int, int]:
     """
     Delete the entire cache directory and recreate it empty.
+
+    Returns
+    -------
+    tuple[int, int]
+        A tuple of (num_deps_deleted, total_bytes_deleted).
     """
+
+    if not _CACHE_DIR.exists():
+        return 0, 0
+
+    num_deps = 0
+    total_bytes = 0
+
+    if _DEPS_CACHE_DIR.is_dir():
+        for entry_dir in _DEPS_CACHE_DIR.iterdir():
+            if entry_dir.is_dir():
+                num_deps += 1
+                total_bytes += _dir_size(entry_dir)
 
     if _CACHE_DIR.exists():
         shutil.rmtree(str(_CACHE_DIR))
 
     _create_cache()
+
+    return num_deps, total_bytes
 
 
 def dep_cache_key(name: str, version: str, python_version: str, platform: str) -> str:
@@ -169,6 +190,31 @@ def store_dep(
             tmp_entry.rename(entry_dir)
 
     _evict_lru(max_entries=max_entries, max_bytes=max_bytes)
+
+
+def format_bytes(size: int) -> str:
+    """
+    Return a human-friendly string representation of a byte count.
+
+    Parameters
+    ----------
+    size : int
+        The size in bytes to format.
+
+    Returns
+    -------
+    str
+        A human-friendly string using B, KiB, MiB, or GiB units.
+    """
+
+    if size < 1024:
+        return f"{size} B"
+    elif size < 1024 * 1024:
+        return f"{size / 1024:.2f} KiB"
+    elif size < 1024 * 1024 * 1024:
+        return f"{size / (1024 * 1024):.2f} MiB"
+    else:
+        return f"{size / (1024 * 1024 * 1024):.2f} GiB"
 
 
 def _create_cache() -> None:

--- a/nextmv/nextmv/cache.py
+++ b/nextmv/nextmv/cache.py
@@ -28,10 +28,10 @@ _DEPS_CACHE_DIR = _CACHE_DIR / "deps"
 """Directory storing per-package dependency tarballs."""
 _CACHE_INFO_FILE = "cache_info.json"
 """Name of the metadata file stored alongside each cached entry."""
-_MAX_DEPS = 500
+_MAX_DEPS = 2000
 """Maximum number of individual package tarballs to keep in the cache."""
-_MAX_DEP_BYTES = 1 * 1024**3
-"""Maximum total cache size in bytes (1 GiB)."""
+_MAX_DEP_BYTES = 5 * 1024**3
+"""Maximum total cache size in bytes (5 GiB)."""
 
 
 def clear_cache() -> None:
@@ -181,15 +181,15 @@ def _create_cache() -> None:
 
 def _evict_lru(max_entries: int = _MAX_DEPS, max_bytes: int = _MAX_DEP_BYTES) -> int:
     """
-    Remove the least-recently-used L2 (per-package tarball) cache entries until
-    both caps are satisfied.
+    Remove the least-recently-used per-package tarball cache entries until both
+    caps are satisfied.
 
     Parameters
     ----------
     max_entries : int, optional
         Maximum number of package tarball entries to retain.
     max_bytes : int, optional
-        Maximum total L2 cache size in bytes.
+        Maximum total cache size in bytes.
 
     Returns
     -------

--- a/nextmv/nextmv/cache.py
+++ b/nextmv/nextmv/cache.py
@@ -31,8 +31,6 @@ _CACHE_DIR = Path.home() / ".nextmv" / "cache"
 """Root directory for all Nextmv cache data."""
 _DEPS_CACHE_DIR = _CACHE_DIR / "deps"
 """Directory storing per-package dependency tarballs."""
-_CACHE_TMP_DIR = _CACHE_DIR / "tmp"
-"""Staging area for atomic write operations."""
 _CACHE_INFO_FILE = "cache_info.json"
 """Name of the metadata file stored alongside each cached entry."""
 _DEP_TARBALL_NAME = "installed.tar.gz"
@@ -231,7 +229,7 @@ def store_dep(
     _create_cache()
     entry_dir = _DEPS_CACHE_DIR / pkg_key
 
-    with tempfile.TemporaryDirectory(dir=_CACHE_TMP_DIR, prefix=f"{pkg_key}-tmp-", ignore_cleanup_errors=True) as _tmp:
+    with tempfile.TemporaryDirectory(dir=_DEPS_CACHE_DIR, prefix=f"{pkg_key}-tmp-", ignore_cleanup_errors=True) as _tmp:
         tmp_entry = Path(_tmp)
         shutil.copy2(str(tar_path), tmp_entry / _DEP_TARBALL_NAME)
         now = _now_iso()
@@ -307,10 +305,11 @@ def _create_cache() -> None:
     """
 
     _DEPS_CACHE_DIR.mkdir(parents=True, exist_ok=True)
-    _CACHE_TMP_DIR.mkdir(parents=True, exist_ok=True)
 
-    # Remove leftover staging dirs/files from previous crashed/killed runs.
-    shutil.rmtree(str(_CACHE_TMP_DIR), ignore_errors=True)
+    # Remove leftover staging dirs from previous crashed/killed runs.
+    for entry in _DEPS_CACHE_DIR.iterdir():
+        if entry.is_dir() and "-tmp-" in entry.name:
+            shutil.rmtree(str(entry), ignore_errors=True)
 
 
 def _evict_lru(max_entries: int = _MAX_DEPS, max_bytes: int = _MAX_DEP_BYTES) -> int:
@@ -336,7 +335,7 @@ def _evict_lru(max_entries: int = _MAX_DEPS, max_bytes: int = _MAX_DEP_BYTES) ->
 
     entries = []
     for entry_dir in _DEPS_CACHE_DIR.iterdir():
-        if not entry_dir.is_dir():
+        if not entry_dir.is_dir() or "-tmp-" in entry_dir.name:
             continue
 
         info_file = entry_dir / _CACHE_INFO_FILE
@@ -411,7 +410,7 @@ def _dir_size(path: Path) -> int:
 
 def _write_json_atomic(path: Path, data: dict) -> None:
     """
-    Write data as JSON to path atomically via a temporary file in the cache tmp dir.
+    Write data as JSON to path atomically via a sibling temporary file.
 
     Parameters
     ----------
@@ -421,8 +420,7 @@ def _write_json_atomic(path: Path, data: dict) -> None:
         The data to write as JSON.
     """
 
-    _CACHE_TMP_DIR.mkdir(parents=True, exist_ok=True)
-    with tempfile.NamedTemporaryFile(mode="w", dir=_CACHE_TMP_DIR, prefix=".tmp-", delete=False) as f:
+    with tempfile.NamedTemporaryFile(mode="w", dir=path.parent, prefix=".tmp-", delete=False) as f:
         json.dump(data, f, indent=2)
         tmp = Path(f.name)
 

--- a/nextmv/nextmv/cache.py
+++ b/nextmv/nextmv/cache.py
@@ -31,6 +31,8 @@ _CACHE_DIR = Path.home() / ".nextmv" / "cache"
 """Root directory for all Nextmv cache data."""
 _DEPS_CACHE_DIR = _CACHE_DIR / "deps"
 """Directory storing per-package dependency tarballs."""
+_CACHE_TMP_DIR = _CACHE_DIR / "tmp"
+"""Staging area for atomic write operations."""
 _CACHE_INFO_FILE = "cache_info.json"
 """Name of the metadata file stored alongside each cached entry."""
 _DEP_TARBALL_NAME = "installed.tar.gz"
@@ -229,7 +231,7 @@ def store_dep(
     _create_cache()
     entry_dir = _DEPS_CACHE_DIR / pkg_key
 
-    with tempfile.TemporaryDirectory(dir=_DEPS_CACHE_DIR, prefix=f"{pkg_key}-tmp-", ignore_cleanup_errors=True) as _tmp:
+    with tempfile.TemporaryDirectory(dir=_CACHE_TMP_DIR, prefix=f"{pkg_key}-tmp-", ignore_cleanup_errors=True) as _tmp:
         tmp_entry = Path(_tmp)
         shutil.copy2(str(tar_path), tmp_entry / _DEP_TARBALL_NAME)
         now = _now_iso()
@@ -305,11 +307,10 @@ def _create_cache() -> None:
     """
 
     _DEPS_CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    _CACHE_TMP_DIR.mkdir(parents=True, exist_ok=True)
 
-    # Remove leftover staging dirs from previous crashed/killed runs.
-    for entry in _DEPS_CACHE_DIR.iterdir():
-        if entry.is_dir() and "-tmp-" in entry.name:
-            shutil.rmtree(str(entry), ignore_errors=True)
+    # Remove leftover staging dirs/files from previous crashed/killed runs.
+    shutil.rmtree(str(_CACHE_TMP_DIR), ignore_errors=True)
 
 
 def _evict_lru(max_entries: int = _MAX_DEPS, max_bytes: int = _MAX_DEP_BYTES) -> int:
@@ -335,7 +336,7 @@ def _evict_lru(max_entries: int = _MAX_DEPS, max_bytes: int = _MAX_DEP_BYTES) ->
 
     entries = []
     for entry_dir in _DEPS_CACHE_DIR.iterdir():
-        if not entry_dir.is_dir() or "-tmp-" in entry_dir.name:
+        if not entry_dir.is_dir():
             continue
 
         info_file = entry_dir / _CACHE_INFO_FILE
@@ -410,7 +411,7 @@ def _dir_size(path: Path) -> int:
 
 def _write_json_atomic(path: Path, data: dict) -> None:
     """
-    Write data as JSON to path atomically via a sibling temporary file.
+    Write data as JSON to path atomically via a temporary file in the cache tmp dir.
 
     Parameters
     ----------
@@ -420,7 +421,8 @@ def _write_json_atomic(path: Path, data: dict) -> None:
         The data to write as JSON.
     """
 
-    with tempfile.NamedTemporaryFile(mode="w", dir=path.parent, prefix=".tmp-", delete=False) as f:
+    _CACHE_TMP_DIR.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(mode="w", dir=_CACHE_TMP_DIR, prefix=".tmp-", delete=False) as f:
         json.dump(data, f, indent=2)
         tmp = Path(f.name)
 

--- a/nextmv/nextmv/cache.py
+++ b/nextmv/nextmv/cache.py
@@ -1,0 +1,282 @@
+"""
+Module with the cache interface and operations for working with dependencies.
+
+Functions
+---------
+create_cache
+    Create the cache directories if they do not already exist.
+cache_key
+    Return a SHA-256 hex digest that uniquely identifies a dependency set.
+get_cached_deps
+    Return the path to the cached `deps` directory on a hit.
+store_deps
+    Copy an installed dependency tree into the cache and run LRU eviction.
+evict_lru
+    Remove the least-recently-used cache entries until both caps are satisfied.
+clear_cache
+    Delete the entire cache directory and recreate it empty.
+"""
+
+import hashlib
+import json
+import os
+import shutil
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+_CACHE_DIR = Path.home() / ".nextmv" / "cache"
+_DEPS_CACHE_DIR = _CACHE_DIR / "deps"
+_CACHE_INFO_FILE = "cache_info.json"
+
+_DEFAULT_MAX_ENTRIES = 200
+"""Maximum number of dependency sets to keep in the cache."""
+
+_DEFAULT_MAX_BYTES = 1 * 1024**3
+"""Maximum total cache size in bytes (1 GiB)."""
+
+
+def clear_cache() -> None:
+    """
+    Delete the entire cache directory and recreate it empty.
+    """
+
+    if _CACHE_DIR.exists():
+        shutil.rmtree(str(_CACHE_DIR))
+
+    _create_cache()
+
+
+def cache_key(lockfile_content: str, python_version: str, platform: str) -> str:
+    """
+    Return a SHA-256 hex digest that uniquely identifies a dependency set.
+
+    The key is derived from the fully-pinned lockfile content combined with the
+    target Python version and platform.  Any change to resolved packages or the
+    target environment produces a different key.
+
+    Parameters
+    ----------
+    lockfile_content : str
+        The fully-pinned lockfile produced by `uv pip compile`.
+    python_version : str
+        The target Python version string (e.g. `"3.11"`).
+    platform : str
+        The target platform string (e.g. `"aarch64-unknown-linux-gnu"`).
+
+    Returns
+    -------
+    str
+        A 64-character lowercase hex SHA-256 digest.
+    """
+    raw = f"{lockfile_content}|{python_version}|{platform}"
+    return hashlib.sha256(raw.encode()).hexdigest()
+
+
+def get_cached_deps(key: str) -> Path | None:
+    """
+    Return the path to the cached `deps` directory on a hit.
+
+    On a cache hit, `last_used_at` in the entry's `cache_info.json` is
+    updated to the current UTC time so that the LRU eviction order reflects
+    actual recency of use.  The caller is responsible for placing the returned
+    directory wherever the consuming logic expects it.
+
+    Parameters
+    ----------
+    key : str
+        The cache key returned by `cache_key`.
+
+    Returns
+    -------
+    Path or None
+        Path to the `deps` directory for the cached entry, or `None` when
+        no entry exists for the given key.
+    """
+    entry_dir = _DEPS_CACHE_DIR / key
+    deps_dir = entry_dir / "deps"
+    info_file = entry_dir / _CACHE_INFO_FILE
+
+    if not deps_dir.is_dir() or not info_file.is_file():
+        return None
+
+    # Update last_used_at for true LRU tracking.
+    try:
+        with open(info_file) as f:
+            info = json.load(f)
+        info["last_used_at"] = _now_iso()
+        _write_json_atomic(info_file, info)
+    except Exception:
+        # A failure to update the timestamp is non-fatal; still serve the hit.
+        pass
+
+    return deps_dir
+
+
+def store_deps(
+    key: str,
+    installed_deps_dir: str | Path,
+    python_version: str,
+    platform: str,
+    lockfile_content: str,
+    max_entries: int = _DEFAULT_MAX_ENTRIES,
+    max_bytes: int = _DEFAULT_MAX_BYTES,
+) -> None:
+    """
+    Copy an installed dependency tree into the cache and run LRU eviction.
+
+    The `installed_deps_dir` must be the `.nextmv/python/deps` directory
+    produced by `uv pip install`.  The copy is performed atomically via a
+    sibling temporary directory followed by a rename, so concurrent readers
+    never observe a partial write.
+
+    Parameters
+    ----------
+    key : str
+        The cache key returned by `cache_key`.
+    installed_deps_dir : str or Path
+        Path to the directory of installed packages produced by
+        `uv pip install`.
+    python_version : str
+        The target Python version string (e.g. `"3.11"`).
+    platform : str
+        The target platform string (e.g. `"aarch64-unknown-linux-gnu"`).
+    lockfile_content : str
+        The fully-pinned lockfile stored in `cache_info.json` for
+        informational purposes.
+    max_entries : int, optional
+        Maximum number of entries allowed in the cache.  Defaults to
+        `DEFAULT_MAX_ENTRIES`.
+    max_bytes : int, optional
+        Maximum total cache size in bytes.  Defaults to `DEFAULT_MAX_BYTES`.
+    """
+    _create_cache()
+
+    entry_dir = _DEPS_CACHE_DIR / key
+
+    # Write to a sibling temp directory first, then rename for atomicity.
+    tmp_entry = Path(tempfile.mkdtemp(dir=_DEPS_CACHE_DIR, prefix=f"{key}-tmp-"))
+    try:
+        tmp_deps = tmp_entry / "deps"
+        shutil.copytree(str(installed_deps_dir), str(tmp_deps))
+
+        now = _now_iso()
+        info = {
+            "created_at": now,
+            "last_used_at": now,
+            "python_version": python_version,
+            "platform": platform,
+            "lockfile": lockfile_content,
+        }
+        _write_json_atomic(tmp_entry / _CACHE_INFO_FILE, info)
+
+        # Rename into place; if the key already exists (race), keep existing.
+        if not entry_dir.exists():
+            tmp_entry.rename(entry_dir)
+        else:
+            shutil.rmtree(str(tmp_entry), ignore_errors=True)
+    except Exception:
+        shutil.rmtree(str(tmp_entry), ignore_errors=True)
+        raise
+
+    _evict_lru(max_entries=max_entries, max_bytes=max_bytes)
+
+
+def _create_cache() -> None:
+    """
+    Create the cache directories if they do not already exist.
+    """
+    _CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    _DEPS_CACHE_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def _evict_lru(
+    max_entries: int = _DEFAULT_MAX_ENTRIES,
+    max_bytes: int = _DEFAULT_MAX_BYTES,
+) -> int:
+    """
+    Remove the least-recently-used cache entries until both caps are satisfied.
+
+    Entries are sorted by `last_used_at` ascending (oldest first) and deleted
+    one by one until the total entry count is at most `max_entries` AND the
+    total disk usage is at most `max_bytes`.
+
+    Parameters
+    ----------
+    max_entries : int, optional
+        Maximum number of entries to retain.  Defaults to
+        `DEFAULT_MAX_ENTRIES`.
+    max_bytes : int, optional
+        Maximum total cache size in bytes to retain.  Defaults to
+        `DEFAULT_MAX_BYTES`.
+
+    Returns
+    -------
+    int
+        The number of entries that were removed.
+    """
+    if not _DEPS_CACHE_DIR.is_dir():
+        return 0
+
+    entries: list[tuple[datetime, Path, int]] = []
+    for entry_dir in _DEPS_CACHE_DIR.iterdir():
+        if not entry_dir.is_dir():
+            continue
+        info_file = entry_dir / _CACHE_INFO_FILE
+        try:
+            with open(info_file) as f:
+                info = json.load(f)
+            last_used = datetime.fromisoformat(info["last_used_at"])
+        except Exception:
+            # Treat unreadable entries as very old so they are evicted first.
+            last_used = datetime.min.replace(tzinfo=timezone.utc)
+        entries.append((last_used, entry_dir, _dir_size(entry_dir)))
+
+    entries.sort(key=lambda e: e[0])  # oldest last_used_at first
+
+    total = sum(size for _, _, size in entries)
+    evicted = 0
+    while entries and (len(entries) > max_entries or total > max_bytes):
+        _, oldest, size = entries.pop(0)
+        shutil.rmtree(str(oldest), ignore_errors=True)
+        total -= size
+        evicted += 1
+
+    return evicted
+
+
+def _now_iso() -> str:
+    """
+    Return the current UTC time as an ISO-8601 string.
+    """
+
+    return datetime.now(tz=timezone.utc).isoformat()
+
+
+def _dir_size(path: Path) -> int:
+    """
+    Return the total size in bytes of all files under path.
+    """
+    total = 0
+    for root, _, files in os.walk(path):
+        for fname in files:
+            try:
+                total += os.path.getsize(os.path.join(root, fname))
+            except OSError:
+                pass
+    return total
+
+
+def _write_json_atomic(path: Path, data: dict) -> None:
+    """
+    Write data as JSON to path atomically via a sibling temporary file.
+    """
+    fd, tmp_str = tempfile.mkstemp(dir=path.parent, prefix=".tmp-")
+    tmp = Path(tmp_str)
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(data, f, indent=2)
+        tmp.rename(path)
+    except Exception:
+        tmp.unlink(missing_ok=True)
+        raise

--- a/nextmv/nextmv/cache.py
+++ b/nextmv/nextmv/cache.py
@@ -414,7 +414,7 @@ def _write_json_atomic(path: Path, data: dict) -> None:
         tmp = Path(f.name)
 
     try:
-        tmp.rename(path)
+        os.replace(tmp, path)
     except Exception as e:
         tmp.unlink(missing_ok=True)
         raise e

--- a/nextmv/nextmv/cache.py
+++ b/nextmv/nextmv/cache.py
@@ -69,6 +69,7 @@ def cache_key(lockfile_content: str, python_version: str, platform: str) -> str:
     str
         A 64-character lowercase hex SHA-256 digest.
     """
+
     raw = f"{lockfile_content}|{python_version}|{platform}"
     return hashlib.sha256(raw.encode()).hexdigest()
 
@@ -93,6 +94,7 @@ def get_cached_deps(key: str) -> Path | None:
         Path to the `deps` directory for the cached entry, or `None` when
         no entry exists for the given key.
     """
+
     entry_dir = _DEPS_CACHE_DIR / key
     deps_dir = entry_dir / "deps"
     info_file = entry_dir / _CACHE_INFO_FILE
@@ -104,8 +106,9 @@ def get_cached_deps(key: str) -> Path | None:
     try:
         with open(info_file) as f:
             info = json.load(f)
+
         info["last_used_at"] = _now_iso()
-        _write_json_atomic(info_file, info)
+        _write_json_atomic(path=info_file, data=info)
     except Exception:
         # A failure to update the timestamp is non-fatal; still serve the hit.
         pass
@@ -150,16 +153,17 @@ def store_deps(
     max_bytes : int, optional
         Maximum total cache size in bytes.  Defaults to `DEFAULT_MAX_BYTES`.
     """
-    _create_cache()
 
+    _create_cache()
     entry_dir = _DEPS_CACHE_DIR / key
 
     # Write to a sibling temp directory first, then rename for atomicity.
-    tmp_entry = Path(tempfile.mkdtemp(dir=_DEPS_CACHE_DIR, prefix=f"{key}-tmp-"))
-    try:
+    # ignore_cleanup_errors=True handles the case where rename succeeded and
+    # the directory no longer exists when the context manager tries to clean up.
+    with tempfile.TemporaryDirectory(dir=_DEPS_CACHE_DIR, prefix=f"{key}-tmp-", ignore_cleanup_errors=True) as _tmp:
+        tmp_entry = Path(_tmp)
         tmp_deps = tmp_entry / "deps"
         shutil.copytree(str(installed_deps_dir), str(tmp_deps))
-
         now = _now_iso()
         info = {
             "created_at": now,
@@ -168,16 +172,12 @@ def store_deps(
             "platform": platform,
             "lockfile": lockfile_content,
         }
-        _write_json_atomic(tmp_entry / _CACHE_INFO_FILE, info)
+        metadata_path = tmp_entry / _CACHE_INFO_FILE
+        _write_json_atomic(path=metadata_path, data=info)
 
         # Rename into place; if the key already exists (race), keep existing.
         if not entry_dir.exists():
             tmp_entry.rename(entry_dir)
-        else:
-            shutil.rmtree(str(tmp_entry), ignore_errors=True)
-    except Exception:
-        shutil.rmtree(str(tmp_entry), ignore_errors=True)
-        raise
 
     _evict_lru(max_entries=max_entries, max_bytes=max_bytes)
 
@@ -186,7 +186,7 @@ def _create_cache() -> None:
     """
     Create the cache directories if they do not already exist.
     """
-    _CACHE_DIR.mkdir(parents=True, exist_ok=True)
+
     _DEPS_CACHE_DIR.mkdir(parents=True, exist_ok=True)
 
 
@@ -195,7 +195,7 @@ def _evict_lru(
     max_bytes: int = _DEFAULT_MAX_BYTES,
 ) -> int:
     """
-    Remove the least-recently-used cache entries until both caps are satisfied.
+    Remove the least-recently-used (LRU) cache entries until both caps are satisfied.
 
     Entries are sorted by `last_used_at` ascending (oldest first) and deleted
     one by one until the total entry count is at most `max_entries` AND the
@@ -215,31 +215,41 @@ def _evict_lru(
     int
         The number of entries that were removed.
     """
+
     if not _DEPS_CACHE_DIR.is_dir():
         return 0
 
-    entries: list[tuple[datetime, Path, int]] = []
+    entries = []
     for entry_dir in _DEPS_CACHE_DIR.iterdir():
         if not entry_dir.is_dir():
             continue
+
         info_file = entry_dir / _CACHE_INFO_FILE
         try:
             with open(info_file) as f:
                 info = json.load(f)
+
             last_used = datetime.fromisoformat(info["last_used_at"])
         except Exception:
             # Treat unreadable entries as very old so they are evicted first.
             last_used = datetime.min.replace(tzinfo=timezone.utc)
-        entries.append((last_used, entry_dir, _dir_size(entry_dir)))
 
-    entries.sort(key=lambda e: e[0])  # oldest last_used_at first
+        entry = {
+            "last_used": last_used,
+            "dir": entry_dir,
+            "size": _dir_size(entry_dir),
+        }
+        entries.append(entry)
 
-    total = sum(size for _, _, size in entries)
+    # Sort oldest to newest by last_used_at.
+    entries.sort(key=lambda e: e["last_used"])
+
+    total = sum(e["size"] for e in entries)
     evicted = 0
     while entries and (len(entries) > max_entries or total > max_bytes):
-        _, oldest, size = entries.pop(0)
-        shutil.rmtree(str(oldest), ignore_errors=True)
-        total -= size
+        oldest = entries.pop(0)
+        shutil.rmtree(str(oldest["dir"]), ignore_errors=True)
+        total -= oldest["size"]
         evicted += 1
 
     return evicted
@@ -271,12 +281,18 @@ def _write_json_atomic(path: Path, data: dict) -> None:
     """
     Write data as JSON to path atomically via a sibling temporary file.
     """
-    fd, tmp_str = tempfile.mkstemp(dir=path.parent, prefix=".tmp-")
-    tmp = Path(tmp_str)
+
+    with tempfile.NamedTemporaryFile(
+        mode="w",
+        dir=path.parent,
+        prefix=".tmp-",
+        delete=False,
+    ) as f:
+        json.dump(data, f, indent=2)
+        tmp = Path(f.name)
+
     try:
-        with os.fdopen(fd, "w") as f:
-            json.dump(data, f, indent=2)
         tmp.rename(path)
-    except Exception:
+    except Exception as e:
         tmp.unlink(missing_ok=True)
-        raise
+        raise e

--- a/nextmv/nextmv/cli/cache/__init__.py
+++ b/nextmv/nextmv/cli/cache/__init__.py
@@ -5,10 +5,12 @@ This module defines the cache command tree for the Nextmv CLI.
 import typer
 
 from nextmv.cli.cache.delete import app as delete_app
+from nextmv.cli.cache.get import app as get_app
 
 # Set up subcommand application.
 app = typer.Typer()
 app.add_typer(delete_app)
+app.add_typer(get_app)
 
 
 @app.callback()

--- a/nextmv/nextmv/cli/cache/__init__.py
+++ b/nextmv/nextmv/cli/cache/__init__.py
@@ -1,0 +1,19 @@
+"""
+This module defines the cache command tree for the Nextmv CLI.
+"""
+
+import typer
+
+from nextmv.cli.cache.delete import app as delete_app
+
+# Set up subcommand application.
+app = typer.Typer()
+app.add_typer(delete_app)
+
+
+@app.callback()
+def callback() -> None:
+    """
+    Manage the cache used for Nextmv operations.
+    """
+    pass

--- a/nextmv/nextmv/cli/cache/delete.py
+++ b/nextmv/nextmv/cli/cache/delete.py
@@ -1,0 +1,32 @@
+"""
+This module defines the cache delete command for the Nextmv CLI.
+"""
+
+import typer
+
+from nextmv.cache import clear_cache, format_bytes
+from nextmv.cli.message import info, success
+
+# Set up subcommand application.
+app = typer.Typer()
+
+
+@app.command()
+def delete() -> None:
+    """
+    Deletes the Nextmv cache and resets it to an empty state.
+
+    [bold][underline]Examples[/underline][/bold]
+
+    - Delete the Nextmv cache.
+        $ [dim]nextmv cache delete[/dim]
+    """
+
+    deps, bytes_deleted = clear_cache()
+    if deps == 0 and bytes_deleted == 0:
+        info("Nothing to delete: cache is already empty.")
+        return
+
+    size_str = format_bytes(bytes_deleted)
+    dep_label = "dependency" if deps == 1 else "dependencies"
+    success(f"Deleted [magenta]{deps}[/magenta] {dep_label} ([magenta]{size_str}[/magenta]) from the cache.")

--- a/nextmv/nextmv/cli/cache/delete.py
+++ b/nextmv/nextmv/cli/cache/delete.py
@@ -5,27 +5,43 @@ This module defines the cache delete command for the Nextmv CLI.
 import typer
 
 from nextmv.cache import clear_cache, format_bytes
-from nextmv.cli.message import info, success
+from nextmv.cli.message import confirmation, info, success
+from nextmv.cli.options import YesOption
 
 # Set up subcommand application.
 app = typer.Typer()
 
 
 @app.command()
-def delete() -> None:
+def delete(yes: YesOption = False) -> None:
     """
     Deletes the Nextmv cache and resets it to an empty state.
+
+    This action is permanent and cannot be undone. Use the --yes flag to skip
+    the confirmation prompt.
 
     [bold][underline]Examples[/underline][/bold]
 
     - Delete the Nextmv cache.
         $ [dim]nextmv cache delete[/dim]
+
+    - Delete the Nextmv cache without confirmation prompt.
+        $ [dim]nextmv cache delete --yes[/dim]
     """
 
     deps, bytes_deleted = clear_cache()
     if deps == 0 and bytes_deleted == 0:
         info("Nothing to delete: cache is already empty.")
         return
+
+    if not yes:
+        confirm = confirmation(
+            "Are you sure you want to delete the Nextmv cache? This action cannot be undone.",
+        )
+
+        if not confirm:
+            info("The Nextmv cache will not be deleted.")
+            return
 
     size_str = format_bytes(bytes_deleted)
     dep_label = "dependency" if deps == 1 else "dependencies"

--- a/nextmv/nextmv/cli/cache/get.py
+++ b/nextmv/nextmv/cli/cache/get.py
@@ -1,0 +1,27 @@
+"""
+This module defines the cache get command for the Nextmv CLI.
+"""
+
+import typer
+
+from nextmv.cache import get_cache
+from nextmv.cli.message import print_json, success
+
+# Set up subcommand application.
+app = typer.Typer()
+
+
+@app.command()
+def get() -> None:
+    """
+    Gets general information about the Nextmv cache.
+
+    [bold][underline]Examples[/underline][/bold]
+
+    - Get cache information.
+        $ [dim]nextmv cache get[/dim]
+    """
+
+    info = get_cache()
+    success("Cache information retrieved successfully.")
+    print_json(info)

--- a/nextmv/nextmv/cli/cloud/app/push.py
+++ b/nextmv/nextmv/cli/cloud/app/push.py
@@ -40,6 +40,13 @@ def push(
             metavar="MANIFEST_PATH",
         ),
     ] = None,
+    no_cache: Annotated[
+        bool,
+        typer.Option(
+            "--no-cache",
+            help="Do not read from or write to the Nextmv dependency cache for [magenta]Python[/magenta] applications.",
+        ),
+    ] = False,
     # Options for version control.
     version_id: Annotated[
         str | None,
@@ -184,6 +191,7 @@ def push(
         update_instance_id=update_instance_id,
         create_defined=create_defined,
         create_instance_id=create_instance_id,
+        no_cache=no_cache,
     )
 
 
@@ -199,6 +207,7 @@ def handle_push(
     update_instance_id: str | None,
     create_defined: bool,
     create_instance_id: str | None,
+    no_cache: bool = False,
 ) -> str:
     """
     Handle the core push flow: push the application, create a version, and link it to an instance.
@@ -227,6 +236,9 @@ def handle_push(
         Whether --create-instance-id was provided.
     create_instance_id : str | None
         The instance ID to create.
+    no_cache : bool
+        Whether to disable the dependency cache when packaging Python
+        applications.
 
     Returns
     -------
@@ -242,6 +254,7 @@ def handle_push(
         app_dir=app_dir,
         verbose=True,
         rich_print=True,
+        no_cache=no_cache,
     )
 
     now = datetime.now(timezone.utc)

--- a/nextmv/nextmv/cli/main.py
+++ b/nextmv/nextmv/cli/main.py
@@ -23,6 +23,7 @@ import rich
 import typer
 from typer import rich_utils
 
+from nextmv.cli.cache import app as cache_app
 from nextmv.cli.cloud import app as cloud_app
 from nextmv.cli.community import app as community_app
 from nextmv.cli.configuration import app as configuration_app
@@ -52,6 +53,7 @@ app = typer.Typer(
 
 # Register subcommands. The `name` parameter is required when the subcommand
 # module has a callback function defined.
+app.add_typer(cache_app, name="cache")
 app.add_typer(cloud_app, name="cloud")
 app.add_typer(community_app, name="community")
 app.add_typer(configuration_app, name="configuration")

--- a/nextmv/nextmv/cli/message.py
+++ b/nextmv/nextmv/cli/message.py
@@ -60,7 +60,7 @@ def message(msg: str, emoji: str | None = None, indents: int = 0) -> None:
         msg = f"{emoji} {msg}"
 
     if indents > 0:
-        msg = "\t" * indents + msg
+        msg = "  " * indents + msg
 
     console = Console(file=sys.stderr, highlight=False)
     console.print(msg)

--- a/nextmv/nextmv/cli/message.py
+++ b/nextmv/nextmv/cli/message.py
@@ -51,8 +51,8 @@ def message(msg: str, emoji: str | None = None, indents: int = 0) -> None:
         https://rich.readthedocs.io/en/latest/markup.html#emoji. For example:
         `:hourglass_flowing_sand:`.
     indents : int
-        The number of indents to prefix the message with. Each indent is a tab
-        character. Default is 0.
+        The number of indents to prefix the message with. Each indent is 4
+        spaces. Default is 0.
     """
 
     msg = _format(msg)
@@ -60,7 +60,7 @@ def message(msg: str, emoji: str | None = None, indents: int = 0) -> None:
         msg = f"{emoji} {msg}"
 
     if indents > 0:
-        msg = "  " * indents + msg
+        msg = "    " * indents + msg
 
     console = Console(file=sys.stderr, highlight=False)
     console.print(msg)

--- a/nextmv/nextmv/cloud/application/__init__.py
+++ b/nextmv/nextmv/cloud/application/__init__.py
@@ -414,7 +414,7 @@ class Application(
             # Re-throw the exception if it is not the expected 404 error.
             raise e from None
 
-    def push(  # noqa: C901
+    def push(
         self,
         manifest: Manifest | None = None,
         app_dir: str | None = None,
@@ -422,6 +422,7 @@ class Application(
         model: Model | None = None,
         model_configuration: ModelConfiguration | None = None,
         rich_print: bool = False,
+        no_cache: bool = False,
     ) -> None:
         """
         Push an app to Nextmv Cloud.
@@ -457,6 +458,13 @@ class Application(
             with `model`.
         rich_print : bool, default=False
             Whether to use rich printing when verbose output is enabled.
+        no_cache : bool, default=False
+            When working with Python, dependencies are cached to speed up
+            subsequent pushes. Setting no_cache to True will skip using the
+            cache and force a fresh build of all dependencies. This is useful
+            when you want to ensure that you are pushing the most up-to-date
+            versions of your dependencies, or if you are encountering issues
+            with the cache and want to rule it out as a potential cause.
 
         Raises
         ------
@@ -552,7 +560,15 @@ class Application(
 
         package.run_build_command(app_dir, manifest.build, verbose, rich_print)
         package.run_pre_push_command(app_dir, manifest.pre_push, verbose, rich_print)
-        tar_file, output_dir = package.package(app_dir, manifest, model, model_configuration, verbose, rich_print)
+        tar_file, output_dir = package.package(
+            app_dir,
+            manifest,
+            model,
+            model_configuration,
+            verbose,
+            rich_print,
+            no_cache,
+        )
         self.__update_app_binary(tar_file, manifest, verbose, rich_print)
 
         try:

--- a/nextmv/nextmv/cloud/application/__init__.py
+++ b/nextmv/nextmv/cloud/application/__init__.py
@@ -550,9 +550,9 @@ class Application(
         if (model is None and model_configuration is not None) or (model is not None and model_configuration is None):
             raise ValueError("model and model_configuration must be provided together")
 
-        package._run_build_command(app_dir, manifest.build, verbose, rich_print)
-        package._run_pre_push_command(app_dir, manifest.pre_push, verbose, rich_print)
-        tar_file, output_dir = package._package(app_dir, manifest, model, model_configuration, verbose, rich_print)
+        package.run_build_command(app_dir, manifest.build, verbose, rich_print)
+        package.run_pre_push_command(app_dir, manifest.pre_push, verbose, rich_print)
+        tar_file, output_dir = package.package(app_dir, manifest, model, model_configuration, verbose, rich_print)
         self.__update_app_binary(tar_file, manifest, verbose, rich_print)
 
         try:

--- a/nextmv/nextmv/cloud/package.py
+++ b/nextmv/nextmv/cloud/package.py
@@ -271,7 +271,7 @@ def _copy_manifest_files(
 
         try:
             shutil.copy2(file["absolute_path"], os.path.join(temp_dir, target_dir))
-        except subprocess.CalledProcessError as e:
+        except OSError as e:
             raise Exception(f"error copying asset files {file['absolute_path']}: {e}") from e
 
 
@@ -847,13 +847,13 @@ def _install_and_compress_package(
         # the entries (no EOF block).  Omitting the EOF block lets these
         # per-package gzip streams be raw-concatenated without causing tar
         # to stop at the first end-of-archive marker.
-        with tempfile.NamedTemporaryFile(suffix=".tar", delete=False, dir=install_tmp) as _tmp_f:
-            tmp_tar_path = _tmp_f.name
+        tmp_tar_path = os.path.join(install_tmp, "pkg.tar")
 
-        tar_obj = tarfile.open(tmp_tar_path, mode="w")
-        tar_obj.add(install_dir, arcname=dep_arcname)
-        entry_end = tar_obj.offset  # byte offset where EOF marker begins
-        tar_obj.close()
+        with tarfile.open(tmp_tar_path, mode="w") as tar_obj:
+            tar_obj.add(install_dir, arcname=dep_arcname)
+            # Byte offset where EOF marker begins; captured before close()
+            # appends EOF blocks.
+            entry_end = tar_obj.offset
 
         with open(tmp_tar_path, "rb") as raw_f:
             with gzip.open(str(tar_path), "wb") as gz:

--- a/nextmv/nextmv/cloud/package.py
+++ b/nextmv/nextmv/cloud/package.py
@@ -13,7 +13,7 @@ from pathlib import Path
 
 import rich
 
-from nextmv.cache import dep_cache_key, get_cached_dep, store_dep
+from nextmv.cache import dep_cache_key, format_bytes, get_cached_dep, store_dep
 from nextmv.logger import log
 from nextmv.manifest import (
     MANIFEST_FILE_NAME,
@@ -102,6 +102,118 @@ def package(
                 shutil.rmtree(str(deps_tar.parent), ignore_errors=True)
             if not success and output_dir is not None:
                 shutil.rmtree(output_dir, ignore_errors=True)
+
+
+def run_build_command(
+    app_dir: str,
+    manifest_build: ManifestBuild | None = None,
+    verbose: bool = False,
+    rich_print: bool = False,
+) -> None:
+    """
+    Run the build command specified in the manifest.
+
+    Parameters
+    ----------
+    app_dir : str
+        The directory of the application, used as the working directory when
+        running the build command.
+    manifest_build : ManifestBuild, optional
+        The build configuration from the manifest.  If ``None`` or if
+        ``manifest_build.command`` is empty, this function is a no-op.
+    verbose : bool, optional
+        Whether to print verbose logs.
+    rich_print : bool, optional
+        Whether to use rich printing for verbose logs.
+
+    Raises
+    ------
+    Exception
+        If the build command exits with a non-zero return code.
+    """
+
+    if manifest_build is None or manifest_build.command is None or manifest_build.command == "":
+        return
+
+    elements = manifest_build.command.split(" ")
+    command_str = " ".join(elements)
+
+    if verbose:
+        if rich_print:
+            rich.print(f":construction: Running build command: [magenta]{command_str}[/magenta]", file=sys.stderr)
+        else:
+            log(f'🚧 Running build command: "{command_str}"')
+    try:
+        result = subprocess.run(
+            elements,
+            env={**os.environ, **manifest_build.environment_to_dict()},
+            check=True,
+            text=True,
+            capture_output=True,
+            cwd=app_dir,
+        )
+
+    except subprocess.CalledProcessError as e:
+        raise Exception(f"error running build command: {e.stderr}") from e
+
+    if verbose and result.stdout.strip():
+        log(result.stdout.rstrip("\n"))
+
+
+def run_pre_push_command(
+    app_dir: str,
+    pre_push_command: str | None = None,
+    verbose: bool = False,
+    rich_print: bool = False,
+) -> None:
+    """
+    Run the pre-push command specified in the manifest.
+
+    Parameters
+    ----------
+    app_dir : str
+        The directory of the application, used as the working directory when
+        running the pre-push command.
+    pre_push_command : str, optional
+        The shell command to execute before pushing.  If ``None`` or empty,
+        this function is a no-op.
+    verbose : bool, optional
+        Whether to print verbose logs.
+    rich_print : bool, optional
+        Whether to use rich printing for verbose logs.
+
+    Raises
+    ------
+    Exception
+        If the pre-push command exits with a non-zero return code.
+    """
+
+    if pre_push_command is None or pre_push_command == "":
+        return
+
+    elements = _get_shell_command_elements(pre_push_command)
+
+    command_str = " ".join(elements)
+    if verbose:
+        if rich_print:
+            rich.print(f":hammer: Running pre-push command: [magenta]{command_str}[/magenta]", file=sys.stderr)
+        else:
+            log(f'🔨 Running pre-push command: "{command_str}"')
+    try:
+        result = subprocess.run(
+            elements,
+            env=os.environ,
+            check=True,
+            text=True,
+            capture_output=True,
+            cwd=app_dir,
+        )
+
+    except subprocess.CalledProcessError as e:
+        raise Exception(f"error running pre-push command: {e.stderr}") from e
+
+    if verbose and result.stdout.strip():
+        log(result.stdout.rstrip("\n"))
 
 
 def _copy_manifest_files(
@@ -220,118 +332,6 @@ def _compress_and_report(
                 log(f"📦 Packaged application ({file_count} {app_file_count_label}).")
 
     return tar_file, file_count
-
-
-def run_build_command(
-    app_dir: str,
-    manifest_build: ManifestBuild | None = None,
-    verbose: bool = False,
-    rich_print: bool = False,
-) -> None:
-    """
-    Run the build command specified in the manifest.
-
-    Parameters
-    ----------
-    app_dir : str
-        The directory of the application, used as the working directory when
-        running the build command.
-    manifest_build : ManifestBuild, optional
-        The build configuration from the manifest.  If ``None`` or if
-        ``manifest_build.command`` is empty, this function is a no-op.
-    verbose : bool, optional
-        Whether to print verbose logs.
-    rich_print : bool, optional
-        Whether to use rich printing for verbose logs.
-
-    Raises
-    ------
-    Exception
-        If the build command exits with a non-zero return code.
-    """
-
-    if manifest_build is None or manifest_build.command is None or manifest_build.command == "":
-        return
-
-    elements = manifest_build.command.split(" ")
-    command_str = " ".join(elements)
-
-    if verbose:
-        if rich_print:
-            rich.print(f":construction: Running build command: [magenta]{command_str}[/magenta]", file=sys.stderr)
-        else:
-            log(f'🚧 Running build command: "{command_str}"')
-    try:
-        result = subprocess.run(
-            elements,
-            env={**os.environ, **manifest_build.environment_to_dict()},
-            check=True,
-            text=True,
-            capture_output=True,
-            cwd=app_dir,
-        )
-
-    except subprocess.CalledProcessError as e:
-        raise Exception(f"error running build command: {e.stderr}") from e
-
-    if verbose and result.stdout.strip():
-        log(result.stdout.rstrip("\n"))
-
-
-def run_pre_push_command(
-    app_dir: str,
-    pre_push_command: str | None = None,
-    verbose: bool = False,
-    rich_print: bool = False,
-) -> None:
-    """
-    Run the pre-push command specified in the manifest.
-
-    Parameters
-    ----------
-    app_dir : str
-        The directory of the application, used as the working directory when
-        running the pre-push command.
-    pre_push_command : str, optional
-        The shell command to execute before pushing.  If ``None`` or empty,
-        this function is a no-op.
-    verbose : bool, optional
-        Whether to print verbose logs.
-    rich_print : bool, optional
-        Whether to use rich printing for verbose logs.
-
-    Raises
-    ------
-    Exception
-        If the pre-push command exits with a non-zero return code.
-    """
-
-    if pre_push_command is None or pre_push_command == "":
-        return
-
-    elements = _get_shell_command_elements(pre_push_command)
-
-    command_str = " ".join(elements)
-    if verbose:
-        if rich_print:
-            rich.print(f":hammer: Running pre-push command: [magenta]{command_str}[/magenta]", file=sys.stderr)
-        else:
-            log(f'🔨 Running pre-push command: "{command_str}"')
-    try:
-        result = subprocess.run(
-            elements,
-            env=os.environ,
-            check=True,
-            text=True,
-            capture_output=True,
-            cwd=app_dir,
-        )
-
-    except subprocess.CalledProcessError as e:
-        raise Exception(f"error running pre-push command: {e.stderr}") from e
-
-    if verbose and result.stdout.strip():
-        log(result.stdout.rstrip("\n"))
 
 
 def _get_shell_command_elements(pre_push_command):
@@ -1201,11 +1201,5 @@ def _human_friendly_file_size(path: str) -> str:
     except OSError as e:
         raise Exception(f"error getting file size: {e}") from e
 
-    if size < 1024:
-        return f"{size} B"
-    elif size < 1024 * 1024:
-        return f"{size / 1024:.2f} KiB"
-    elif size < 1024 * 1024 * 1024:
-        return f"{size / (1024 * 1024):.2f} MiB"
-    else:
-        return f"{size / (1024 * 1024 * 1024):.2f} GiB"
+    pretty_size = format_bytes(size)
+    return pretty_size

--- a/nextmv/nextmv/cloud/package.py
+++ b/nextmv/nextmv/cloud/package.py
@@ -1,5 +1,6 @@
 """Module with the logic for pushing an app to Nextmv Cloud."""
 
+import json
 import os
 import platform
 import re
@@ -8,6 +9,7 @@ import subprocess
 import sys
 import tarfile
 import tempfile
+from pathlib import Path
 
 import rich
 
@@ -44,8 +46,9 @@ def _package(  # noqa: C901 # complexity attributed to printing.
     """Package the app into a tarball."""
 
     with tempfile.TemporaryDirectory(prefix="nextmv-temp-") as temp_dir:
+        deps_tar: Path | None = None
         if manifest.type == ManifestType.PYTHON:
-            __handle_python(app_dir, temp_dir, manifest, model, model_configuration, verbose, rich_print)
+            deps_tar = __handle_python(app_dir, manifest, model, model_configuration, verbose, rich_print)
 
         found, missing, files = find_files(app_dir, manifest.files)
         manifest.confirm_mandatory_files(found)
@@ -86,7 +89,11 @@ def _package(  # noqa: C901 # complexity attributed to printing.
                 log("💾 Compressing application into tarball.")
 
         output_dir = tempfile.mkdtemp(prefix="nextmv-build-out-")
-        tar_file, file_count = __compress_tar(temp_dir, output_dir)
+        if deps_tar is not None:
+            tar_file, file_count = __build_from_deps_tar(deps_tar, temp_dir, output_dir, verbose, rich_print)
+        else:
+            tar_file, file_count = __compress_tar(temp_dir, output_dir, verbose, rich_print)
+
         file_count_msg = f"{file_count} file" if file_count == 1 else f"{file_count} files"
 
         if verbose:
@@ -144,8 +151,8 @@ def _run_build_command(
     except subprocess.CalledProcessError as e:
         raise Exception(f"error running build command: {e.stderr}") from e
 
-    if verbose:
-        log(result.stdout)
+    if verbose and result.stdout.strip():
+        log(result.stdout.rstrip("\n"))
 
 
 def _get_shell_command_elements(pre_push_command):
@@ -194,19 +201,18 @@ def _run_pre_push_command(
     except subprocess.CalledProcessError as e:
         raise Exception(f"error running pre-push command: {e.stderr}") from e
 
-    if verbose:
-        log(result.stdout)
+    if verbose and result.stdout.strip():
+        log(result.stdout.rstrip("\n"))
 
 
 def __handle_python(
     app_dir: str,
-    temp_dir: str,
     manifest: Manifest,
     model: Model | None = None,
     model_configuration: ModelConfiguration | None = None,
     verbose: bool = False,
     rich_print: bool = False,
-) -> None:
+) -> Path | None:
     """Handles the Python-specific packaging logic."""
 
     if model is not None and model_configuration is not None:
@@ -224,53 +230,68 @@ def __handle_python(
         else:
             log("🐍 Bundling Python dependencies.")
 
-    __install_dependencies(manifest, app_dir, temp_dir, verbose, rich_print)
+    return __install_dependencies(manifest, app_dir, verbose, rich_print)
 
 
 def __install_dependencies(  # noqa: C901 # complexity
     manifest: Manifest,
     app_dir: str,
-    temp_dir: str,
     verbose: bool = False,
     rich_print: bool = False,
-) -> None:
+) -> Path | None:
     """Install dependencies for the Python app."""
 
     if manifest.python is None:
-        return
+        return None
 
     pip_requirements = manifest.python.pip_requirements
 
     if pip_requirements is None or pip_requirements == "":
         # If no pip requirements are specified, we do not install any dependencies.
-        return
+        return None
 
     if isinstance(pip_requirements, list):
         # If pip_requirements is a list, we write it to a temporary file so that we can
         # pass it to pip.
-        pip_requirements_file = os.path.join(temp_dir, "requirements.txt")
-        with open(pip_requirements_file, "w") as f:
+        pip_requirements_file = tempfile.NamedTemporaryFile(
+            mode="w",
+            suffix=".txt",
+            prefix="nextmv-reqs-",
+            delete=False,
+        )
+        try:
             for requirement in pip_requirements:
-                f.write(requirement + "\n")
-        pip_requirements = pip_requirements_file
+                pip_requirements_file.write(requirement + "\n")
+
+            pip_requirements_file.flush()
+            pip_requirements = pip_requirements_file.name
+
+        finally:
+            pip_requirements_file.close()
     elif isinstance(pip_requirements, str):
         # If pip_requirements is a string, we expect it to be a file path to a
         # requirements file.
         pip_requirements = pip_requirements.strip()
         if not os.path.isfile(os.path.join(app_dir, pip_requirements)):
             raise FileNotFoundError(f"pip requirements file '{pip_requirements}' not found in '{app_dir}'")
+
         if pip_requirements.endswith(".toml"):
             # If the requirements file is a pyproject.toml, read [project.dependencies]
             # and write them to a temporary requirements.txt file for pip.
             deps = read_pyproject_dependencies(os.path.join(app_dir, pip_requirements))
-            pip_requirements_file = os.path.join(temp_dir, "requirements.txt")
-            with open(pip_requirements_file, "w") as f:
+            pip_requirements_file = tempfile.NamedTemporaryFile(
+                mode="w", suffix=".txt", prefix="nextmv-reqs-", delete=False
+            )
+            try:
                 for dep in deps:
-                    f.write(dep + "\n")
-            pip_requirements = pip_requirements_file
+                    pip_requirements_file.write(dep + "\n")
 
-    dep_dir = os.path.join(".nextmv", "python", "deps")
-    target_dir = os.path.join(temp_dir, dep_dir)
+                pip_requirements_file.flush()
+                pip_requirements = pip_requirements_file.name
+            finally:
+                pip_requirements_file.close()
+        else:
+            pip_requirements = os.path.abspath(os.path.join(app_dir, pip_requirements))
 
     python_version = "3.11"
     if manifest.python.version:
@@ -285,14 +306,12 @@ def __install_dependencies(  # noqa: C901 # complexity
         raise Exception(f"unknown architecture '{manifest.python.arch}' specified in manifest")
 
     uv_bin = _find_uv_binary()
-    __resolve_and_install_deps(
+    return __resolve_and_install_deps(
         uv_bin,
         pip_requirements,
         python_version,
         uv_platform,
         app_dir,
-        temp_dir,
-        target_dir,
         verbose,
         rich_print,
     )
@@ -304,41 +323,44 @@ def __resolve_and_install_deps(
     python_version: str,
     uv_platform: str,
     app_dir: str,
-    temp_dir: str,
-    target_dir: str,
     verbose: bool = False,
     rich_print: bool = False,
-) -> None:
+) -> Path | None:
     """Orchestrate the compile -> cache-check -> install -> cache-store flow."""
     lockfile_content = __compile_lockfile(uv_bin, pip_requirements, python_version, uv_platform, app_dir)
     key = cache_key(lockfile_content, python_version, uv_platform)
 
-    cache_dir = get_cached_deps(key)
-    if cache_dir is not None:
-        os.makedirs(target_dir, exist_ok=True)
-        shutil.copytree(str(cache_dir), target_dir, dirs_exist_ok=True)
+    cached_tar = get_cached_deps(key)
+    if cached_tar is not None:
         if verbose:
             if rich_print:
-                rich.print("\t:fast_up_button: Loaded Python dependencies from cache.", file=sys.stderr)
+                rich.print("\t:fast_up_button: Loading compressed Python dependencies from cache.", file=sys.stderr)
             else:
-                log("   ⏫ Loaded Python dependencies from cache.")
+                log("   ⏫ Loading compressed Python dependencies from cache.")
 
-        return
+        return cached_tar
 
     if verbose:
         if rich_print:
-            rich.print("\t:rabbit2: Downloading Python dependencies from package index.", file=sys.stderr)
+            rich.print(
+                "\t:rabbit2: Downloading and compressing Python dependencies from package index.", file=sys.stderr
+            )
         else:
-            log("   🐇 Downloading Python dependencies from package index.")
+            log("   🐇 Downloading and compressing Python dependencies from package index.")
 
-    __run_install(uv_bin, lockfile_content, python_version, uv_platform, app_dir, temp_dir, target_dir)
-    store_deps(
-        key=key,
-        installed_deps_dir=target_dir,
-        python_version=python_version,
-        platform=uv_platform,
-        lockfile_content=lockfile_content,
-    )
+    with tempfile.TemporaryDirectory(prefix="nextmv-deps-install-") as install_tmp:
+        install_dir = os.path.join(install_tmp, "deps")
+        os.makedirs(install_dir)
+        __run_install(uv_bin, lockfile_content, python_version, uv_platform, app_dir, install_tmp, install_dir)
+        store_deps(
+            key=key,
+            installed_deps_dir=install_dir,
+            python_version=python_version,
+            platform=uv_platform,
+            lockfile_content=lockfile_content,
+        )
+
+    return get_cached_deps(key)
 
 
 def __compile_lockfile(
@@ -424,8 +446,68 @@ def __confirm_python_bundling_version(version: str) -> None:
     raise Exception(f"python version 3.10 or higher is required for bundling, got {version}")
 
 
-def __compress_tar(source: str, target: str) -> tuple[str, int]:
+def __build_from_deps_tar(
+    deps_tar: Path,
+    files_dir: str,
+    output_dir: str,
+    verbose: bool = False,
+    rich_print: bool = False,
+) -> tuple[str, int]:
+    """Build the final tarball by concatenating the cached deps.tar.gz with a
+    freshly-compressed tarball of the app files.
+
+    The gzip format (RFC 1952) explicitly supports concatenated streams, and
+    tar decompressors handle them correctly.  This avoids decompressing and
+    recompressing the (large) deps archive — only the small set of app files
+    needs to be compressed from scratch.
+    """
+
+    if verbose:
+        if rich_print:
+            rich.print("\t:hammer_and_wrench:  Appending application files.", file=sys.stderr)
+        else:
+            log("   🛠️  Appending application files.")
+
+    # Read the deps file count from cache_info.json stored next to deps.tar.gz.
+    num_deps_files = 0
+    info_path = deps_tar.parent / "cache_info.json"
+    try:
+        with open(info_path) as f:
+            num_deps_files = json.load(f).get("num_files", 0)
+    except Exception:
+        pass
+
+    # Compress only the app files (small) into a temporary gzip stream.
+    app_files_tar_gz = os.path.join(output_dir, "app-files.tar.gz")
+    num_app_files = 0
+    with tarfile.open(app_files_tar_gz, "w:gz") as tar:
+        for root, _, files in os.walk(files_dir):
+            for file in files:
+                file_path = os.path.join(root, file)
+                arcname = os.path.relpath(file_path, start=files_dir)
+                tar.add(file_path, arcname=arcname)
+                num_app_files += 1
+
+    # Concatenate the two gzip streams — valid per RFC 1952.
+    output_file = os.path.join(output_dir, "app.tar.gz")
+    with open(output_file, "wb") as f_out:
+        with open(str(deps_tar), "rb") as f_deps:
+            shutil.copyfileobj(f_deps, f_out)
+        with open(app_files_tar_gz, "rb") as f_app:
+            shutil.copyfileobj(f_app, f_out)
+
+    os.remove(app_files_tar_gz)
+    return output_file, num_deps_files + num_app_files
+
+
+def __compress_tar(source: str, target: str, verbose: bool = False, rich_print: bool = False) -> tuple[str, int]:
     """Compress the source directory into a tar.gz file in the target"""
+
+    if verbose:
+        if rich_print:
+            rich.print("\t:hammer_and_wrench:  Compressing tarball from scratch.", file=sys.stderr)
+        else:
+            log("   🛠️  Compressing tarball from scratch.")
 
     return_file_name = "app.tar.gz"
     target = os.path.join(target, return_file_name)

--- a/nextmv/nextmv/cloud/package.py
+++ b/nextmv/nextmv/cloud/package.py
@@ -972,22 +972,23 @@ def _log_pkg_cache_status(
         total_word = "dependency" if total == 1 else "dependencies"
         if rich_print:
             rich.print(
-                f"  :fast_up_button: [magenta]{cached_count}/{total}[/magenta] compressed {total_word} found in cache.",
+                f"    :fast_up_button: [magenta]{cached_count}/{total}[/magenta] compressed {total_word} "
+                "found in cache.",
                 file=sys.stderr,
             )
         else:
-            log(f"  ⏫ {cached_count}/{total} compressed {total_word} found in cache.")
+            log(f"    ⏫ {cached_count}/{total} compressed {total_word} found in cache.")
 
     if missing_count > 0:
         missing_word = "dependency" if missing_count == 1 else "dependencies"
         if rich_print:
             rich.print(
-                f"  :rabbit2: Downloading and compressing [magenta]{missing_count}[/magenta] {missing_word} "
+                f"    :rabbit2: Downloading and compressing [magenta]{missing_count}[/magenta] {missing_word} "
                 "from package index.",
                 file=sys.stderr,
             )
         else:
-            log(f"  🐇 Downloading and compressing {missing_count} {missing_word} from package index.")
+            log(f"    🐇 Downloading and compressing {missing_count} {missing_word} from package index.")
 
 
 def _parse_lockfile(lockfile_content: str) -> list[dict[str, str]]:
@@ -1143,9 +1144,9 @@ def _build_from_deps_tar(
 
     if verbose:
         if rich_print:
-            rich.print("  :hammer_and_wrench:  Appending application files.", file=sys.stderr)
+            rich.print("    :hammer_and_wrench:  Appending application files.", file=sys.stderr)
         else:
-            log("  🛠️  Appending application files.")
+            log("    🛠️  Appending application files.")
 
     output_file = os.path.join(output_dir, "app.tar.gz")
     num_files = 0
@@ -1199,9 +1200,9 @@ def _compress_tar(source: str, target: str, verbose: bool = False, rich_print: b
 
     if verbose:
         if rich_print:
-            rich.print("  :hammer_and_wrench:  Compressing tarball from scratch.", file=sys.stderr)
+            rich.print("    :hammer_and_wrench:  Compressing tarball from scratch.", file=sys.stderr)
         else:
-            log("  🛠️  Compressing tarball from scratch.")
+            log("    🛠️  Compressing tarball from scratch.")
 
     return_file_name = "app.tar.gz"
     target = os.path.join(target, return_file_name)

--- a/nextmv/nextmv/cloud/package.py
+++ b/nextmv/nextmv/cloud/package.py
@@ -13,7 +13,7 @@ from pathlib import Path
 
 import rich
 
-from nextmv.cache import cache_key, get_cached_deps, store_deps
+from nextmv.cache import dep_cache_key, get_cached_dep, store_dep
 from nextmv.logger import log
 from nextmv.manifest import (
     MANIFEST_FILE_NAME,
@@ -27,15 +27,8 @@ from nextmv.manifest import (
 from nextmv.model import Model, _cleanup_python_model
 from nextmv.uv_handler import _find_uv_binary
 
-_MANDATORY_FILES_PER_TYPE = {
-    ManifestType.PYTHON: ["main.py"],
-    ManifestType.GO: ["main"],
-    ManifestType.BINARY: ["main"],
-    ManifestType.JAVA: ["main.jar"],
-}
 
-
-def _package(  # noqa: C901 # complexity attributed to printing.
+def package(  # noqa: C901 # complexity attributed to printing.
     app_dir: str,
     manifest: Manifest,
     model: Model | None = None,
@@ -48,10 +41,10 @@ def _package(  # noqa: C901 # complexity attributed to printing.
     with tempfile.TemporaryDirectory(prefix="nextmv-temp-") as temp_dir:
         deps_tar: Path | None = None
         if manifest.type == ManifestType.PYTHON:
-            deps_tar = __handle_python(app_dir, manifest, model, model_configuration, verbose, rich_print)
+            deps_tar = _handle_python(app_dir, manifest, model, model_configuration, verbose, rich_print)
 
         found, missing, files = find_files(app_dir, manifest.files)
-        manifest.confirm_mandatory_files(found)
+        manifest.confirm_mandatory_files(present_files=found)
 
         if len(missing) > 0:
             raise Exception(f"could not find files listed in manifest: {', '.join(missing)}")
@@ -90,15 +83,15 @@ def _package(  # noqa: C901 # complexity attributed to printing.
 
         output_dir = tempfile.mkdtemp(prefix="nextmv-build-out-")
         if deps_tar is not None:
-            tar_file, file_count = __build_from_deps_tar(deps_tar, temp_dir, output_dir, verbose, rich_print)
+            tar_file, file_count = _build_from_deps_tar(deps_tar, temp_dir, output_dir, verbose, rich_print)
         else:
-            tar_file, file_count = __compress_tar(temp_dir, output_dir, verbose, rich_print)
+            tar_file, file_count = _compress_tar(temp_dir, output_dir, verbose, rich_print)
 
         file_count_msg = f"{file_count} file" if file_count == 1 else f"{file_count} files"
 
         if verbose:
             try:
-                size = __human_friendly_file_size(tar_file)
+                size = _human_friendly_file_size(tar_file)
                 if rich_print:
                     rich.print(
                         ":package: Packaged application "
@@ -119,7 +112,7 @@ def _package(  # noqa: C901 # complexity attributed to printing.
         return tar_file, output_dir
 
 
-def _run_build_command(
+def run_build_command(
     app_dir: str,
     manifest_build: ManifestBuild | None = None,
     verbose: bool = False,
@@ -155,21 +148,7 @@ def _run_build_command(
         log(result.stdout.rstrip("\n"))
 
 
-def _get_shell_command_elements(pre_push_command):
-    """Get the shell command elements based on the operating system."""
-    # Check if we're in a Unix-like shell (including MINGW on Windows)
-    bash = shutil.which("bash")
-    if "SHELL" in os.environ and bash:
-        return [bash, "-c", pre_push_command]
-    # Default to cmd on Windows
-    elif platform.system() == "Windows":
-        return ["cmd", "/c", pre_push_command]
-    # Default to sh on Unix-like systems (Linux, macOS)
-    else:
-        return ["sh", "-c", pre_push_command]
-
-
-def _run_pre_push_command(
+def run_pre_push_command(
     app_dir: str,
     pre_push_command: str | None = None,
     verbose: bool = False,
@@ -205,7 +184,21 @@ def _run_pre_push_command(
         log(result.stdout.rstrip("\n"))
 
 
-def __handle_python(
+def _get_shell_command_elements(pre_push_command):
+    """Get the shell command elements based on the operating system."""
+    # Check if we're in a Unix-like shell (including MINGW on Windows)
+    bash = shutil.which("bash")
+    if "SHELL" in os.environ and bash:
+        return [bash, "-c", pre_push_command]
+    # Default to cmd on Windows
+    elif platform.system() == "Windows":
+        return ["cmd", "/c", pre_push_command]
+    # Default to sh on Unix-like systems (Linux, macOS)
+    else:
+        return ["sh", "-c", pre_push_command]
+
+
+def _handle_python(
     app_dir: str,
     manifest: Manifest,
     model: Model | None = None,
@@ -213,7 +206,36 @@ def __handle_python(
     verbose: bool = False,
     rich_print: bool = False,
 ) -> Path | None:
-    """Handles the Python-specific packaging logic."""
+    """
+    Handles the Python-specific packaging logic.
+
+    This includes encoding the Python model (if provided) and bundling Python
+    dependencies using `uv pip`.  The dependencies are resolved, installed, and
+    cached on a per-package basis to maximize cache hits and efficiency.  The
+    final output is a `deps.tar.gz` file containing the installed dependencies,
+    which is returned for inclusion in the final app tarball.
+
+    Parameters
+    ----------
+    app_dir : str
+        The directory of the application.
+    manifest : Manifest
+        The app manifest containing dependency information.
+    model : Model, optional
+        The Python model to encode and include in the package.
+    model_configuration : ModelConfiguration, optional
+        The configuration for encoding the Python model.
+    verbose : bool, optional
+        Whether to print verbose logs.
+    rich_print : bool, optional
+        Whether to use rich printing for verbose logs.
+
+    Returns
+    -------
+    Path or None
+        The path to the `deps.tar.gz` file containing the installed dependencies,
+        or `None` if no dependencies are specified.
+    """
 
     if model is not None and model_configuration is not None:
         if verbose:
@@ -230,94 +252,135 @@ def __handle_python(
         else:
             log("🐍 Bundling Python dependencies.")
 
-    return __install_dependencies(manifest, app_dir, verbose, rich_print)
+    deps_tar = _install_dependencies(manifest, app_dir, verbose, rich_print)
+
+    return deps_tar
 
 
-def __install_dependencies(  # noqa: C901 # complexity
+def _install_dependencies(
     manifest: Manifest,
     app_dir: str,
     verbose: bool = False,
     rich_print: bool = False,
 ) -> Path | None:
-    """Install dependencies for the Python app."""
+    """
+    Install dependencies for the Python app.
+
+    Parameters
+    ----------
+    manifest : Manifest
+        The app manifest containing dependency information.
+    app_dir : str
+        The directory of the application.
+    verbose : bool, optional
+        Whether to print verbose logs.
+    rich_print : bool, optional
+        Whether to use rich printing for verbose logs.
+
+    Returns
+    -------
+    Path or None
+        Path to the `deps.tar.gz` file containing the installed dependencies,
+        or `None` if no dependencies are specified.
+    """
 
     if manifest.python is None:
         return None
 
     pip_requirements = manifest.python.pip_requirements
 
+    # If no pip requirements are specified, we do not install any dependencies.
     if pip_requirements is None or pip_requirements == "":
-        # If no pip requirements are specified, we do not install any dependencies.
         return None
+
+    pip_requirements, is_temp_file = _resolve_pip_requirements_file(pip_requirements, app_dir)
+    try:
+        python_version = "3.11"
+        if manifest.python.version:
+            _confirm_python_bundling_version(manifest.python.version)
+            python_version = manifest.python.version
+
+        if not manifest.python.arch or manifest.python.arch == "arm64":
+            uv_platform = "aarch64-unknown-linux-gnu"
+        elif manifest.python.arch == "amd64":
+            uv_platform = "x86_64-unknown-linux-gnu"
+        else:
+            raise Exception(f"unknown architecture '{manifest.python.arch}' specified in manifest")
+
+        uv_bin = _find_uv_binary()
+        deps_tar = _resolve_and_install_deps(
+            uv_bin,
+            pip_requirements,
+            python_version,
+            uv_platform,
+            app_dir,
+            verbose,
+            rich_print,
+        )
+
+        return deps_tar
+    finally:
+        if is_temp_file:
+            try:
+                os.unlink(pip_requirements)
+            except OSError:
+                pass
+
+
+def _resolve_pip_requirements_file(pip_requirements: list[str] | str, app_dir: str) -> tuple[str, bool]:
+    """
+    Resolve pip_requirements to a path to a requirements .txt file.
+
+    - A list of requirement strings is written to a temporary file.
+    - A string path to a pyproject.toml is converted by extracting
+      [project.dependencies] into a temporary file.
+    - Any other string path is resolved to an absolute path.
+
+    Parameters
+    ----------
+    pip_requirements : list[str] or str
+        Either a list of pip requirement strings or a string path to a requirements file.
+    app_dir : str
+        The directory of the application.
+
+    Returns
+    -------
+    tuple[str, bool]
+        A tuple containing the path to the requirements file and a boolean indicating
+        whether the file is temporary and should be deleted by the caller.
+    """
 
     if isinstance(pip_requirements, list):
         # If pip_requirements is a list, we write it to a temporary file so that we can
         # pass it to pip.
-        pip_requirements_file = tempfile.NamedTemporaryFile(
-            mode="w",
-            suffix=".txt",
-            prefix="nextmv-reqs-",
-            delete=False,
-        )
-        try:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", prefix="nextmv-reqs-", delete=False) as f:
             for requirement in pip_requirements:
-                pip_requirements_file.write(requirement + "\n")
+                f.write(requirement + "\n")
 
-            pip_requirements_file.flush()
-            pip_requirements = pip_requirements_file.name
+            return f.name, True
 
-        finally:
-            pip_requirements_file.close()
-    elif isinstance(pip_requirements, str):
-        # If pip_requirements is a string, we expect it to be a file path to a
-        # requirements file.
-        pip_requirements = pip_requirements.strip()
-        if not os.path.isfile(os.path.join(app_dir, pip_requirements)):
-            raise FileNotFoundError(f"pip requirements file '{pip_requirements}' not found in '{app_dir}'")
+    # pip_requirements is a string path.
+    pip_requirements = pip_requirements.strip()
+    if not os.path.isfile(os.path.join(app_dir, pip_requirements)):
+        raise FileNotFoundError(f"pip requirements file '{pip_requirements}' not found in '{app_dir}'")
 
-        if os.path.basename(pip_requirements) == "pyproject.toml":
-            # If the requirements file is a pyproject.toml, read [project.dependencies]
-            # and write them to a temporary requirements.txt file for pip.
-            deps = read_pyproject_dependencies(os.path.join(app_dir, pip_requirements))
-            pip_requirements_file = tempfile.NamedTemporaryFile(
-                mode="w", suffix=".txt", prefix="nextmv-reqs-", delete=False
-            )
-            try:
-                for dep in deps:
-                    pip_requirements_file.write(dep + "\n")
+    if os.path.basename(pip_requirements) == "pyproject.toml":
+        # If the requirements file is a pyproject.toml, read
+        # [project].dependencies and write them to a temporary requirements.txt
+        # file for pip.
+        deps = read_pyproject_dependencies(os.path.join(app_dir, pip_requirements))
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", prefix="nextmv-reqs-", delete=False) as f:
+            for dep in deps:
+                f.write(dep + "\n")
 
-                pip_requirements_file.flush()
-                pip_requirements = pip_requirements_file.name
-            finally:
-                pip_requirements_file.close()
-        else:
-            pip_requirements = os.path.abspath(os.path.join(app_dir, pip_requirements))
+            return f.name, True
 
-    python_version = "3.11"
-    if manifest.python.version:
-        __confirm_python_bundling_version(manifest.python.version)
-        python_version = manifest.python.version
-
-    if not manifest.python.arch or manifest.python.arch == "arm64":
-        uv_platform = "aarch64-unknown-linux-gnu"
-    elif manifest.python.arch == "amd64":
-        uv_platform = "x86_64-unknown-linux-gnu"
-    else:
-        raise Exception(f"unknown architecture '{manifest.python.arch}' specified in manifest")
-
-    uv_bin = _find_uv_binary()
-    return __resolve_and_install_deps(
-        uv_bin,
-        pip_requirements,
-        python_version,
-        uv_platform,
-        app_dir,
-        verbose,
-        rich_print,
-    )
+    # Otherwise, we assume it's a path to a requirements.txt file and return
+    # the absolute path.
+    return os.path.abspath(os.path.join(app_dir, pip_requirements)), False
 
 
-def __resolve_and_install_deps(
+def _resolve_and_install_deps(
     uv_bin: str,
     pip_requirements: str,
     python_version: str,
@@ -326,44 +389,434 @@ def __resolve_and_install_deps(
     verbose: bool = False,
     rich_print: bool = False,
 ) -> Path | None:
-    """Orchestrate the compile -> cache-check -> install -> cache-store flow."""
-    lockfile_content = __compile_lockfile(uv_bin, pip_requirements, python_version, uv_platform, app_dir)
-    key = cache_key(lockfile_content, python_version, uv_platform)
+    """
+    Compile the lockfile, fetch missing packages, and assemble deps.tar.gz.
 
-    cached_tar = get_cached_deps(key)
-    if cached_tar is not None:
-        if verbose:
-            if rich_print:
-                rich.print("\t:fast_up_button: Loading compressed Python dependencies from cache.", file=sys.stderr)
-            else:
-                log("   ⏫ Loading compressed Python dependencies from cache.")
+    For each package in the lockfile:
+    - If a cached per-package `installed.tar.gz` exists, use it directly.
+    - Otherwise download the wheel, install it, compress it, and store it in
+      the cache for future runs.
 
-        return cached_tar
+    The final `deps.tar.gz` is assembled by concatenating the per-package
+    gzip streams (valid per RFC 1952 — no decompression or recompression
+    needed).
 
-    if verbose:
+    Parameters
+    ----------
+    uv_bin : str
+        Path to the `uv` binary.
+    pip_requirements : str
+        Path to the pip requirements file.
+    python_version : str
+        The Python version to target, e.g. "3.11".
+    uv_platform : str
+        The `uv` platform string to target, e.g. "x86_64-unknown-linux-gnu".
+    app_dir : str
+        The application directory to use as the working directory for `uv pip`
+        commands.
+    verbose : bool, optional
+        Whether to print verbose logs.
+    rich_print : bool, optional
+        Whether to use rich printing for verbose logs.
+
+    Returns
+    -------
+    Path or None
+        The path to the assembled `deps.tar.gz` file containing the installed
+        dependencies, or `None` if no dependencies are specified.
+    """
+
+    lockfile_content = _compile_lockfile(uv_bin, pip_requirements, python_version, uv_platform, app_dir)
+    packages = _parse_lockfile(lockfile_content)
+
+    with tempfile.TemporaryDirectory(prefix="nextmv-pkg-tars-") as tars_tmp:
+        cached_tars, missing_packages = _collect_cached_package_tars(packages, python_version, uv_platform)
+        _log_pkg_cache_status(verbose, rich_print, len(cached_tars), len(packages), len(missing_packages))
+
+        new_pkg_tars: list[dict[str, Path]] = []
+        if missing_packages:
+            new_pkg_tars = _fetch_missing_package_tars(
+                uv_bin,
+                missing_packages,
+                python_version,
+                uv_platform,
+                app_dir,
+                out_dir=tars_tmp,
+            )
+            _store_new_package_tars(pkg_tars=new_pkg_tars, python_version=python_version, uv_platform=uv_platform)
+
+        all_tars = cached_tars + [pkg["tar_path"] for pkg in new_pkg_tars]
+        _, deps_tar = _concat_package_tars(tars=all_tars, out_dir=tars_tmp)
+
+        # Move the assembled tar out of the temp dir before it is cleaned up.
+        final_tar = Path(tempfile.mkdtemp(prefix="nextmv-deps-out-")) / "deps.tar.gz"
+        shutil.move(str(deps_tar), str(final_tar))
+
+    return final_tar
+
+
+def _collect_cached_package_tars(
+    packages: list[dict[str, str]],
+    python_version: str,
+    uv_platform: str,
+) -> tuple[list[Path], list[dict[str, str]]]:
+    """
+    Check L2 for each package and return `(cached_tar_paths,
+    missing_packages)`.
+
+    Parameters
+    ----------
+    packages : list of dict
+        A list of dictionaries, each containing the `name` and `version` of a
+        package in the lockfile.
+    python_version : str
+        The Python version to target, e.g. "3.11".
+    uv_platform : str
+        The `uv` platform string to target, e.g. "x86_64-unknown-linux-gnu".
+
+    Returns
+    -------
+    tuple of (list of Path, list of dict)
+        A tuple containing two lists:
+        - The first list contains the paths to the cached tar files for each package.
+        - The second list contains dictionaries for the packages that are
+        missing from the cache, each containing the `name` and `version`.
+    """
+
+    cached_tars: list[Path] = []
+    missing_packages: list[dict[str, str]] = []
+
+    for package in packages:
+        name, version = package["name"], package["version"]
+        pkg_key = dep_cache_key(name, version, python_version, uv_platform)
+        cached_tar = get_cached_dep(pkg_key)
+        if cached_tar is not None:
+            cached_tars.append(cached_tar)
+        else:
+            missing_packages.append({"name": name, "version": version})
+
+    return cached_tars, missing_packages
+
+
+def _fetch_missing_package_tars(
+    uv_bin: str,
+    missing_packages: list[dict[str, str]],
+    python_version: str,
+    uv_platform: str,
+    app_dir: str,
+    out_dir: str,
+) -> list[dict[str, Path]]:
+    """
+    Download, install, and compress each missing package into *out_dir*.
+
+    Downloading is done in a single batch call for efficiency.  Installation
+    and compression are then done per-package so each gets its own
+    `installed.tar.gz` suitable for caching and gzip concatenation.
+
+    Parameters
+    ----------
+    uv_bin : str
+        Path to the `uv` binary.
+    missing_packages : list of dict
+        A list of dictionaries for the packages that are missing from the cache,
+        each containing the `name` and `version`.
+    python_version : str
+        The Python version to target, e.g. "3.11".
+    uv_platform : str
+        The `uv` platform string to target, e.g. "x86_64-unknown-linux-gnu".
+    app_dir : str
+        The application directory to use as the working directory for `uv pip`
+        commands.
+    out_dir : str
+        The directory to write the per-package `installed.tar.gz` files to.
+        This should be a temporary directory that is cleaned up by the caller.
+
+    Returns
+    -------
+    list of dict
+        A list of dictionaries, each containing the `pkg_key` and `tar_path` for
+        a missing package that was fetched, installed, and compressed.
+    """
+
+    wheel_dir = os.path.join(out_dir, "wheels")
+    os.makedirs(wheel_dir)
+    _batch_download_packages(
+        uv_bin=uv_bin,
+        packages=missing_packages,
+        python_version=python_version,
+        uv_platform=uv_platform,
+        app_dir=app_dir,
+        wheel_dir=wheel_dir,
+    )
+
+    results: list[dict[str, Path]] = []
+    for package in missing_packages:
+        name, version = package["name"], package["version"]
+        pkg_key = dep_cache_key(name, version, python_version, uv_platform)
+        tar_path = _install_and_compress_package(
+            uv_bin=uv_bin,
+            name=name,
+            version=version,
+            python_version=python_version,
+            uv_platform=uv_platform,
+            app_dir=app_dir,
+            wheel_dir=wheel_dir,
+            out_dir=out_dir,
+        )
+        results.append({"pkg_key": pkg_key, "tar_path": tar_path})
+
+    return results
+
+
+def _batch_download_packages(
+    uv_bin: str,
+    packages: list[dict[str, str]],
+    python_version: str,
+    uv_platform: str,
+    app_dir: str,
+    wheel_dir: str,
+) -> None:
+    """Download all *packages* as wheels into *wheel_dir* in one `uv pip download` call."""
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", prefix="nextmv-missing-", delete=False) as f:
+        for package in packages:
+            name, version = package["name"], package["version"]
+            f.write(f"{name}=={version}\n")
+
+        reqs_file = f.name
+
+    try:
+        result = subprocess.run(
+            [
+                uv_bin,
+                "pip",
+                "download",
+                "-r",
+                reqs_file,
+                "--no-deps",
+                "--only-binary=:all:",
+                f"--python-platform={uv_platform}",
+                f"--python-version={python_version}",
+                "-d",
+                wheel_dir,
+                "--quiet",
+            ],
+            cwd=app_dir,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            raise Exception(f"error downloading dependencies: {os.linesep}{result.stderr}")
+    finally:
+        os.unlink(reqs_file)
+
+
+def _install_and_compress_package(
+    uv_bin: str,
+    name: str,
+    version: str,
+    python_version: str,
+    uv_platform: str,
+    app_dir: str,
+    wheel_dir: str,
+    out_dir: str,
+) -> Path:
+    """Install a single package from *wheel_dir* and compress its installed tree.
+
+    Uses `--no-deps` because the lockfile already encodes the complete
+    dependency graph — each package is handled independently.
+
+    Returns the path to `<name>-<version>.tar.gz` written inside *out_dir*.
+    """
+
+    with tempfile.TemporaryDirectory(prefix="nextmv-pkg-install-") as install_tmp:
+        install_dir = os.path.join(install_tmp, "pkg")
+        os.makedirs(install_dir)
+
+        result = subprocess.run(
+            [
+                uv_bin,
+                "pip",
+                "install",
+                f"{name}=={version}",
+                "--no-deps",
+                "--only-binary=:all:",
+                "--find-links",
+                wheel_dir,
+                "--no-index",
+                "--target",
+                install_dir,
+                "--quiet",
+                f"--python-platform={uv_platform}",
+                f"--python-version={python_version}",
+            ],
+            cwd=app_dir,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+        if result.returncode != 0:
+            raise Exception(f"error installing {name}=={version}: {os.linesep}{result.stdout}")
+
+        safe_name = re.sub(r"[^A-Za-z0-9._-]", "_", f"{name}-{version}")
+        tar_path = Path(out_dir) / f"{safe_name}.tar.gz"
+        dep_arcname = os.path.join(".nextmv", "python", "deps")
+        with tarfile.open(str(tar_path), "w:gz") as tar:
+            tar.add(install_dir, arcname=dep_arcname)
+
+    return tar_path
+
+
+def _store_new_package_tars(
+    pkg_tars: list[dict[str, Path]],
+    python_version: str,
+    uv_platform: str,
+) -> None:
+    """
+    Store newly built per-package tarballs into the cache.
+
+    Parameters
+    ----------
+    pkg_tars : list of dict
+        A list of dictionaries, each containing the `pkg_key` and `tar_path` for
+        a missing package that was fetched, installed, and compressed.
+    python_version : str
+        The Python version to target, e.g. "3.11".
+    uv_platform : str
+        The `uv` platform string to target, e.g. "x86_64-linux-gnu".
+    """
+
+    for pkg in pkg_tars:
+        pkg_key, tar_path = pkg["pkg_key"], pkg["tar_path"]
+        if get_cached_dep(pkg_key) is None:
+            store_dep(pkg_key, tar_path, python_version, uv_platform)
+
+
+def _concat_package_tars(tars: list[Path], out_dir: str) -> tuple[int, Path]:
+    """
+    Concatenate per-package gzip streams into a single `deps.tar.gz`.
+
+    The gzip format (RFC 1952) explicitly supports concatenated member streams,
+    and tar decompressors handle them correctly.  This means no decompression
+    or recompression is needed — assembly is pure sequential I/O.
+
+    Parameters
+    ----------
+    tars : list of Path
+        A list of paths to the per-package `installed.tar.gz` files to
+        concatenate.
+    out_dir : str
+        The directory to write the concatenated `deps.tar.gz` file to.  This
+        should be a temporary directory that is cleaned up by the caller.
+
+    Returns
+    -------
+    tuple of (int, Path)
+        A tuple containing the total number of files across all packages and the
+        path to the assembled `deps.tar.gz` file.
+    """
+
+    out_path = Path(out_dir) / "deps.tar.gz"
+    num_files = 0
+
+    with open(str(out_path), "wb") as f_out:
+        for tar_path in tars:
+            try:
+                with tarfile.open(str(tar_path), "r:gz") as tar:
+                    num_files += len(tar.getmembers())
+            except Exception:
+                pass
+
+            with open(str(tar_path), "rb") as f_in:
+                shutil.copyfileobj(f_in, f_out)
+
+    return num_files, out_path
+
+
+def _log_pkg_cache_status(
+    verbose: bool,
+    rich_print: bool,
+    cached_count: int,
+    total: int,
+    missing_count: int,
+) -> None:
+    """
+    Emit a verbose message about the per-package tarball cache hit/miss ratio.
+
+    Parameters
+    ----------
+    verbose : bool
+        Whether to print verbose logs.
+    rich_print : bool
+        Whether to use rich printing for verbose logs.
+    cached_count : int
+        The number of packages found in the cache.
+    total : int
+        The total number of packages in the lockfile.
+    missing_count : int
+        The number of packages missing from the cache (i.e. `total -
+        cached_count`).
+    """
+
+    if not verbose:
+        return
+
+    if missing_count == 0 and total > 0:
         if rich_print:
             rich.print(
-                "\t:rabbit2: Downloading and compressing Python dependencies from package index.", file=sys.stderr
+                f"\t:fast_up_button: All [magenta]{total}[/magenta] package(s) found in cache.",
+                file=sys.stderr,
             )
         else:
-            log("   🐇 Downloading and compressing Python dependencies from package index.")
-
-    with tempfile.TemporaryDirectory(prefix="nextmv-deps-install-") as install_tmp:
-        install_dir = os.path.join(install_tmp, "deps")
-        os.makedirs(install_dir)
-        __run_install(uv_bin, lockfile_content, python_version, uv_platform, app_dir, install_tmp, install_dir)
-        store_deps(
-            key=key,
-            installed_deps_dir=install_dir,
-            python_version=python_version,
-            platform=uv_platform,
-            lockfile_content=lockfile_content,
-        )
-
-    return get_cached_deps(key)
+            log(f"   ⏫ All {total} package(s) found in cache.")
+    elif missing_count > 0:
+        if rich_print:
+            rich.print(
+                f"\t:rabbit2: {cached_count}/{total} packages cached; "
+                f"downloading [magenta]{missing_count}[/magenta] from package index.",
+                file=sys.stderr,
+            )
+        else:
+            log(f"   🐇 {cached_count}/{total} packages cached; downloading {missing_count} from package index.")
 
 
-def __compile_lockfile(
+def _parse_lockfile(lockfile_content: str) -> list[dict[str, str]]:
+    """
+    Parse a `uv pip compile` lockfile and return `(name, version)` pairs.
+
+    Only top-level package lines are matched — lines that start with a package
+    name followed by `==`.  Comment lines (`#`) and indented annotation
+    lines (`    # via ...`) are skipped.
+
+    The returned `(name, version)` pairs are used to check the cache and fetch
+    missing packages.
+
+    Parameters
+    ----------
+    lockfile_content : str
+        The content of the lockfile produced by `uv pip compile`.
+
+    Returns
+    -------
+    list of dict
+        A list of dictionaries, each containing the `name` and `version` of a
+        top-level package in the lockfile.
+    """
+
+    _re_pkg = re.compile(r"^([A-Za-z0-9][A-Za-z0-9._-]*)==([^\s;#\[]+)")
+    packages = []
+    for line in lockfile_content.splitlines():
+        if not line or line[0] in (" ", "\t", "#"):
+            continue
+
+        m = _re_pkg.match(line)
+        if m:
+            packages.append({"name": m.group(1), "version": m.group(2)})
+
+    return packages
+
+
+def _compile_lockfile(
     uv_bin: str,
     pip_requirements: str,
     python_version: str,
@@ -375,6 +828,26 @@ def __compile_lockfile(
 
     Pinning makes the cache key deterministic: the same requirements always
     produce the same key regardless of when the build runs.
+
+    Parameters
+    ----------
+    uv_bin : str
+        Path to the `uv` binary.
+    pip_requirements : str
+        Path to the pip requirements file.
+    python_version : str
+        The Python version to target, e.g. "3.11".
+    uv_platform : str
+        The `uv` platform string to target, e.g. "x86_64-unknown-linux-gnu".
+    app_dir : str
+        The application directory to use as the working directory for `uv pip`
+        commands.
+
+    Returns
+    -------
+    str
+        The content of the compiled lockfile, which is a fully-pinned list of
+        packages and versions.
     """
 
     result = subprocess.run(
@@ -398,44 +871,24 @@ def __compile_lockfile(
     return result.stdout
 
 
-def __run_install(
-    uv_bin: str,
-    lockfile_content: str,
-    python_version: str,
-    uv_platform: str,
-    app_dir: str,
-    temp_dir: str,
-    target_dir: str,
-) -> None:
-    """Install packages from a pinned lockfile via `uv pip install`."""
-    lockfile_file = os.path.join(temp_dir, "requirements.lock")
-    with open(lockfile_file, "w") as f:
-        f.write(lockfile_content)
+def _confirm_python_bundling_version(version: str) -> None:
+    """
+    Validate that *version* is suitable for dependency bundling.
 
-    result = subprocess.run(
-        [
-            uv_bin,
-            "pip",
-            "install",
-            "-r",
-            lockfile_file,
-            "--only-binary=:all:",
-            "--target",
-            target_dir,
-            "--quiet",
-            f"--python-platform={uv_platform}",
-            f"--python-version={python_version}",
-        ],
-        cwd=app_dir,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        text=True,
-    )
-    if result.returncode != 0:
-        raise Exception(f"error installing dependencies: {os.linesep}{result.stdout}")
+    Raises an exception if the version is not in ``major.minor`` form or is
+    below Python 3.10, which is the minimum required for bundling.
 
+    Parameters
+    ----------
+    version : str
+        The Python version string to validate, e.g. ``"3.11"``.
 
-def __confirm_python_bundling_version(version: str) -> None:
+    Raises
+    ------
+    Exception
+        If the version is not in ``major.minor`` form or is below 3.10.
+    """
+
     # Only accept versions in the form "major.minor" where both are integers
     re_version = re.compile(r"^(\d+)\.(\d+)$")
     match = re_version.fullmatch(version)
@@ -443,10 +896,11 @@ def __confirm_python_bundling_version(version: str) -> None:
         major, minor = int(match.group(1)), int(match.group(2))
         if major == 3 and minor >= 10:
             return
+
     raise Exception(f"python version 3.10 or higher is required for bundling, got {version}")
 
 
-def __build_from_deps_tar(
+def _build_from_deps_tar(
     deps_tar: Path,
     files_dir: str,
     output_dir: str,
@@ -500,7 +954,7 @@ def __build_from_deps_tar(
     return output_file, num_deps_files + num_app_files
 
 
-def __compress_tar(source: str, target: str, verbose: bool = False, rich_print: bool = False) -> tuple[str, int]:
+def _compress_tar(source: str, target: str, verbose: bool = False, rich_print: bool = False) -> tuple[str, int]:
     """Compress the source directory into a tar.gz file in the target"""
 
     if verbose:
@@ -526,7 +980,7 @@ def __compress_tar(source: str, target: str, verbose: bool = False, rich_print: 
     return target, num_files
 
 
-def __human_friendly_file_size(path: str) -> str:
+def _human_friendly_file_size(path: str) -> str:
     """Return a human-friendly string representation of the file size."""
 
     try:

--- a/nextmv/nextmv/cloud/package.py
+++ b/nextmv/nextmv/cloud/package.py
@@ -55,6 +55,15 @@ def _package(  # noqa: C901 # complexity attributed to printing.
 
         manifest.to_yaml(temp_dir)
 
+        if verbose:
+            if rich_print:
+                rich.print(
+                    f":clipboard: Copying files listed in [magenta]{MANIFEST_FILE_NAME}[/magenta] manifest.",
+                    file=sys.stderr,
+                )
+            else:
+                log(f'📋 Copying files listed in "{MANIFEST_FILE_NAME}" manifest.')
+
         for file in files:
             target_dir = os.path.dirname(os.path.join(temp_dir, file["interior_path"]))
             try:
@@ -67,21 +76,19 @@ def _package(  # noqa: C901 # complexity attributed to printing.
             except subprocess.CalledProcessError as e:
                 raise Exception(f"error copying asset files {file['absolute_path']}: {e}") from e
 
-        if verbose:
-            if rich_print:
-                rich.print(
-                    f":clipboard: Copied files listed in [magenta]{MANIFEST_FILE_NAME}[/magenta] manifest.",
-                    file=sys.stderr,
-                )
-            else:
-                log(f'📋 Copied files listed in "{MANIFEST_FILE_NAME}" manifest.')
-
         if manifest.type == ManifestType.PYTHON:
             _cleanup_python_model(app_dir, model_configuration, verbose)
+
+        if verbose:
+            if rich_print:
+                rich.print(":dvd: Compressing application into tarball.", file=sys.stderr)
+            else:
+                log("📀 Compressing application into tarball.")
 
         output_dir = tempfile.mkdtemp(prefix="nextmv-build-out-")
         tar_file, file_count = __compress_tar(temp_dir, output_dir)
         file_count_msg = f"{file_count} file" if file_count == 1 else f"{file_count} files"
+
         if verbose:
             try:
                 size = __human_friendly_file_size(tar_file)
@@ -217,13 +224,15 @@ def __handle_python(
         else:
             log("🐍 Bundling Python dependencies.")
 
-    __install_dependencies(manifest, app_dir, temp_dir)
+    __install_dependencies(manifest, app_dir, temp_dir, verbose, rich_print)
 
 
 def __install_dependencies(  # noqa: C901 # complexity
     manifest: Manifest,
     app_dir: str,
     temp_dir: str,
+    verbose: bool = False,
+    rich_print: bool = False,
 ) -> None:
     """Install dependencies for the Python app."""
 
@@ -276,7 +285,17 @@ def __install_dependencies(  # noqa: C901 # complexity
         raise Exception(f"unknown architecture '{manifest.python.arch}' specified in manifest")
 
     uv_bin = _find_uv_binary()
-    __resolve_and_install_deps(uv_bin, pip_requirements, python_version, uv_platform, app_dir, temp_dir, target_dir)
+    __resolve_and_install_deps(
+        uv_bin,
+        pip_requirements,
+        python_version,
+        uv_platform,
+        app_dir,
+        temp_dir,
+        target_dir,
+        verbose,
+        rich_print,
+    )
 
 
 def __resolve_and_install_deps(
@@ -287,16 +306,30 @@ def __resolve_and_install_deps(
     app_dir: str,
     temp_dir: str,
     target_dir: str,
+    verbose: bool = False,
+    rich_print: bool = False,
 ) -> None:
-    """Orchestrate the compile → cache-check → install → cache-store flow."""
+    """Orchestrate the compile -> cache-check -> install -> cache-store flow."""
     lockfile_content = __compile_lockfile(uv_bin, pip_requirements, python_version, uv_platform, app_dir)
     key = cache_key(lockfile_content, python_version, uv_platform)
 
-    cached = get_cached_deps(key)
-    if cached is not None:
+    cache_dir = get_cached_deps(key)
+    if cache_dir is not None:
         os.makedirs(target_dir, exist_ok=True)
-        shutil.copytree(str(cached), target_dir, dirs_exist_ok=True)
+        shutil.copytree(str(cache_dir), target_dir, dirs_exist_ok=True)
+        if verbose:
+            if rich_print:
+                rich.print(":zap: Loaded Python dependencies from cache.", file=sys.stderr)
+            else:
+                log("⚡ Loaded Python dependencies from cache.")
+
         return
+
+    if verbose:
+        if rich_print:
+            rich.print(":rabbit2: Downloading Python dependencies from package index.", file=sys.stderr)
+        else:
+            log("🐇 Downloading Python dependencies from package index.")
 
     __run_install(uv_bin, lockfile_content, python_version, uv_platform, app_dir, temp_dir, target_dir)
     store_deps(
@@ -315,11 +348,13 @@ def __compile_lockfile(
     uv_platform: str,
     app_dir: str,
 ) -> str:
-    """Resolve requirements to a fully-pinned lockfile via ``uv pip compile``.
+    """
+    Resolve requirements to a fully-pinned lockfile via `uv pip compile`.
 
     Pinning makes the cache key deterministic: the same requirements always
     produce the same key regardless of when the build runs.
     """
+
     result = subprocess.run(
         [
             uv_bin,
@@ -334,8 +369,10 @@ def __compile_lockfile(
         capture_output=True,
         text=True,
     )
+
     if result.returncode != 0:
         raise Exception(f"error resolving dependencies: {os.linesep}{result.stderr}")
+
     return result.stdout
 
 
@@ -348,7 +385,7 @@ def __run_install(
     temp_dir: str,
     target_dir: str,
 ) -> None:
-    """Install packages from a pinned lockfile via ``uv pip install``."""
+    """Install packages from a pinned lockfile via `uv pip install`."""
     lockfile_file = os.path.join(temp_dir, "requirements.lock")
     with open(lockfile_file, "w") as f:
         f.write(lockfile_content)

--- a/nextmv/nextmv/cloud/package.py
+++ b/nextmv/nextmv/cloud/package.py
@@ -44,6 +44,7 @@ def package(
     model_configuration: ModelConfiguration | None = None,
     verbose: bool = False,
     rich_print: bool = False,
+    no_cache: bool = False,
 ) -> tuple[str, str]:
     """
     Package the app into a tarball.
@@ -62,6 +63,13 @@ def package(
         Whether to print verbose logs.
     rich_print : bool, optional
         Whether to use rich printing for verbose logs.
+    no_cache : bool, default=False
+        When working with Python, dependencies are cached to speed up
+        subsequent pushes. Setting no_cache to True will skip using the
+        cache and force a fresh build of all dependencies. This is useful
+        when you want to ensure that you are pushing the most up-to-date
+        versions of your dependencies, or if you are encountering issues
+        with the cache and want to rule it out as a potential cause.
 
     Returns
     -------
@@ -78,7 +86,7 @@ def package(
         success = False
         try:
             if manifest.type == ManifestType.PYTHON:
-                deps_tar = _handle_python(app_dir, manifest, model, model_configuration, verbose, rich_print)
+                deps_tar = _handle_python(app_dir, manifest, model, model_configuration, verbose, rich_print, no_cache)
 
             found, missing, files = find_files(app_dir, manifest.files)
             manifest.confirm_mandatory_files(present_files=found)
@@ -372,6 +380,7 @@ def _handle_python(
     model_configuration: ModelConfiguration | None = None,
     verbose: bool = False,
     rich_print: bool = False,
+    no_cache: bool = False,
 ) -> Path | None:
     """
     Handles the Python-specific packaging logic.
@@ -396,6 +405,12 @@ def _handle_python(
         Whether to print verbose logs.
     rich_print : bool, optional
         Whether to use rich printing for verbose logs.
+    no_cache : bool, default=False
+        Do not use or populate the dependency cache when resolving and
+        installing Python dependencies. This forces a fresh build of all
+        dependencies, which can be useful to ensure that the most up-to-date
+        versions of dependencies are included or to rule out cache-related
+        issues.
 
     Returns
     -------
@@ -415,11 +430,13 @@ def _handle_python(
 
     if verbose:
         if rich_print:
-            rich.print(":snake: Bundling Python dependencies.", file=sys.stderr)
+            suffix = " - caching [italic]disabled[/italic]" if no_cache else ""
+            rich.print(f":snake: Bundling Python dependencies{suffix}.", file=sys.stderr)
         else:
-            log("🐍 Bundling Python dependencies.")
+            suffix = " - caching disabled" if no_cache else ""
+            log(f"🐍 Bundling Python dependencies{suffix}.")
 
-    deps_tar = _install_dependencies(manifest, app_dir, verbose, rich_print)
+    deps_tar = _install_dependencies(manifest, app_dir, verbose, rich_print, no_cache)
 
     return deps_tar
 
@@ -429,6 +446,7 @@ def _install_dependencies(
     app_dir: str,
     verbose: bool = False,
     rich_print: bool = False,
+    no_cache: bool = False,
 ) -> Path | None:
     """
     Install dependencies for the Python app.
@@ -443,6 +461,12 @@ def _install_dependencies(
         Whether to print verbose logs.
     rich_print : bool, optional
         Whether to use rich printing for verbose logs.
+    no_cache : bool, default=False
+        Do not use or populate the dependency cache when resolving and
+        installing Python dependencies. This forces a fresh build of all
+        dependencies, which can be useful to ensure that the most up-to-date
+        versions of dependencies are included or to rule out cache-related
+        issues.
 
     Returns
     -------
@@ -483,6 +507,7 @@ def _install_dependencies(
             app_dir,
             verbose,
             rich_print,
+            no_cache,
         )
 
         return deps_tar
@@ -555,6 +580,7 @@ def _resolve_and_install_deps(
     app_dir: str,
     verbose: bool = False,
     rich_print: bool = False,
+    no_cache: bool = False,
 ) -> Path | None:
     """
     Compile the lockfile, fetch missing packages, and assemble deps.tar.gz.
@@ -585,6 +611,12 @@ def _resolve_and_install_deps(
         Whether to print verbose logs.
     rich_print : bool, optional
         Whether to use rich printing for verbose logs.
+    no_cache : bool, default=False
+        Do not use or populate the dependency cache when resolving and
+        installing Python dependencies. This forces a fresh build of all
+        dependencies, which can be useful to ensure that the most up-to-date
+        versions of dependencies are included or to rule out cache-related
+        issues.
 
     Returns
     -------
@@ -597,20 +629,26 @@ def _resolve_and_install_deps(
     packages = _parse_lockfile(lockfile_content)
 
     with tempfile.TemporaryDirectory(prefix="nextmv-pkg-tars-") as tars_tmp:
-        cached_tars, missing_packages = _collect_cached_package_tars(packages, python_version, uv_platform)
+        if no_cache:
+            cached_tars: list[Path] = []
+            missing_packages = packages
+        else:
+            cached_tars, missing_packages = _collect_cached_package_tars(packages, python_version, uv_platform)
+
         _log_pkg_cache_status(verbose, rich_print, len(cached_tars), len(packages), len(missing_packages))
 
         new_pkg_tars: list[dict[str, Path]] = []
         if missing_packages:
             new_pkg_tars = _fetch_missing_package_tars(
-                uv_bin,
-                missing_packages,
-                python_version,
-                uv_platform,
-                app_dir,
+                uv_bin=uv_bin,
+                missing_packages=missing_packages,
+                python_version=python_version,
+                uv_platform=uv_platform,
+                app_dir=app_dir,
                 out_dir=tars_tmp,
             )
-            _store_new_package_tars(pkg_tars=new_pkg_tars, python_version=python_version, uv_platform=uv_platform)
+            if not no_cache:
+                _store_new_package_tars(pkg_tars=new_pkg_tars, python_version=python_version, uv_platform=uv_platform)
 
         all_tars = cached_tars + [pkg["tar_path"] for pkg in new_pkg_tars]
         _, deps_tar = _concat_package_tars(tars=all_tars, out_dir=tars_tmp)
@@ -852,10 +890,13 @@ def _store_new_package_tars(
 
     for pkg in pkg_tars:
         pkg_key, tar_path = pkg["pkg_key"], pkg["tar_path"]
+        name, version = pkg["name"], pkg["version"]
         if get_cached_dep(pkg_key) is None:
             store_dep(
                 pkg_key=pkg_key,
                 tar_path=tar_path,
+                name=name,
+                version=version,
                 python_version=python_version,
                 platform=uv_platform,
             )

--- a/nextmv/nextmv/cloud/package.py
+++ b/nextmv/nextmv/cloud/package.py
@@ -11,6 +11,7 @@ import tempfile
 
 import rich
 
+from nextmv.cache import cache_key, get_cached_deps, store_deps
 from nextmv.logger import log
 from nextmv.manifest import (
     MANIFEST_FILE_NAME,
@@ -275,25 +276,100 @@ def __install_dependencies(  # noqa: C901 # complexity
         raise Exception(f"unknown architecture '{manifest.python.arch}' specified in manifest")
 
     uv_bin = _find_uv_binary()
-    command = [
-        uv_bin,
-        "pip",
-        "install",
-        "-r",
-        pip_requirements,
-        "--only-binary=:all:",
-        "--upgrade",
-        "--target",
-        target_dir,
-        "--quiet",
-        f"--python-platform={uv_platform}",
-        f"--python-version={python_version}",
-    ]
+    __resolve_and_install_deps(uv_bin, pip_requirements, python_version, uv_platform, app_dir, temp_dir, target_dir)
+
+
+def __resolve_and_install_deps(
+    uv_bin: str,
+    pip_requirements: str,
+    python_version: str,
+    uv_platform: str,
+    app_dir: str,
+    temp_dir: str,
+    target_dir: str,
+) -> None:
+    """Orchestrate the compile → cache-check → install → cache-store flow."""
+    lockfile_content = __compile_lockfile(uv_bin, pip_requirements, python_version, uv_platform, app_dir)
+    key = cache_key(lockfile_content, python_version, uv_platform)
+
+    cached = get_cached_deps(key)
+    if cached is not None:
+        os.makedirs(target_dir, exist_ok=True)
+        shutil.copytree(str(cached), target_dir, dirs_exist_ok=True)
+        return
+
+    __run_install(uv_bin, lockfile_content, python_version, uv_platform, app_dir, temp_dir, target_dir)
+    store_deps(
+        key=key,
+        installed_deps_dir=target_dir,
+        python_version=python_version,
+        platform=uv_platform,
+        lockfile_content=lockfile_content,
+    )
+
+
+def __compile_lockfile(
+    uv_bin: str,
+    pip_requirements: str,
+    python_version: str,
+    uv_platform: str,
+    app_dir: str,
+) -> str:
+    """Resolve requirements to a fully-pinned lockfile via ``uv pip compile``.
+
+    Pinning makes the cache key deterministic: the same requirements always
+    produce the same key regardless of when the build runs.
+    """
     result = subprocess.run(
-        command,
+        [
+            uv_bin,
+            "pip",
+            "compile",
+            pip_requirements,
+            "--quiet",
+            f"--python-platform={uv_platform}",
+            f"--python-version={python_version}",
+        ],
+        cwd=app_dir,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise Exception(f"error resolving dependencies: {os.linesep}{result.stderr}")
+    return result.stdout
+
+
+def __run_install(
+    uv_bin: str,
+    lockfile_content: str,
+    python_version: str,
+    uv_platform: str,
+    app_dir: str,
+    temp_dir: str,
+    target_dir: str,
+) -> None:
+    """Install packages from a pinned lockfile via ``uv pip install``."""
+    lockfile_file = os.path.join(temp_dir, "requirements.lock")
+    with open(lockfile_file, "w") as f:
+        f.write(lockfile_content)
+
+    result = subprocess.run(
+        [
+            uv_bin,
+            "pip",
+            "install",
+            "-r",
+            lockfile_file,
+            "--only-binary=:all:",
+            "--target",
+            target_dir,
+            "--quiet",
+            f"--python-platform={uv_platform}",
+            f"--python-version={python_version}",
+        ],
         cwd=app_dir,
         stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,  # Merge stderr into stdout
+        stderr=subprocess.STDOUT,
         text=True,
     )
     if result.returncode != 0:

--- a/nextmv/nextmv/cloud/package.py
+++ b/nextmv/nextmv/cloud/package.py
@@ -81,9 +81,9 @@ def _package(  # noqa: C901 # complexity attributed to printing.
 
         if verbose:
             if rich_print:
-                rich.print(":dvd: Compressing application into tarball.", file=sys.stderr)
+                rich.print(":floppy_disk: Compressing application into tarball.", file=sys.stderr)
             else:
-                log("📀 Compressing application into tarball.")
+                log("💾 Compressing application into tarball.")
 
         output_dir = tempfile.mkdtemp(prefix="nextmv-build-out-")
         tar_file, file_count = __compress_tar(temp_dir, output_dir)
@@ -319,17 +319,17 @@ def __resolve_and_install_deps(
         shutil.copytree(str(cache_dir), target_dir, dirs_exist_ok=True)
         if verbose:
             if rich_print:
-                rich.print(":zap: Loaded Python dependencies from cache.", file=sys.stderr)
+                rich.print("\t:fast_up_button: Loaded Python dependencies from cache.", file=sys.stderr)
             else:
-                log("⚡ Loaded Python dependencies from cache.")
+                log("   ⏫ Loaded Python dependencies from cache.")
 
         return
 
     if verbose:
         if rich_print:
-            rich.print(":rabbit2: Downloading Python dependencies from package index.", file=sys.stderr)
+            rich.print("\t:rabbit2: Downloading Python dependencies from package index.", file=sys.stderr)
         else:
-            log("🐇 Downloading Python dependencies from package index.")
+            log("   🐇 Downloading Python dependencies from package index.")
 
     __run_install(uv_bin, lockfile_content, python_version, uv_platform, app_dir, temp_dir, target_dir)
     store_deps(

--- a/nextmv/nextmv/cloud/package.py
+++ b/nextmv/nextmv/cloud/package.py
@@ -1,6 +1,6 @@
-"""Module with the logic for pushing an app to Nextmv Cloud."""
+"""Module with the logic for packaging an app to Nextmv Cloud."""
 
-import json
+import gzip
 import os
 import platform
 import re
@@ -27,8 +27,17 @@ from nextmv.manifest import (
 from nextmv.model import Model, _cleanup_python_model
 from nextmv.uv_handler import _find_uv_binary
 
+_IO_CHUNK_SIZE = 65536
+"""
+Buffer size in bytes for streaming I/O operations (64 KiB).
 
-def package(  # noqa: C901 # complexity attributed to printing.
+Matches the default used by :func:`shutil.copyfileobj` and is a common OS
+page-aligned I/O buffer size that balances syscall overhead against memory
+pressure for sequential reads and writes.
+"""
+
+
+def package(
     app_dir: str,
     manifest: Manifest,
     model: Model | None = None,
@@ -36,80 +45,181 @@ def package(  # noqa: C901 # complexity attributed to printing.
     verbose: bool = False,
     rich_print: bool = False,
 ) -> tuple[str, str]:
-    """Package the app into a tarball."""
+    """
+    Package the app into a tarball.
+
+    Parameters
+    ----------
+    app_dir : str
+        The directory of the application to package.
+    manifest : Manifest
+        The app manifest describing the application type, files, and dependencies.
+    model : Model, optional
+        The Python model to encode and include in the package.
+    model_configuration : ModelConfiguration, optional
+        The configuration for encoding the Python model.
+    verbose : bool, optional
+        Whether to print verbose logs.
+    rich_print : bool, optional
+        Whether to use rich printing for verbose logs.
+
+    Returns
+    -------
+    tuple of (str, str)
+        A tuple containing the path to the resulting ``app.tar.gz`` file and
+        the path to the output directory that holds it.  The caller is
+        responsible for cleaning up the output directory when it is no longer
+        needed.
+    """
 
     with tempfile.TemporaryDirectory(prefix="nextmv-temp-") as temp_dir:
         deps_tar: Path | None = None
-        if manifest.type == ManifestType.PYTHON:
-            deps_tar = _handle_python(app_dir, manifest, model, model_configuration, verbose, rich_print)
+        output_dir: str | None = None
+        success = False
+        try:
+            if manifest.type == ManifestType.PYTHON:
+                deps_tar = _handle_python(app_dir, manifest, model, model_configuration, verbose, rich_print)
 
-        found, missing, files = find_files(app_dir, manifest.files)
-        manifest.confirm_mandatory_files(present_files=found)
+            found, missing, files = find_files(app_dir, manifest.files)
+            manifest.confirm_mandatory_files(present_files=found)
 
-        if len(missing) > 0:
-            raise Exception(f"could not find files listed in manifest: {', '.join(missing)}")
+            if len(missing) > 0:
+                raise Exception(f"could not find files listed in manifest: {', '.join(missing)}")
 
-        manifest.to_yaml(temp_dir)
+            manifest.to_yaml(temp_dir)
+            _copy_manifest_files(files, temp_dir, verbose, rich_print)
 
-        if verbose:
+            if manifest.type == ManifestType.PYTHON:
+                _cleanup_python_model(app_dir, model_configuration, verbose)
+
+            output_dir = tempfile.mkdtemp(prefix="nextmv-build-out-")
+            tar_file, _ = _compress_and_report(deps_tar, temp_dir, output_dir, verbose, rich_print)
+
+            success = True
+            return tar_file, output_dir
+        finally:
+            if deps_tar is not None:
+                shutil.rmtree(str(deps_tar.parent), ignore_errors=True)
+            if not success and output_dir is not None:
+                shutil.rmtree(output_dir, ignore_errors=True)
+
+
+def _copy_manifest_files(
+    files: list[dict],
+    temp_dir: str,
+    verbose: bool = False,
+    rich_print: bool = False,
+) -> None:
+    """
+    Copy files listed in the manifest into the temp directory.
+
+    Parameters
+    ----------
+    files : list of dict
+        A list of file descriptors as returned by :func:`find_files`, each
+        containing an ``absolute_path`` and an ``interior_path`` key.
+    temp_dir : str
+        The temporary directory into which files are copied, preserving the
+        relative layout given by ``interior_path``.
+    verbose : bool, optional
+        Whether to print verbose logs.
+    rich_print : bool, optional
+        Whether to use rich printing for verbose logs.
+
+    Raises
+    ------
+    Exception
+        If a destination directory cannot be created or a file cannot be
+        copied.
+    """
+
+    if verbose:
+        if rich_print:
+            rich.print(
+                f":clipboard: Copying files listed in [magenta]{MANIFEST_FILE_NAME}[/magenta] manifest.",
+                file=sys.stderr,
+            )
+        else:
+            log(f'📋 Copying files listed in "{MANIFEST_FILE_NAME}" manifest.')
+
+    for file in files:
+        target_dir = os.path.dirname(os.path.join(temp_dir, file["interior_path"]))
+        try:
+            os.makedirs(target_dir, exist_ok=True)
+        except OSError as e:
+            raise Exception(f"error creating directory for asset file {file['interior_path']}: {e}") from e
+
+        try:
+            shutil.copy2(file["absolute_path"], os.path.join(temp_dir, target_dir))
+        except subprocess.CalledProcessError as e:
+            raise Exception(f"error copying asset files {file['absolute_path']}: {e}") from e
+
+
+def _compress_and_report(
+    deps_tar: Path | None,
+    temp_dir: str,
+    output_dir: str,
+    verbose: bool = False,
+    rich_print: bool = False,
+) -> tuple[str, int]:
+    """
+    Compress the app into a tarball and log the result.
+
+    Parameters
+    ----------
+    deps_tar : Path or None
+        Path to a pre-built ``deps.tar.gz`` containing installed Python
+        dependencies, or ``None`` when no dependencies need to be bundled.
+    temp_dir : str
+        Directory containing the app files that have been staged for packaging.
+    output_dir : str
+        Directory where the resulting ``app.tar.gz`` will be written.
+    verbose : bool, optional
+        Whether to print verbose logs.
+    rich_print : bool, optional
+        Whether to use rich printing for verbose logs.
+
+    Returns
+    -------
+    tuple of (str, int)
+        A tuple containing the path to the resulting ``app.tar.gz`` file and
+        the number of application files included in the archive.
+    """
+
+    if verbose:
+        if rich_print:
+            rich.print(":floppy_disk: Compressing application into tarball.", file=sys.stderr)
+        else:
+            log("💾 Compressing application into tarball.")
+
+    if deps_tar is not None:
+        tar_file, file_count = _build_from_deps_tar(deps_tar, temp_dir, output_dir, verbose, rich_print)
+    else:
+        tar_file, file_count = _compress_tar(temp_dir, output_dir, verbose, rich_print)
+
+    if verbose:
+        app_file_count_label = "app file" if file_count == 1 else "app files"
+        size_label = "with dependencies" if deps_tar is not None else "total"
+        try:
+            size = _human_friendly_file_size(tar_file)
             if rich_print:
                 rich.print(
-                    f":clipboard: Copying files listed in [magenta]{MANIFEST_FILE_NAME}[/magenta] manifest.",
+                    f":package: Packaged application ([magenta]{file_count}[/magenta] {app_file_count_label}, "
+                    f"[magenta]{size}[/magenta] {size_label}).",
                     file=sys.stderr,
                 )
             else:
-                log(f'📋 Copying files listed in "{MANIFEST_FILE_NAME}" manifest.')
-
-        for file in files:
-            target_dir = os.path.dirname(os.path.join(temp_dir, file["interior_path"]))
-            try:
-                os.makedirs(target_dir, exist_ok=True)
-            except OSError as e:
-                raise Exception(f"error creating directory for asset file {file['interior_path']}: {e}") from e
-
-            try:
-                shutil.copy2(file["absolute_path"], os.path.join(temp_dir, target_dir))
-            except subprocess.CalledProcessError as e:
-                raise Exception(f"error copying asset files {file['absolute_path']}: {e}") from e
-
-        if manifest.type == ManifestType.PYTHON:
-            _cleanup_python_model(app_dir, model_configuration, verbose)
-
-        if verbose:
+                log(f"📦 Packaged application ({file_count} {app_file_count_label}, {size} {size_label}).")
+        except Exception:
             if rich_print:
-                rich.print(":floppy_disk: Compressing application into tarball.", file=sys.stderr)
+                rich.print(
+                    f":package: Packaged application ([magenta]{file_count}[/magenta] {app_file_count_label}).",
+                    file=sys.stderr,
+                )
             else:
-                log("💾 Compressing application into tarball.")
+                log(f"📦 Packaged application ({file_count} {app_file_count_label}).")
 
-        output_dir = tempfile.mkdtemp(prefix="nextmv-build-out-")
-        if deps_tar is not None:
-            tar_file, file_count = _build_from_deps_tar(deps_tar, temp_dir, output_dir, verbose, rich_print)
-        else:
-            tar_file, file_count = _compress_tar(temp_dir, output_dir, verbose, rich_print)
-
-        file_count_msg = f"{file_count} file" if file_count == 1 else f"{file_count} files"
-
-        if verbose:
-            try:
-                size = _human_friendly_file_size(tar_file)
-                if rich_print:
-                    rich.print(
-                        ":package: Packaged application "
-                        f"([magenta]{file_count_msg}[/magenta], [magenta]{size}[/magenta]).",
-                        file=sys.stderr,
-                    )
-                else:
-                    log(f"📦 Packaged application ({file_count_msg}, {size}).")
-            except Exception:
-                if rich_print:
-                    rich.print(
-                        f":package: Packaged application ([magenta]{file_count_msg}[/magenta]).",
-                        file=sys.stderr,
-                    )
-                else:
-                    log(f"📦 Packaged application ({file_count_msg}).")
-
-        return tar_file, output_dir
+    return tar_file, file_count
 
 
 def run_build_command(
@@ -118,7 +228,27 @@ def run_build_command(
     verbose: bool = False,
     rich_print: bool = False,
 ) -> None:
-    """Run the build command specified in the manifest."""
+    """
+    Run the build command specified in the manifest.
+
+    Parameters
+    ----------
+    app_dir : str
+        The directory of the application, used as the working directory when
+        running the build command.
+    manifest_build : ManifestBuild, optional
+        The build configuration from the manifest.  If ``None`` or if
+        ``manifest_build.command`` is empty, this function is a no-op.
+    verbose : bool, optional
+        Whether to print verbose logs.
+    rich_print : bool, optional
+        Whether to use rich printing for verbose logs.
+
+    Raises
+    ------
+    Exception
+        If the build command exits with a non-zero return code.
+    """
 
     if manifest_build is None or manifest_build.command is None or manifest_build.command == "":
         return
@@ -154,7 +284,27 @@ def run_pre_push_command(
     verbose: bool = False,
     rich_print: bool = False,
 ) -> None:
-    """Run the pre-push command specified in the manifest."""
+    """
+    Run the pre-push command specified in the manifest.
+
+    Parameters
+    ----------
+    app_dir : str
+        The directory of the application, used as the working directory when
+        running the pre-push command.
+    pre_push_command : str, optional
+        The shell command to execute before pushing.  If ``None`` or empty,
+        this function is a no-op.
+    verbose : bool, optional
+        Whether to print verbose logs.
+    rich_print : bool, optional
+        Whether to use rich printing for verbose logs.
+
+    Raises
+    ------
+    Exception
+        If the pre-push command exits with a non-zero return code.
+    """
 
     if pre_push_command is None or pre_push_command == "":
         return
@@ -185,7 +335,24 @@ def run_pre_push_command(
 
 
 def _get_shell_command_elements(pre_push_command):
-    """Get the shell command elements based on the operating system."""
+    """
+    Get the shell command elements based on the operating system.
+
+    Wraps *pre_push_command* in the appropriate shell invocation for the
+    current platform so that shell features (pipes, redirects, etc.) work
+    correctly.
+
+    Parameters
+    ----------
+    pre_push_command : str
+        The raw shell command string to execute.
+
+    Returns
+    -------
+    list of str
+        A list of arguments suitable for passing directly to
+        :func:`subprocess.run`, e.g. ``["bash", "-c", command]``.
+    """
     # Check if we're in a Unix-like shell (including MINGW on Windows)
     bash = shutil.which("bash")
     if "SHELL" in os.environ and bash:
@@ -449,8 +616,13 @@ def _resolve_and_install_deps(
         _, deps_tar = _concat_package_tars(tars=all_tars, out_dir=tars_tmp)
 
         # Move the assembled tar out of the temp dir before it is cleaned up.
-        final_tar = Path(tempfile.mkdtemp(prefix="nextmv-deps-out-")) / "deps.tar.gz"
-        shutil.move(str(deps_tar), str(final_tar))
+        deps_out_dir = tempfile.mkdtemp(prefix="nextmv-deps-out-")
+        try:
+            final_tar = Path(deps_out_dir) / "deps.tar.gz"
+            shutil.move(str(deps_tar), str(final_tar))
+        except Exception:
+            shutil.rmtree(deps_out_dir, ignore_errors=True)
+            raise
 
     return final_tar
 
@@ -461,8 +633,8 @@ def _collect_cached_package_tars(
     uv_platform: str,
 ) -> tuple[list[Path], list[dict[str, str]]]:
     """
-    Check L2 for each package and return `(cached_tar_paths,
-    missing_packages)`.
+    Check the cache for each package and collect paths to cached tars,
+    returning any missing packages.
 
     Parameters
     ----------
@@ -538,17 +710,6 @@ def _fetch_missing_package_tars(
         a missing package that was fetched, installed, and compressed.
     """
 
-    wheel_dir = os.path.join(out_dir, "wheels")
-    os.makedirs(wheel_dir)
-    _batch_download_packages(
-        uv_bin=uv_bin,
-        packages=missing_packages,
-        python_version=python_version,
-        uv_platform=uv_platform,
-        app_dir=app_dir,
-        wheel_dir=wheel_dir,
-    )
-
     results: list[dict[str, Path]] = []
     for package in missing_packages:
         name, version = package["name"], package["version"]
@@ -560,55 +721,18 @@ def _fetch_missing_package_tars(
             python_version=python_version,
             uv_platform=uv_platform,
             app_dir=app_dir,
-            wheel_dir=wheel_dir,
             out_dir=out_dir,
         )
-        results.append({"pkg_key": pkg_key, "tar_path": tar_path})
+        results.append(
+            {
+                "pkg_key": pkg_key,
+                "tar_path": tar_path,
+                "name": name,
+                "version": version,
+            }
+        )
 
     return results
-
-
-def _batch_download_packages(
-    uv_bin: str,
-    packages: list[dict[str, str]],
-    python_version: str,
-    uv_platform: str,
-    app_dir: str,
-    wheel_dir: str,
-) -> None:
-    """Download all *packages* as wheels into *wheel_dir* in one `uv pip download` call."""
-
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", prefix="nextmv-missing-", delete=False) as f:
-        for package in packages:
-            name, version = package["name"], package["version"]
-            f.write(f"{name}=={version}\n")
-
-        reqs_file = f.name
-
-    try:
-        result = subprocess.run(
-            [
-                uv_bin,
-                "pip",
-                "download",
-                "-r",
-                reqs_file,
-                "--no-deps",
-                "--only-binary=:all:",
-                f"--python-platform={uv_platform}",
-                f"--python-version={python_version}",
-                "-d",
-                wheel_dir,
-                "--quiet",
-            ],
-            cwd=app_dir,
-            capture_output=True,
-            text=True,
-        )
-        if result.returncode != 0:
-            raise Exception(f"error downloading dependencies: {os.linesep}{result.stderr}")
-    finally:
-        os.unlink(reqs_file)
 
 
 def _install_and_compress_package(
@@ -618,15 +742,36 @@ def _install_and_compress_package(
     python_version: str,
     uv_platform: str,
     app_dir: str,
-    wheel_dir: str,
     out_dir: str,
 ) -> Path:
-    """Install a single package from *wheel_dir* and compress its installed tree.
+    """Install a single package from the package index and compress its installed tree.
 
     Uses `--no-deps` because the lockfile already encodes the complete
     dependency graph — each package is handled independently.
 
-    Returns the path to `<name>-<version>.tar.gz` written inside *out_dir*.
+    Parameters
+    ----------
+    uv_bin : str
+        Path to the `uv` binary.
+    name : str
+        The package name as it appears in the lockfile or wheel filename.
+    version : str
+        The pinned version string (e.g. `"2.23.4"`).
+    python_version : str
+        The target Python version string (e.g. `"3.11"`).
+    uv_platform : str
+        The target platform string (e.g. `"aarch64-unknown-linux-gnu"`).
+    app_dir : str
+        The application directory to use as the working directory for `uv pip`
+        commands.
+    out_dir : str
+        The directory to write the per-package `installed.tar.gz` files to.
+        This should be a temporary directory that is cleaned up by the caller.
+
+    Returns
+    -------
+    Path
+        The path to the `installed.tar.gz` file for the installed package.
     """
 
     with tempfile.TemporaryDirectory(prefix="nextmv-pkg-install-") as install_tmp:
@@ -641,9 +786,6 @@ def _install_and_compress_package(
                 f"{name}=={version}",
                 "--no-deps",
                 "--only-binary=:all:",
-                "--find-links",
-                wheel_dir,
-                "--no-index",
                 "--target",
                 install_dir,
                 "--quiet",
@@ -661,8 +803,30 @@ def _install_and_compress_package(
         safe_name = re.sub(r"[^A-Za-z0-9._-]", "_", f"{name}-{version}")
         tar_path = Path(out_dir) / f"{safe_name}.tar.gz"
         dep_arcname = os.path.join(".nextmv", "python", "deps")
-        with tarfile.open(str(tar_path), "w:gz") as tar:
-            tar.add(install_dir, arcname=dep_arcname)
+
+        # Write tar entries to a temp .tar file, capture the byte offset
+        # where tarfile will write the EOF marker, then gzip-compress only
+        # the entries (no EOF block).  Omitting the EOF block lets these
+        # per-package gzip streams be raw-concatenated without causing tar
+        # to stop at the first end-of-archive marker.
+        with tempfile.NamedTemporaryFile(suffix=".tar", delete=False, dir=install_tmp) as _tmp_f:
+            tmp_tar_path = _tmp_f.name
+
+        tar_obj = tarfile.open(tmp_tar_path, mode="w")
+        tar_obj.add(install_dir, arcname=dep_arcname)
+        entry_end = tar_obj.offset  # byte offset where EOF marker begins
+        tar_obj.close()
+
+        with open(tmp_tar_path, "rb") as raw_f:
+            with gzip.open(str(tar_path), "wb") as gz:
+                remaining = entry_end
+                while remaining > 0:
+                    chunk = raw_f.read(min(_IO_CHUNK_SIZE, remaining))
+                    if not chunk:
+                        break
+
+                    gz.write(chunk)
+                    remaining -= len(chunk)
 
     return tar_path
 
@@ -689,7 +853,12 @@ def _store_new_package_tars(
     for pkg in pkg_tars:
         pkg_key, tar_path = pkg["pkg_key"], pkg["tar_path"]
         if get_cached_dep(pkg_key) is None:
-            store_dep(pkg_key, tar_path, python_version, uv_platform)
+            store_dep(
+                pkg_key=pkg_key,
+                tar_path=tar_path,
+                python_version=python_version,
+                platform=uv_platform,
+            )
 
 
 def _concat_package_tars(tars: list[Path], out_dir: str) -> tuple[int, Path]:
@@ -717,20 +886,17 @@ def _concat_package_tars(tars: list[Path], out_dir: str) -> tuple[int, Path]:
     """
 
     out_path = Path(out_dir) / "deps.tar.gz"
-    num_files = 0
 
-    with open(str(out_path), "wb") as f_out:
+    # Each per-package .tar.gz is a gzip stream of tar entries with no
+    # end-of-archive block.  Concatenate raw bytes — zero decompression needed.
+    # The tar EOF block is written later by _build_from_deps_tar as part of
+    # the final app.tar.gz gzip member.
+    with open(str(out_path), "wb") as out_f:
         for tar_path in tars:
-            try:
-                with tarfile.open(str(tar_path), "r:gz") as tar:
-                    num_files += len(tar.getmembers())
-            except Exception:
-                pass
+            with open(str(tar_path), "rb") as in_f:
+                shutil.copyfileobj(in_f, out_f)
 
-            with open(str(tar_path), "rb") as f_in:
-                shutil.copyfileobj(f_in, f_out)
-
-    return num_files, out_path
+    return 0, out_path
 
 
 def _log_pkg_cache_status(
@@ -761,23 +927,26 @@ def _log_pkg_cache_status(
     if not verbose:
         return
 
-    if missing_count == 0 and total > 0:
+    if cached_count > 0:
+        total_word = "dependency" if total == 1 else "dependencies"
         if rich_print:
             rich.print(
-                f"\t:fast_up_button: All [magenta]{total}[/magenta] package(s) found in cache.",
+                f"\t:fast_up_button: [magenta]{cached_count}/{total}[/magenta] compressed {total_word} found in cache.",
                 file=sys.stderr,
             )
         else:
-            log(f"   ⏫ All {total} package(s) found in cache.")
-    elif missing_count > 0:
+            log(f"   ⏫ {cached_count}/{total} compressed {total_word} found in cache.")
+
+    if missing_count > 0:
+        missing_word = "dependency" if missing_count == 1 else "dependencies"
         if rich_print:
             rich.print(
-                f"\t:rabbit2: {cached_count}/{total} packages cached; "
-                f"downloading [magenta]{missing_count}[/magenta] from package index.",
+                f"\t:rabbit2: Downloading and compressing [magenta]{missing_count}[/magenta] {missing_word} "
+                "from package index.",
                 file=sys.stderr,
             )
         else:
-            log(f"   🐇 {cached_count}/{total} packages cached; downloading {missing_count} from package index.")
+            log(f"   🐇 Downloading and compressing {missing_count} {missing_word} from package index.")
 
 
 def _parse_lockfile(lockfile_content: str) -> list[dict[str, str]]:
@@ -907,13 +1076,28 @@ def _build_from_deps_tar(
     verbose: bool = False,
     rich_print: bool = False,
 ) -> tuple[str, int]:
-    """Build the final tarball by concatenating the cached deps.tar.gz with a
+    """
+    Build the final tarball by concatenating the cached deps.tar.gz with a
     freshly-compressed tarball of the app files.
 
     The gzip format (RFC 1952) explicitly supports concatenated streams, and
     tar decompressors handle them correctly.  This avoids decompressing and
     recompressing the (large) deps archive — only the small set of app files
     needs to be compressed from scratch.
+
+    Parameters
+    ----------
+    deps_tar : Path
+        The path to the `deps.tar.gz` file containing the installed dependencies.
+    files_dir : str
+        The directory containing the app files to be included in the final tarball.
+    output_dir : str
+        The directory to write the final `app.tar.gz` file to.  This should be
+        a temporary directory that is cleaned up by the caller.
+    verbose : bool, optional
+        Whether to print verbose logs.
+    rich_print : bool, optional
+        Whether to use rich printing for verbose logs.
     """
 
     if verbose:
@@ -922,40 +1106,55 @@ def _build_from_deps_tar(
         else:
             log("   🛠️  Appending application files.")
 
-    # Read the deps file count from cache_info.json stored next to deps.tar.gz.
-    num_deps_files = 0
-    info_path = deps_tar.parent / "cache_info.json"
-    try:
-        with open(info_path) as f:
-            num_deps_files = json.load(f).get("num_files", 0)
-    except Exception:
-        pass
-
-    # Compress only the app files (small) into a temporary gzip stream.
-    app_files_tar_gz = os.path.join(output_dir, "app-files.tar.gz")
-    num_app_files = 0
-    with tarfile.open(app_files_tar_gz, "w:gz") as tar:
-        for root, _, files in os.walk(files_dir):
-            for file in files:
-                file_path = os.path.join(root, file)
-                arcname = os.path.relpath(file_path, start=files_dir)
-                tar.add(file_path, arcname=arcname)
-                num_app_files += 1
-
-    # Concatenate the two gzip streams — valid per RFC 1952.
     output_file = os.path.join(output_dir, "app.tar.gz")
-    with open(output_file, "wb") as f_out:
-        with open(str(deps_tar), "rb") as f_deps:
-            shutil.copyfileobj(f_deps, f_out)
-        with open(app_files_tar_gz, "rb") as f_app:
-            shutil.copyfileobj(f_app, f_out)
+    num_files = 0
 
-    os.remove(app_files_tar_gz)
-    return output_file, num_deps_files + num_app_files
+    # Raw-copy all per-package gzip streams (no decompression).
+    with open(output_file, "wb") as out_f:
+        with open(str(deps_tar), "rb") as df:
+            shutil.copyfileobj(df, out_f)
+
+    # Append app files + tar EOF as the final gzip member.  gzip.open in
+    # append-binary mode starts a new gzip member in the same file, so the
+    # complete app.tar.gz is a valid multi-member gzip that any modern tar
+    # decompressor handles correctly.
+    with gzip.open(output_file, "ab") as gz_out:
+        with tarfile.open(fileobj=gz_out, mode="w|") as app_tar:
+            for root, _, files in os.walk(files_dir):
+                for file in files:
+                    file_path = os.path.join(root, file)
+                    arcname = os.path.relpath(file_path, start=files_dir)
+                    app_tar.add(file_path, arcname=arcname)
+                    num_files += 1
+
+    return output_file, num_files
 
 
 def _compress_tar(source: str, target: str, verbose: bool = False, rich_print: bool = False) -> tuple[str, int]:
-    """Compress the source directory into a tar.gz file in the target"""
+    """
+    Compress the source directory into a tar.gz file in the target.
+
+    This is used when there are no dependencies to bundle and we can simply
+    compress the app files directly without needing to concatenate with a deps
+    tarball.
+
+    Parameters
+    ----------
+    source : str
+        The directory containing the files to be compressed into the tarball.
+    target : str
+        The directory where the resulting tar.gz file should be saved.
+    verbose : bool, optional
+        Whether to print verbose logs.
+    rich_print : bool, optional
+        Whether to use rich printing for verbose logs.
+
+    Returns
+    -------
+    tuple of (str, int)
+        A tuple containing the path to the resulting tar.gz file and the number
+        of files included in the tarball.
+    """
 
     if verbose:
         if rich_print:
@@ -981,7 +1180,21 @@ def _compress_tar(source: str, target: str, verbose: bool = False, rich_print: b
 
 
 def _human_friendly_file_size(path: str) -> str:
-    """Return a human-friendly string representation of the file size."""
+    """
+    Return a human-friendly string representation of the file size.
+
+    Parameters
+    ----------
+    path : str
+        The path to the file whose size is to be determined.
+
+    Returns
+    -------
+    str
+        A human-friendly string representation of the file size, using
+        appropriate units (B, KiB, MiB, GiB) and rounded to two decimal places
+        for larger units.
+    """
 
     try:
         size = os.path.getsize(path)

--- a/nextmv/nextmv/cloud/package.py
+++ b/nextmv/nextmv/cloud/package.py
@@ -972,22 +972,22 @@ def _log_pkg_cache_status(
         total_word = "dependency" if total == 1 else "dependencies"
         if rich_print:
             rich.print(
-                f"\t:fast_up_button: [magenta]{cached_count}/{total}[/magenta] compressed {total_word} found in cache.",
+                f"  :fast_up_button: [magenta]{cached_count}/{total}[/magenta] compressed {total_word} found in cache.",
                 file=sys.stderr,
             )
         else:
-            log(f"   ⏫ {cached_count}/{total} compressed {total_word} found in cache.")
+            log(f"  ⏫ {cached_count}/{total} compressed {total_word} found in cache.")
 
     if missing_count > 0:
         missing_word = "dependency" if missing_count == 1 else "dependencies"
         if rich_print:
             rich.print(
-                f"\t:rabbit2: Downloading and compressing [magenta]{missing_count}[/magenta] {missing_word} "
+                f"  :rabbit2: Downloading and compressing [magenta]{missing_count}[/magenta] {missing_word} "
                 "from package index.",
                 file=sys.stderr,
             )
         else:
-            log(f"   🐇 Downloading and compressing {missing_count} {missing_word} from package index.")
+            log(f"  🐇 Downloading and compressing {missing_count} {missing_word} from package index.")
 
 
 def _parse_lockfile(lockfile_content: str) -> list[dict[str, str]]:
@@ -1143,9 +1143,9 @@ def _build_from_deps_tar(
 
     if verbose:
         if rich_print:
-            rich.print("\t:hammer_and_wrench:  Appending application files.", file=sys.stderr)
+            rich.print("  :hammer_and_wrench:  Appending application files.", file=sys.stderr)
         else:
-            log("   🛠️  Appending application files.")
+            log("  🛠️  Appending application files.")
 
     output_file = os.path.join(output_dir, "app.tar.gz")
     num_files = 0
@@ -1199,9 +1199,9 @@ def _compress_tar(source: str, target: str, verbose: bool = False, rich_print: b
 
     if verbose:
         if rich_print:
-            rich.print("\t:hammer_and_wrench:  Compressing tarball from scratch.", file=sys.stderr)
+            rich.print("  :hammer_and_wrench:  Compressing tarball from scratch.", file=sys.stderr)
         else:
-            log("   🛠️  Compressing tarball from scratch.")
+            log("  🛠️  Compressing tarball from scratch.")
 
     return_file_name = "app.tar.gz"
     target = os.path.join(target, return_file_name)

--- a/nextmv/nextmv/local/application.py
+++ b/nextmv/nextmv/local/application.py
@@ -1761,12 +1761,12 @@ class Application(BaseModel):
             if verbose:
                 if rich_print:
                     rich.print(
-                        f"  :fast_forward: Skipping local run [magenta]{run_id}[/magenta], already synced with "
+                        f"    :fast_forward: Skipping local run [magenta]{run_id}[/magenta], already synced with "
                         f"[magenta]{synced_run.to_dict()}[/magenta].",
                         file=sys.stderr,
                     )
                 else:
-                    log(f"  ⏭️  Skipping local run `{run_id}`, already synced with {synced_run.to_dict()}.")
+                    log(f"    ⏭️  Skipping local run `{run_id}`, already synced with {synced_run.to_dict()}.")
 
             return False
 
@@ -1775,11 +1775,11 @@ class Application(BaseModel):
             if verbose:
                 if rich_print:
                     rich.print(
-                        f"  :x: Skipping local run [magenta]{run_id}[/magenta], invalid run (missing inputs).",
+                        f"    :x: Skipping local run [magenta]{run_id}[/magenta], invalid run (missing inputs).",
                         file=sys.stderr,
                     )
                 else:
-                    log(f"  ❌  Skipping local run `{run_id}`, invalid run (missing inputs).")
+                    log(f"    ❌  Skipping local run `{run_id}`, invalid run (missing inputs).")
 
             return False
 
@@ -1866,12 +1866,12 @@ class Application(BaseModel):
         if verbose:
             if rich_print:
                 rich.print(
-                    f"  :white_check_mark: Synced local run [magenta]{run_id}[/magenta] as remote run "
+                    f"    :white_check_mark: Synced local run [magenta]{run_id}[/magenta] as remote run "
                     f"[magenta]{synced_run.to_dict()}[/magenta].",
                     file=sys.stderr,
                 )
             else:
-                log(f"  ✅ Synced local run `{run_id}` as remote run `{synced_run.to_dict()}`.")
+                log(f"    ✅ Synced local run `{run_id}` as remote run `{synced_run.to_dict()}`.")
 
         return True
 

--- a/nextmv/nextmv/local/application.py
+++ b/nextmv/nextmv/local/application.py
@@ -1761,12 +1761,12 @@ class Application(BaseModel):
             if verbose:
                 if rich_print:
                     rich.print(
-                        f"\t:fast_forward: Skipping local run [magenta]{run_id}[/magenta], already synced with "
+                        f"  :fast_forward: Skipping local run [magenta]{run_id}[/magenta], already synced with "
                         f"[magenta]{synced_run.to_dict()}[/magenta].",
                         file=sys.stderr,
                     )
                 else:
-                    log(f"   ⏭️  Skipping local run `{run_id}`, already synced with {synced_run.to_dict()}.")
+                    log(f"  ⏭️  Skipping local run `{run_id}`, already synced with {synced_run.to_dict()}.")
 
             return False
 
@@ -1775,11 +1775,11 @@ class Application(BaseModel):
             if verbose:
                 if rich_print:
                     rich.print(
-                        f"\t:x: Skipping local run [magenta]{run_id}[/magenta], invalid run (missing inputs).",
+                        f"  :x: Skipping local run [magenta]{run_id}[/magenta], invalid run (missing inputs).",
                         file=sys.stderr,
                     )
                 else:
-                    log(f"   ❌  Skipping local run `{run_id}`, invalid run (missing inputs).")
+                    log(f"  ❌  Skipping local run `{run_id}`, invalid run (missing inputs).")
 
             return False
 
@@ -1866,12 +1866,12 @@ class Application(BaseModel):
         if verbose:
             if rich_print:
                 rich.print(
-                    f"\t:white_check_mark: Synced local run [magenta]{run_id}[/magenta] as remote run "
+                    f"  :white_check_mark: Synced local run [magenta]{run_id}[/magenta] as remote run "
                     f"[magenta]{synced_run.to_dict()}[/magenta].",
                     file=sys.stderr,
                 )
             else:
-                log(f"✅ Synced local run `{run_id}` as remote run `{synced_run.to_dict()}`.")
+                log(f"  ✅ Synced local run `{run_id}` as remote run `{synced_run.to_dict()}`.")
 
         return True
 

--- a/nextmv/tests/cloud/test_package.py
+++ b/nextmv/tests/cloud/test_package.py
@@ -5,7 +5,7 @@ import subprocess
 import tempfile
 import unittest
 
-from nextmv.cloud.package import _get_shell_command_elements, _package
+from nextmv.cloud.package import _get_shell_command_elements, package
 from nextmv.manifest import Manifest, ManifestType
 
 
@@ -20,20 +20,20 @@ class TestPackageOneFile(unittest.TestCase):
         shutil.rmtree(self.app_dir)
 
     def test_package_creates_tarball(self):
-        tar_file, output_dir = _package(self.app_dir, self.manifest, verbose=False)
+        tar_file, output_dir = package(self.app_dir, self.manifest, verbose=False)
         self.assertTrue(os.path.isfile(tar_file))
         self.assertTrue(os.path.isdir(output_dir))
 
     def test_package_missing_files(self):
         self.manifest.files.append("missing_file.py")
         with self.assertRaises(Exception) as context:
-            _package(self.app_dir, self.manifest, verbose=False)
+            package(self.app_dir, self.manifest, verbose=False)
         self.assertIn("could not find files listed in manifest", str(context.exception))
 
     def test_package_mandatory_files(self):
         self.manifest.type = ManifestType.GO
         with self.assertRaises(Exception) as context:
-            _package(self.app_dir, self.manifest, verbose=False)
+            package(self.app_dir, self.manifest, verbose=False)
         self.assertIn("missing mandatory files", str(context.exception))
 
 
@@ -52,7 +52,7 @@ class TestPackageDir(unittest.TestCase):
         shutil.rmtree(self.app_dir)
 
     def test_package_creates_tarball(self):
-        tar_file, output_dir = _package(self.app_dir, self.manifest, verbose=False)
+        tar_file, output_dir = package(self.app_dir, self.manifest, verbose=False)
         self.assertTrue(os.path.isfile(tar_file))
         self.assertTrue(os.path.isdir(output_dir))
 
@@ -65,13 +65,13 @@ class TestPackageDir(unittest.TestCase):
     def test_package_missing_files(self):
         self.manifest.files.append("missing_file.py")
         with self.assertRaises(Exception) as context:
-            _package(self.app_dir, self.manifest, verbose=False)
+            package(self.app_dir, self.manifest, verbose=False)
         self.assertIn("could not find files listed in manifest", str(context.exception))
 
     def test_package_mandatory_files(self):
         self.manifest.type = ManifestType.GO
         with self.assertRaises(Exception) as context:
-            _package(self.app_dir, self.manifest, verbose=False)
+            package(self.app_dir, self.manifest, verbose=False)
         self.assertIn("missing mandatory files", str(context.exception))
 
     def test_get_shell_command_elements(self):

--- a/nextmv/tests/test_cache.py
+++ b/nextmv/tests/test_cache.py
@@ -1,6 +1,5 @@
 """Tests for the nextmv.cache module."""
 
-import io
 import json
 import os
 import shutil
@@ -13,350 +12,28 @@ from unittest.mock import patch
 
 from nextmv.cache import (
     _CACHE_INFO_FILE,
-    _DEFAULT_MAX_BYTES,
-    _DEPS_CACHE_DIR,
+    _MAX_DEP_BYTES,
+    _MAX_DEPS,
     _evict_lru,
-    cache_key,
     clear_cache,
-    get_cached_deps,
-    store_deps,
+    dep_cache_key,
+    get_cached_dep,
+    store_dep,
 )
-
-
-def _write_fake_entry(key: str, last_used_at: str, size_bytes: int = 0) -> None:
-    """Write a minimal cache entry for use in tests."""
-    entry_dir = _DEPS_CACHE_DIR / key
-    entry_dir.mkdir(parents=True, exist_ok=True)
-
-    deps_tar = entry_dir / "deps.tar.gz"
-    with tarfile.open(str(deps_tar), "w:gz") as tar:
-        if size_bytes > 0:
-            data = b"x" * size_bytes
-            info = tarfile.TarInfo(name=".nextmv/python/deps/dummy.pth")
-            info.size = size_bytes
-            tar.addfile(info, io.BytesIO(data))
-
-    info = {
-        "created_at": last_used_at,
-        "last_used_at": last_used_at,
-        "python_version": "3.11",
-        "platform": "aarch64-unknown-linux-gnu",
-        "lockfile": "# pinned\nnextmv==1.0.0\n",
-    }
-    with open(entry_dir / _CACHE_INFO_FILE, "w") as f:
-        json.dump(info, f)
-
-
-class TestCacheKey(unittest.TestCase):
-    def test_stable(self):
-        k1 = cache_key("lock\nnextmv==1.0.0", "3.11", "aarch64-unknown-linux-gnu")
-        k2 = cache_key("lock\nnextmv==1.0.0", "3.11", "aarch64-unknown-linux-gnu")
-        self.assertEqual(k1, k2)
-
-    def test_differs_on_lockfile(self):
-        k1 = cache_key("nextmv==1.0.0", "3.11", "aarch64-unknown-linux-gnu")
-        k2 = cache_key("nextmv==2.0.0", "3.11", "aarch64-unknown-linux-gnu")
-        self.assertNotEqual(k1, k2)
-
-    def test_differs_on_python_version(self):
-        k1 = cache_key("nextmv==1.0.0", "3.11", "aarch64-unknown-linux-gnu")
-        k2 = cache_key("nextmv==1.0.0", "3.12", "aarch64-unknown-linux-gnu")
-        self.assertNotEqual(k1, k2)
-
-    def test_differs_on_platform(self):
-        k1 = cache_key("nextmv==1.0.0", "3.11", "aarch64-unknown-linux-gnu")
-        k2 = cache_key("nextmv==1.0.0", "3.11", "x86_64-unknown-linux-gnu")
-        self.assertNotEqual(k1, k2)
-
-    def test_returns_hex_string(self):
-        k = cache_key("lock", "3.11", "aarch64-unknown-linux-gnu")
-        self.assertEqual(len(k), 64)
-        int(k, 16)  # raises if not valid hex
-
-
-class TestGetCachedDeps(unittest.TestCase):
-    def setUp(self):
-        self._original_deps_dir = _DEPS_CACHE_DIR
-        self._tmpdir = tempfile.mkdtemp()
-        self._patch = patch("nextmv.cache._DEPS_CACHE_DIR", Path(self._tmpdir))
-        self._patch.start()
-
-    def tearDown(self):
-        self._patch.stop()
-        shutil.rmtree(self._tmpdir, ignore_errors=True)
-
-    def test_miss_returns_none(self):
-        result = get_cached_deps("nonexistent-key")
-        self.assertIsNone(result)
-
-    def test_hit_returns_path(self):
-        from nextmv import cache as cache_mod
-
-        key = "abc123"
-        deps_tar = Path(self._tmpdir) / key / "deps.tar.gz"
-        deps_tar.parent.mkdir(parents=True)
-        with tarfile.open(str(deps_tar), "w:gz"):
-            pass  # empty tar
-        info_file = Path(self._tmpdir) / key / _CACHE_INFO_FILE
-        now = datetime.now(tz=timezone.utc).isoformat()
-        with open(info_file, "w") as f:
-            json.dump(
-                {"created_at": now, "last_used_at": now, "python_version": "3.11", "platform": "p", "lockfile": ""}, f
-            )
-
-        with patch.object(cache_mod, "_DEPS_CACHE_DIR", Path(self._tmpdir)):
-            result = get_cached_deps(key)
-
-        self.assertIsNotNone(result)
-        self.assertTrue(str(result).endswith("deps.tar.gz"))
-
-    def test_hit_updates_last_used_at(self):
-        from nextmv import cache as cache_mod
-
-        key = "upd456"
-        deps_tar = Path(self._tmpdir) / key / "deps.tar.gz"
-        deps_tar.parent.mkdir(parents=True)
-        with tarfile.open(str(deps_tar), "w:gz"):
-            pass  # empty tar
-        info_file = Path(self._tmpdir) / key / _CACHE_INFO_FILE
-        old_time = "2020-01-01T00:00:00+00:00"
-        with open(info_file, "w") as f:
-            json.dump(
-                {
-                    "created_at": old_time,
-                    "last_used_at": old_time,
-                    "python_version": "3.11",
-                    "platform": "p",
-                    "lockfile": "",
-                },
-                f,
-            )
-
-        with patch.object(cache_mod, "_DEPS_CACHE_DIR", Path(self._tmpdir)):
-            get_cached_deps(key)
-
-        with open(info_file) as f:
-            updated = json.load(f)
-
-        self.assertNotEqual(updated["last_used_at"], old_time)
-        self.assertEqual(updated["created_at"], old_time)  # created_at unchanged
-
-    def test_missing_info_file_returns_none(self):
-        from nextmv import cache as cache_mod
-
-        key = "noinfo"
-        deps_tar = Path(self._tmpdir) / key / "deps.tar.gz"
-        deps_tar.parent.mkdir(parents=True)
-        with tarfile.open(str(deps_tar), "w:gz"):
-            pass  # empty tar, no cache_info.json written
-
-        with patch.object(cache_mod, "_DEPS_CACHE_DIR", Path(self._tmpdir)):
-            result = get_cached_deps(key)
-
-        self.assertIsNone(result)
-
-
-class TestStoreDeps(unittest.TestCase):
-    def setUp(self):
-        self._tmpdir = tempfile.mkdtemp()
-        self._cache_root = Path(tempfile.mkdtemp())
-        self._patcher_cache = patch("nextmv.cache._CACHE_DIR", self._cache_root)
-        self._patcher_deps = patch("nextmv.cache._DEPS_CACHE_DIR", self._cache_root / "deps")
-        self._patcher_cache.start()
-        self._patcher_deps.start()
-
-    def tearDown(self):
-        self._patcher_cache.stop()
-        self._patcher_deps.stop()
-        shutil.rmtree(self._tmpdir, ignore_errors=True)
-        shutil.rmtree(str(self._cache_root), ignore_errors=True)
-
-    def _make_installed_dir(self) -> Path:
-        installed = Path(self._tmpdir) / "installed" / "deps"
-        installed.mkdir(parents=True)
-        (installed / "somepackage.py").write_text("# package")
-        return installed
-
-    def test_creates_entry_directory(self):
-        from nextmv import cache as cache_mod
-
-        installed = self._make_installed_dir()
-        key = cache_key("lockfile", "3.11", "aarch64-unknown-linux-gnu")
-
-        with (
-            patch.object(cache_mod, "_CACHE_DIR", self._cache_root),
-            patch.object(cache_mod, "_DEPS_CACHE_DIR", self._cache_root / "deps"),
-        ):
-            store_deps(
-                key,
-                installed,
-                "3.11",
-                "aarch64-unknown-linux-gnu",
-                "lockfile",
-                max_entries=200,
-                max_bytes=_DEFAULT_MAX_BYTES,
-            )
-
-        entry_dir = self._cache_root / "deps" / key
-        self.assertTrue(entry_dir.is_dir())
-
-    def test_cache_info_has_required_fields(self):
-        from nextmv import cache as cache_mod
-
-        installed = self._make_installed_dir()
-        key = cache_key("lockfile", "3.11", "aarch64-unknown-linux-gnu")
-
-        with (
-            patch.object(cache_mod, "_CACHE_DIR", self._cache_root),
-            patch.object(cache_mod, "_DEPS_CACHE_DIR", self._cache_root / "deps"),
-        ):
-            store_deps(
-                key,
-                installed,
-                "3.11",
-                "aarch64-unknown-linux-gnu",
-                "lockfile",
-                max_entries=200,
-                max_bytes=_DEFAULT_MAX_BYTES,
-            )
-
-        info_file = self._cache_root / "deps" / key / _CACHE_INFO_FILE
-        with open(info_file) as f:
-            info = json.load(f)
-
-        self.assertIn("created_at", info)
-        self.assertIn("last_used_at", info)
-        self.assertEqual(info["created_at"], info["last_used_at"])
-        self.assertEqual(info["python_version"], "3.11")
-        self.assertEqual(info["platform"], "aarch64-unknown-linux-gnu")
-        self.assertEqual(info["lockfile"], "lockfile")
-
-    def test_deps_are_copied(self):
-        from nextmv import cache as cache_mod
-
-        installed = self._make_installed_dir()
-        key = cache_key("lockfile2", "3.11", "aarch64-unknown-linux-gnu")
-
-        with (
-            patch.object(cache_mod, "_CACHE_DIR", self._cache_root),
-            patch.object(cache_mod, "_DEPS_CACHE_DIR", self._cache_root / "deps"),
-        ):
-            store_deps(
-                key,
-                installed,
-                "3.11",
-                "aarch64-unknown-linux-gnu",
-                "lockfile2",
-                max_entries=200,
-                max_bytes=_DEFAULT_MAX_BYTES,
-            )
-
-        deps_tar = self._cache_root / "deps" / key / "deps.tar.gz"
-        self.assertTrue(deps_tar.is_file())
-        with tarfile.open(str(deps_tar), "r:gz") as tar:
-            names = tar.getnames()
-        self.assertIn(".nextmv/python/deps/somepackage.py", names)
-
-
-class TestEvictLru(unittest.TestCase):
-    def setUp(self):
-        self._cache_root = Path(tempfile.mkdtemp())
-        self._deps_dir = self._cache_root / "deps"
-        self._deps_dir.mkdir(parents=True)
-        self._patcher = patch("nextmv.cache._DEPS_CACHE_DIR", self._deps_dir)
-        self._patcher.start()
-
-    def tearDown(self):
-        self._patcher.stop()
-        shutil.rmtree(str(self._cache_root), ignore_errors=True)
-
-    def _add_entry(self, key: str, last_used: str, size_bytes: int = 0):
-        entry_dir = self._deps_dir / key
-        entry_dir.mkdir(parents=True, exist_ok=True)
-        deps_tar = entry_dir / "deps.tar.gz"
-        with tarfile.open(str(deps_tar), "w:gz") as tar:
-            if size_bytes > 0:
-                # Use incompressible random data so gzip cannot shrink it.
-                data = os.urandom(size_bytes)
-                info = tarfile.TarInfo(name=".nextmv/python/deps/dummy.bin")
-                info.size = size_bytes
-                tar.addfile(info, io.BytesIO(data))
-        info = {
-            "created_at": last_used,
-            "last_used_at": last_used,
-            "python_version": "3.11",
-            "platform": "p",
-            "lockfile": "",
-        }
-        with open(entry_dir / _CACHE_INFO_FILE, "w") as f:
-            json.dump(info, f)
-
-    def test_no_eviction_under_caps(self):
-        from nextmv import cache as cache_mod
-
-        self._add_entry("k1", "2026-01-01T00:00:00+00:00")
-        self._add_entry("k2", "2026-01-02T00:00:00+00:00")
-
-        with patch.object(cache_mod, "_DEPS_CACHE_DIR", self._deps_dir):
-            evicted = _evict_lru(max_entries=10, max_bytes=_DEFAULT_MAX_BYTES)
-
-        self.assertEqual(evicted, 0)
-        self.assertTrue((self._deps_dir / "k1").exists())
-        self.assertTrue((self._deps_dir / "k2").exists())
-
-    def test_evicts_oldest_by_last_used(self):
-        from nextmv import cache as cache_mod
-
-        self._add_entry("oldest", "2025-01-01T00:00:00+00:00")
-        self._add_entry("middle", "2025-06-01T00:00:00+00:00")
-        self._add_entry("newest", "2026-01-01T00:00:00+00:00")
-
-        with patch.object(cache_mod, "_DEPS_CACHE_DIR", self._deps_dir):
-            evicted = _evict_lru(max_entries=2, max_bytes=_DEFAULT_MAX_BYTES)
-
-        self.assertEqual(evicted, 1)
-        self.assertFalse((self._deps_dir / "oldest").exists())
-        self.assertTrue((self._deps_dir / "middle").exists())
-        self.assertTrue((self._deps_dir / "newest").exists())
-
-    def test_evicts_by_size_cap(self):
-        from nextmv import cache as cache_mod
-
-        # Each deps.tar.gz holds ~10 KiB of random (incompressible) data.
-        # Use a cap that sits between one and two entries so exactly the oldest
-        # is evicted.
-        self._add_entry("big_old", "2025-01-01T00:00:00+00:00", size_bytes=10 * 1024)
-        self._add_entry("big_new", "2026-01-01T00:00:00+00:00", size_bytes=10 * 1024)
-
-        with patch.object(cache_mod, "_DEPS_CACHE_DIR", self._deps_dir):
-            evicted = _evict_lru(max_entries=200, max_bytes=15 * 1024)
-
-        self.assertEqual(evicted, 1)
-        self.assertFalse((self._deps_dir / "big_old").exists())
-        self.assertTrue((self._deps_dir / "big_new").exists())
-
-    def test_returns_zero_when_cache_missing(self):
-        from nextmv import cache as cache_mod
-
-        missing = self._cache_root / "nonexistent"
-        with patch.object(cache_mod, "_DEPS_CACHE_DIR", missing):
-            evicted = _evict_lru(max_entries=10, max_bytes=_DEFAULT_MAX_BYTES)
-
-        self.assertEqual(evicted, 0)
 
 
 class TestClearCache(unittest.TestCase):
     def setUp(self):
         self._cache_root = Path(tempfile.mkdtemp())
-        self._deps_dir = self._cache_root / "deps"
+        self._pkg_tars_dir = self._cache_root / "pkg_tars"
         self._patcher_cache = patch("nextmv.cache._CACHE_DIR", self._cache_root)
-        self._patcher_deps = patch("nextmv.cache._DEPS_CACHE_DIR", self._deps_dir)
+        self._patcher_pkg = patch("nextmv.cache._PKG_TARS_CACHE_DIR", self._pkg_tars_dir)
         self._patcher_cache.start()
-        self._patcher_deps.start()
+        self._patcher_pkg.start()
 
     def tearDown(self):
         self._patcher_cache.stop()
-        self._patcher_deps.stop()
+        self._patcher_pkg.stop()
         shutil.rmtree(str(self._cache_root), ignore_errors=True)
 
     def test_wipes_and_recreates(self):
@@ -368,25 +45,358 @@ class TestClearCache(unittest.TestCase):
 
         with (
             patch.object(cache_mod, "_CACHE_DIR", self._cache_root),
-            patch.object(cache_mod, "_DEPS_CACHE_DIR", self._deps_dir),
+            patch.object(cache_mod, "_PKG_TARS_CACHE_DIR", self._pkg_tars_dir),
         ):
             clear_cache()
 
         self.assertTrue(self._cache_root.exists())
         self.assertFalse(leftover.exists())
-        self.assertTrue(self._deps_dir.exists())  # recreated by create_cache()
+        self.assertTrue(self._pkg_tars_dir.exists())  # recreated by _create_cache()
 
     def test_idempotent_when_already_empty(self):
         from nextmv import cache as cache_mod
 
         with (
             patch.object(cache_mod, "_CACHE_DIR", self._cache_root),
-            patch.object(cache_mod, "_DEPS_CACHE_DIR", self._deps_dir),
+            patch.object(cache_mod, "_PKG_TARS_CACHE_DIR", self._pkg_tars_dir),
         ):
             clear_cache()
             clear_cache()  # second call should not raise
 
         self.assertTrue(self._cache_root.exists())
+
+
+class TestPackageCacheKey(unittest.TestCase):
+    def test_stable(self):
+        k1 = dep_cache_key("pydantic", "2.9.2", "3.11", "aarch64-unknown-linux-gnu")
+        k2 = dep_cache_key("pydantic", "2.9.2", "3.11", "aarch64-unknown-linux-gnu")
+        self.assertEqual(k1, k2)
+
+    def test_normalises_hyphens_and_underscores(self):
+        k1 = dep_cache_key("pydantic-core", "2.23.4", "3.11", "aarch64-unknown-linux-gnu")
+        k2 = dep_cache_key("pydantic_core", "2.23.4", "3.11", "aarch64-unknown-linux-gnu")
+        self.assertEqual(k1, k2)
+
+    def test_normalises_dots(self):
+        k1 = dep_cache_key("some.pkg", "1.0.0", "3.11", "aarch64-unknown-linux-gnu")
+        k2 = dep_cache_key("some_pkg", "1.0.0", "3.11", "aarch64-unknown-linux-gnu")
+        self.assertEqual(k1, k2)
+
+    def test_case_insensitive(self):
+        k1 = dep_cache_key("Pydantic", "2.9.2", "3.11", "aarch64-unknown-linux-gnu")
+        k2 = dep_cache_key("pydantic", "2.9.2", "3.11", "aarch64-unknown-linux-gnu")
+        self.assertEqual(k1, k2)
+
+    def test_differs_on_version(self):
+        k1 = dep_cache_key("pydantic", "2.9.2", "3.11", "aarch64-unknown-linux-gnu")
+        k2 = dep_cache_key("pydantic", "2.9.3", "3.11", "aarch64-unknown-linux-gnu")
+        self.assertNotEqual(k1, k2)
+
+    def test_differs_on_python_version(self):
+        k1 = dep_cache_key("pydantic", "2.9.2", "3.11", "aarch64-unknown-linux-gnu")
+        k2 = dep_cache_key("pydantic", "2.9.2", "3.12", "aarch64-unknown-linux-gnu")
+        self.assertNotEqual(k1, k2)
+
+    def test_differs_on_platform(self):
+        k1 = dep_cache_key("pydantic", "2.9.2", "3.11", "aarch64-unknown-linux-gnu")
+        k2 = dep_cache_key("pydantic", "2.9.2", "3.11", "x86_64-unknown-linux-gnu")
+        self.assertNotEqual(k1, k2)
+
+    def test_returns_hex_string(self):
+        k = dep_cache_key("pydantic", "2.9.2", "3.11", "aarch64-unknown-linux-gnu")
+        self.assertEqual(len(k), 64)
+        int(k, 16)
+
+
+class TestGetCachedPackageTar(unittest.TestCase):
+    def setUp(self):
+        self._tmpdir = Path(tempfile.mkdtemp())
+        self._patch = patch("nextmv.cache._PKG_TARS_CACHE_DIR", self._tmpdir)
+        self._patch.start()
+
+    def tearDown(self):
+        self._patch.stop()
+        shutil.rmtree(str(self._tmpdir), ignore_errors=True)
+
+    def _make_pkg_tar_entry(self, key: str) -> Path:
+        entry_dir = self._tmpdir / key
+        entry_dir.mkdir(parents=True, exist_ok=True)
+        installed_tar = entry_dir / "installed.tar.gz"
+        with tarfile.open(str(installed_tar), "w:gz"):
+            pass  # empty tar
+        now = datetime.now(tz=timezone.utc).isoformat()
+        info = {
+            "created_at": now,
+            "last_used_at": now,
+            "python_version": "3.11",
+            "platform": "aarch64-unknown-linux-gnu",
+        }
+        with open(entry_dir / _CACHE_INFO_FILE, "w") as f:
+            json.dump(info, f)
+        return installed_tar
+
+    def test_miss_returns_none(self):
+        from nextmv import cache as cache_mod
+
+        with patch.object(cache_mod, "_PKG_TARS_CACHE_DIR", self._tmpdir):
+            result = get_cached_dep("nonexistent-key")
+        self.assertIsNone(result)
+
+    def test_hit_returns_path(self):
+        from nextmv import cache as cache_mod
+
+        key = "abc123"
+        self._make_pkg_tar_entry(key)
+
+        with patch.object(cache_mod, "_PKG_TARS_CACHE_DIR", self._tmpdir):
+            result = get_cached_dep(key)
+
+        self.assertIsNotNone(result)
+        self.assertTrue(str(result).endswith("installed.tar.gz"))
+
+    def test_hit_updates_last_used_at(self):
+        from nextmv import cache as cache_mod
+
+        key = "upd456"
+        installed_tar = self._make_pkg_tar_entry(key)
+        info_file = installed_tar.parent / _CACHE_INFO_FILE
+        old_time = "2020-01-01T00:00:00+00:00"
+        with open(info_file) as f:
+            info = json.load(f)
+        info["last_used_at"] = old_time
+        with open(info_file, "w") as f:
+            json.dump(info, f)
+
+        with patch.object(cache_mod, "_PKG_TARS_CACHE_DIR", self._tmpdir):
+            get_cached_dep(key)
+
+        with open(info_file) as f:
+            updated = json.load(f)
+
+        self.assertNotEqual(updated["last_used_at"], old_time)
+        self.assertEqual(updated["created_at"], info["created_at"])
+
+    def test_missing_info_file_returns_none(self):
+        from nextmv import cache as cache_mod
+
+        key = "noinfo"
+        entry_dir = self._tmpdir / key
+        entry_dir.mkdir(parents=True)
+        with tarfile.open(str(entry_dir / "installed.tar.gz"), "w:gz"):
+            pass  # no cache_info.json written
+
+        with patch.object(cache_mod, "_PKG_TARS_CACHE_DIR", self._tmpdir):
+            result = get_cached_dep(key)
+
+        self.assertIsNone(result)
+
+    def test_missing_installed_tar_returns_none(self):
+        from nextmv import cache as cache_mod
+
+        key = "notar"
+        entry_dir = self._tmpdir / key
+        entry_dir.mkdir(parents=True)
+        now = datetime.now(tz=timezone.utc).isoformat()
+        with open(entry_dir / _CACHE_INFO_FILE, "w") as f:
+            json.dump({"created_at": now, "last_used_at": now, "python_version": "3.11", "platform": "p"}, f)
+        # No installed.tar.gz written.
+
+        with patch.object(cache_mod, "_PKG_TARS_CACHE_DIR", self._tmpdir):
+            result = get_cached_dep(key)
+
+        self.assertIsNone(result)
+
+
+class TestStorePackageTar(unittest.TestCase):
+    def setUp(self):
+        self._tmpdir = tempfile.mkdtemp()
+        self._cache_root = Path(tempfile.mkdtemp())
+        self._pkg_tars_dir = self._cache_root / "pkg_tars"
+        self._patcher_cache = patch("nextmv.cache._CACHE_DIR", self._cache_root)
+        self._patcher_pkg = patch("nextmv.cache._PKG_TARS_CACHE_DIR", self._pkg_tars_dir)
+        self._patcher_cache.start()
+        self._patcher_pkg.start()
+
+    def tearDown(self):
+        self._patcher_cache.stop()
+        self._patcher_pkg.stop()
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+        shutil.rmtree(str(self._cache_root), ignore_errors=True)
+
+    def _make_installed_tar(self, name: str = "pkg-1.0.0.tar.gz") -> Path:
+        p = Path(self._tmpdir) / name
+        with tarfile.open(str(p), "w:gz"):
+            pass  # empty tar
+        return p
+
+    def test_creates_entry(self):
+        from nextmv import cache as cache_mod
+
+        tar = self._make_installed_tar()
+        key = dep_cache_key("pkg", "1.0.0", "3.11", "aarch64-unknown-linux-gnu")
+
+        with (
+            patch.object(cache_mod, "_CACHE_DIR", self._cache_root),
+            patch.object(cache_mod, "_PKG_TARS_CACHE_DIR", self._pkg_tars_dir),
+        ):
+            store_dep(
+                key,
+                tar,
+                "3.11",
+                "aarch64-unknown-linux-gnu",
+                max_entries=_MAX_DEPS,
+                max_bytes=_MAX_DEP_BYTES,
+            )
+
+        entry_dir = self._pkg_tars_dir / key
+        self.assertTrue(entry_dir.is_dir())
+        self.assertTrue((entry_dir / "installed.tar.gz").is_file())
+
+    def test_info_file_has_required_fields(self):
+        from nextmv import cache as cache_mod
+
+        tar = self._make_installed_tar()
+        key = dep_cache_key("pkg", "1.0.0", "3.11", "aarch64-unknown-linux-gnu")
+
+        with (
+            patch.object(cache_mod, "_CACHE_DIR", self._cache_root),
+            patch.object(cache_mod, "_PKG_TARS_CACHE_DIR", self._pkg_tars_dir),
+        ):
+            store_dep(
+                key,
+                tar,
+                "3.11",
+                "aarch64-unknown-linux-gnu",
+                max_entries=_MAX_DEPS,
+                max_bytes=_MAX_DEP_BYTES,
+            )
+
+        info_file = self._pkg_tars_dir / key / _CACHE_INFO_FILE
+        with open(info_file) as f:
+            info = json.load(f)
+
+        self.assertIn("created_at", info)
+        self.assertIn("last_used_at", info)
+        self.assertEqual(info["python_version"], "3.11")
+        self.assertEqual(info["platform"], "aarch64-unknown-linux-gnu")
+        self.assertNotIn("wheel_file", info)  # no wheel_file key in new format
+
+    def test_idempotent_on_duplicate_key(self):
+        from nextmv import cache as cache_mod
+
+        tar = self._make_installed_tar()
+        key = dep_cache_key("pkg", "1.0.0", "3.11", "aarch64-unknown-linux-gnu")
+
+        with (
+            patch.object(cache_mod, "_CACHE_DIR", self._cache_root),
+            patch.object(cache_mod, "_PKG_TARS_CACHE_DIR", self._pkg_tars_dir),
+        ):
+            store_dep(
+                key,
+                tar,
+                "3.11",
+                "aarch64-unknown-linux-gnu",
+                max_entries=_MAX_DEPS,
+                max_bytes=_MAX_DEP_BYTES,
+            )
+            store_dep(
+                key,
+                tar,
+                "3.11",
+                "aarch64-unknown-linux-gnu",
+                max_entries=_MAX_DEPS,
+                max_bytes=_MAX_DEP_BYTES,
+            )
+
+        entries = [d for d in self._pkg_tars_dir.iterdir() if d.is_dir()]
+        self.assertEqual(len(entries), 1)
+
+
+class TestEvictLruPackages(unittest.TestCase):
+    def setUp(self):
+        self._cache_root = Path(tempfile.mkdtemp())
+        self._pkg_tars_dir = self._cache_root / "pkg_tars"
+        self._pkg_tars_dir.mkdir(parents=True)
+        self._patcher = patch("nextmv.cache._PKG_TARS_CACHE_DIR", self._pkg_tars_dir)
+        self._patcher.start()
+
+    def tearDown(self):
+        self._patcher.stop()
+        shutil.rmtree(str(self._cache_root), ignore_errors=True)
+
+    def _add_entry(self, key: str, last_used: str, size_bytes: int = 0):
+        entry_dir = self._pkg_tars_dir / key
+        entry_dir.mkdir(parents=True, exist_ok=True)
+        installed_tar = entry_dir / "installed.tar.gz"
+        if size_bytes > 0:
+            data = os.urandom(size_bytes)
+            with tarfile.open(str(installed_tar), "w:gz") as tar:
+                info = tarfile.TarInfo(name=".nextmv/python/deps/dummy.bin")
+                info.size = size_bytes
+                import io as _io
+
+                tar.addfile(info, _io.BytesIO(data))
+        else:
+            with tarfile.open(str(installed_tar), "w:gz"):
+                pass
+        info = {
+            "created_at": last_used,
+            "last_used_at": last_used,
+            "python_version": "3.11",
+            "platform": "p",
+        }
+        with open(entry_dir / _CACHE_INFO_FILE, "w") as f:
+            json.dump(info, f)
+
+    def test_no_eviction_under_caps(self):
+        from nextmv import cache as cache_mod
+
+        self._add_entry("k1", "2026-01-01T00:00:00+00:00")
+        self._add_entry("k2", "2026-01-02T00:00:00+00:00")
+
+        with patch.object(cache_mod, "_PKG_TARS_CACHE_DIR", self._pkg_tars_dir):
+            evicted = _evict_lru(max_entries=10, max_bytes=_MAX_DEP_BYTES)
+
+        self.assertEqual(evicted, 0)
+        self.assertTrue((self._pkg_tars_dir / "k1").exists())
+        self.assertTrue((self._pkg_tars_dir / "k2").exists())
+
+    def test_evicts_oldest_first(self):
+        from nextmv import cache as cache_mod
+
+        self._add_entry("oldest", "2025-01-01T00:00:00+00:00")
+        self._add_entry("middle", "2025-06-01T00:00:00+00:00")
+        self._add_entry("newest", "2026-01-01T00:00:00+00:00")
+
+        with patch.object(cache_mod, "_PKG_TARS_CACHE_DIR", self._pkg_tars_dir):
+            evicted = _evict_lru(max_entries=2, max_bytes=_MAX_DEP_BYTES)
+
+        self.assertEqual(evicted, 1)
+        self.assertFalse((self._pkg_tars_dir / "oldest").exists())
+        self.assertTrue((self._pkg_tars_dir / "middle").exists())
+        self.assertTrue((self._pkg_tars_dir / "newest").exists())
+
+    def test_evicts_by_size_cap(self):
+        from nextmv import cache as cache_mod
+
+        self._add_entry("big_old", "2025-01-01T00:00:00+00:00", size_bytes=10 * 1024)
+        self._add_entry("big_new", "2026-01-01T00:00:00+00:00", size_bytes=10 * 1024)
+
+        with patch.object(cache_mod, "_PKG_TARS_CACHE_DIR", self._pkg_tars_dir):
+            evicted = _evict_lru(max_entries=200, max_bytes=15 * 1024)
+
+        self.assertEqual(evicted, 1)
+        self.assertFalse((self._pkg_tars_dir / "big_old").exists())
+        self.assertTrue((self._pkg_tars_dir / "big_new").exists())
+
+    def test_returns_zero_when_cache_missing(self):
+        from nextmv import cache as cache_mod
+
+        missing = self._cache_root / "nonexistent"
+        with patch.object(cache_mod, "_PKG_TARS_CACHE_DIR", missing):
+            evicted = _evict_lru(max_entries=10, max_bytes=_MAX_DEP_BYTES)
+
+        self.assertEqual(evicted, 0)
 
 
 if __name__ == "__main__":

--- a/nextmv/tests/test_cache.py
+++ b/nextmv/tests/test_cache.py
@@ -1,0 +1,373 @@
+"""Tests for the nextmv.cache module."""
+
+import json
+import shutil
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+from nextmv.cache import (
+    _CACHE_INFO_FILE,
+    _DEFAULT_MAX_BYTES,
+    _DEPS_CACHE_DIR,
+    _evict_lru,
+    cache_key,
+    clear_cache,
+    get_cached_deps,
+    store_deps,
+)
+
+
+def _write_fake_entry(key: str, last_used_at: str, size_bytes: int = 0) -> None:
+    """Write a minimal cache entry for use in tests."""
+    entry_dir = _DEPS_CACHE_DIR / key
+    deps_dir = entry_dir / ".nextmv" / "python" / "deps"
+    deps_dir.mkdir(parents=True, exist_ok=True)
+
+    if size_bytes > 0:
+        dummy_file = deps_dir / "dummy.pth"
+        dummy_file.write_bytes(b"x" * size_bytes)
+
+    info = {
+        "created_at": last_used_at,
+        "last_used_at": last_used_at,
+        "python_version": "3.11",
+        "platform": "aarch64-unknown-linux-gnu",
+        "lockfile": "# pinned\nnextmv==1.0.0\n",
+    }
+    with open(entry_dir / _CACHE_INFO_FILE, "w") as f:
+        json.dump(info, f)
+
+
+class TestCacheKey(unittest.TestCase):
+    def test_stable(self):
+        k1 = cache_key("lock\nnextmv==1.0.0", "3.11", "aarch64-unknown-linux-gnu")
+        k2 = cache_key("lock\nnextmv==1.0.0", "3.11", "aarch64-unknown-linux-gnu")
+        self.assertEqual(k1, k2)
+
+    def test_differs_on_lockfile(self):
+        k1 = cache_key("nextmv==1.0.0", "3.11", "aarch64-unknown-linux-gnu")
+        k2 = cache_key("nextmv==2.0.0", "3.11", "aarch64-unknown-linux-gnu")
+        self.assertNotEqual(k1, k2)
+
+    def test_differs_on_python_version(self):
+        k1 = cache_key("nextmv==1.0.0", "3.11", "aarch64-unknown-linux-gnu")
+        k2 = cache_key("nextmv==1.0.0", "3.12", "aarch64-unknown-linux-gnu")
+        self.assertNotEqual(k1, k2)
+
+    def test_differs_on_platform(self):
+        k1 = cache_key("nextmv==1.0.0", "3.11", "aarch64-unknown-linux-gnu")
+        k2 = cache_key("nextmv==1.0.0", "3.11", "x86_64-unknown-linux-gnu")
+        self.assertNotEqual(k1, k2)
+
+    def test_returns_hex_string(self):
+        k = cache_key("lock", "3.11", "aarch64-unknown-linux-gnu")
+        self.assertEqual(len(k), 64)
+        int(k, 16)  # raises if not valid hex
+
+
+class TestGetCachedDeps(unittest.TestCase):
+    def setUp(self):
+        self._original_deps_dir = _DEPS_CACHE_DIR
+        self._tmpdir = tempfile.mkdtemp()
+        self._patch = patch("nextmv.cache._DEPS_CACHE_DIR", Path(self._tmpdir))
+        self._patch.start()
+
+    def tearDown(self):
+        self._patch.stop()
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def test_miss_returns_none(self):
+        result = get_cached_deps("nonexistent-key")
+        self.assertIsNone(result)
+
+    def test_hit_returns_path(self):
+        from nextmv import cache as cache_mod
+
+        key = "abc123"
+        deps_dir = Path(self._tmpdir) / key / "deps"
+        deps_dir.mkdir(parents=True)
+        info_file = Path(self._tmpdir) / key / _CACHE_INFO_FILE
+        now = datetime.now(tz=timezone.utc).isoformat()
+        with open(info_file, "w") as f:
+            json.dump(
+                {"created_at": now, "last_used_at": now, "python_version": "3.11", "platform": "p", "lockfile": ""}, f
+            )
+
+        with patch.object(cache_mod, "_DEPS_CACHE_DIR", Path(self._tmpdir)):
+            result = get_cached_deps(key)
+
+        self.assertIsNotNone(result)
+        self.assertTrue(str(result).endswith("deps"))
+
+    def test_hit_updates_last_used_at(self):
+        from nextmv import cache as cache_mod
+
+        key = "upd456"
+        deps_dir = Path(self._tmpdir) / key / "deps"
+        deps_dir.mkdir(parents=True)
+        info_file = Path(self._tmpdir) / key / _CACHE_INFO_FILE
+        old_time = "2020-01-01T00:00:00+00:00"
+        with open(info_file, "w") as f:
+            json.dump(
+                {
+                    "created_at": old_time,
+                    "last_used_at": old_time,
+                    "python_version": "3.11",
+                    "platform": "p",
+                    "lockfile": "",
+                },
+                f,
+            )
+
+        with patch.object(cache_mod, "_DEPS_CACHE_DIR", Path(self._tmpdir)):
+            get_cached_deps(key)
+
+        with open(info_file) as f:
+            updated = json.load(f)
+
+        self.assertNotEqual(updated["last_used_at"], old_time)
+        self.assertEqual(updated["created_at"], old_time)  # created_at unchanged
+
+    def test_missing_info_file_returns_none(self):
+        from nextmv import cache as cache_mod
+
+        key = "noinfo"
+        deps_dir = Path(self._tmpdir) / key / "deps"
+        deps_dir.mkdir(parents=True)
+        # No cache_info.json written.
+
+        with patch.object(cache_mod, "_DEPS_CACHE_DIR", Path(self._tmpdir)):
+            result = get_cached_deps(key)
+
+        self.assertIsNone(result)
+
+
+class TestStoreDeps(unittest.TestCase):
+    def setUp(self):
+        self._tmpdir = tempfile.mkdtemp()
+        self._cache_root = Path(tempfile.mkdtemp())
+        self._patcher_cache = patch("nextmv.cache._CACHE_DIR", self._cache_root)
+        self._patcher_deps = patch("nextmv.cache._DEPS_CACHE_DIR", self._cache_root / "deps")
+        self._patcher_cache.start()
+        self._patcher_deps.start()
+
+    def tearDown(self):
+        self._patcher_cache.stop()
+        self._patcher_deps.stop()
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+        shutil.rmtree(str(self._cache_root), ignore_errors=True)
+
+    def _make_installed_dir(self) -> Path:
+        installed = Path(self._tmpdir) / "installed" / "deps"
+        installed.mkdir(parents=True)
+        (installed / "somepackage.py").write_text("# package")
+        return installed
+
+    def test_creates_entry_directory(self):
+        from nextmv import cache as cache_mod
+
+        installed = self._make_installed_dir()
+        key = cache_key("lockfile", "3.11", "aarch64-unknown-linux-gnu")
+
+        with (
+            patch.object(cache_mod, "_CACHE_DIR", self._cache_root),
+            patch.object(cache_mod, "_DEPS_CACHE_DIR", self._cache_root / "deps"),
+        ):
+            store_deps(
+                key,
+                installed,
+                "3.11",
+                "aarch64-unknown-linux-gnu",
+                "lockfile",
+                max_entries=200,
+                max_bytes=_DEFAULT_MAX_BYTES,
+            )
+
+        entry_dir = self._cache_root / "deps" / key
+        self.assertTrue(entry_dir.is_dir())
+
+    def test_cache_info_has_required_fields(self):
+        from nextmv import cache as cache_mod
+
+        installed = self._make_installed_dir()
+        key = cache_key("lockfile", "3.11", "aarch64-unknown-linux-gnu")
+
+        with (
+            patch.object(cache_mod, "_CACHE_DIR", self._cache_root),
+            patch.object(cache_mod, "_DEPS_CACHE_DIR", self._cache_root / "deps"),
+        ):
+            store_deps(
+                key,
+                installed,
+                "3.11",
+                "aarch64-unknown-linux-gnu",
+                "lockfile",
+                max_entries=200,
+                max_bytes=_DEFAULT_MAX_BYTES,
+            )
+
+        info_file = self._cache_root / "deps" / key / _CACHE_INFO_FILE
+        with open(info_file) as f:
+            info = json.load(f)
+
+        self.assertIn("created_at", info)
+        self.assertIn("last_used_at", info)
+        self.assertEqual(info["created_at"], info["last_used_at"])
+        self.assertEqual(info["python_version"], "3.11")
+        self.assertEqual(info["platform"], "aarch64-unknown-linux-gnu")
+        self.assertEqual(info["lockfile"], "lockfile")
+
+    def test_deps_are_copied(self):
+        from nextmv import cache as cache_mod
+
+        installed = self._make_installed_dir()
+        key = cache_key("lockfile2", "3.11", "aarch64-unknown-linux-gnu")
+
+        with (
+            patch.object(cache_mod, "_CACHE_DIR", self._cache_root),
+            patch.object(cache_mod, "_DEPS_CACHE_DIR", self._cache_root / "deps"),
+        ):
+            store_deps(
+                key,
+                installed,
+                "3.11",
+                "aarch64-unknown-linux-gnu",
+                "lockfile2",
+                max_entries=200,
+                max_bytes=_DEFAULT_MAX_BYTES,
+            )
+
+        cached_pkg = self._cache_root / "deps" / key / "deps" / "somepackage.py"
+        self.assertTrue(cached_pkg.exists())
+
+
+class TestEvictLru(unittest.TestCase):
+    def setUp(self):
+        self._cache_root = Path(tempfile.mkdtemp())
+        self._deps_dir = self._cache_root / "deps"
+        self._deps_dir.mkdir(parents=True)
+        self._patcher = patch("nextmv.cache._DEPS_CACHE_DIR", self._deps_dir)
+        self._patcher.start()
+
+    def tearDown(self):
+        self._patcher.stop()
+        shutil.rmtree(str(self._cache_root), ignore_errors=True)
+
+    def _add_entry(self, key: str, last_used: str, size_bytes: int = 0):
+        entry_dir = self._deps_dir / key
+        deps_dir = entry_dir / "deps"
+        deps_dir.mkdir(parents=True, exist_ok=True)
+        if size_bytes > 0:
+            (deps_dir / "dummy.bin").write_bytes(b"x" * size_bytes)
+        info = {
+            "created_at": last_used,
+            "last_used_at": last_used,
+            "python_version": "3.11",
+            "platform": "p",
+            "lockfile": "",
+        }
+        with open(entry_dir / _CACHE_INFO_FILE, "w") as f:
+            json.dump(info, f)
+
+    def test_no_eviction_under_caps(self):
+        from nextmv import cache as cache_mod
+
+        self._add_entry("k1", "2026-01-01T00:00:00+00:00")
+        self._add_entry("k2", "2026-01-02T00:00:00+00:00")
+
+        with patch.object(cache_mod, "_DEPS_CACHE_DIR", self._deps_dir):
+            evicted = _evict_lru(max_entries=10, max_bytes=_DEFAULT_MAX_BYTES)
+
+        self.assertEqual(evicted, 0)
+        self.assertTrue((self._deps_dir / "k1").exists())
+        self.assertTrue((self._deps_dir / "k2").exists())
+
+    def test_evicts_oldest_by_last_used(self):
+        from nextmv import cache as cache_mod
+
+        self._add_entry("oldest", "2025-01-01T00:00:00+00:00")
+        self._add_entry("middle", "2025-06-01T00:00:00+00:00")
+        self._add_entry("newest", "2026-01-01T00:00:00+00:00")
+
+        with patch.object(cache_mod, "_DEPS_CACHE_DIR", self._deps_dir):
+            evicted = _evict_lru(max_entries=2, max_bytes=_DEFAULT_MAX_BYTES)
+
+        self.assertEqual(evicted, 1)
+        self.assertFalse((self._deps_dir / "oldest").exists())
+        self.assertTrue((self._deps_dir / "middle").exists())
+        self.assertTrue((self._deps_dir / "newest").exists())
+
+    def test_evicts_by_size_cap(self):
+        from nextmv import cache as cache_mod
+
+        # Use large files (10 KiB each) so cache_info.json overhead is negligible.
+        # Total ≈ 20 KiB; cap at 15 KiB → only the older entry should be evicted.
+        self._add_entry("big_old", "2025-01-01T00:00:00+00:00", size_bytes=10 * 1024)
+        self._add_entry("big_new", "2026-01-01T00:00:00+00:00", size_bytes=10 * 1024)
+
+        with patch.object(cache_mod, "_DEPS_CACHE_DIR", self._deps_dir):
+            evicted = _evict_lru(max_entries=200, max_bytes=15 * 1024)
+
+        self.assertEqual(evicted, 1)
+        self.assertFalse((self._deps_dir / "big_old").exists())
+        self.assertTrue((self._deps_dir / "big_new").exists())
+
+    def test_returns_zero_when_cache_missing(self):
+        from nextmv import cache as cache_mod
+
+        missing = self._cache_root / "nonexistent"
+        with patch.object(cache_mod, "_DEPS_CACHE_DIR", missing):
+            evicted = _evict_lru(max_entries=10, max_bytes=_DEFAULT_MAX_BYTES)
+
+        self.assertEqual(evicted, 0)
+
+
+class TestClearCache(unittest.TestCase):
+    def setUp(self):
+        self._cache_root = Path(tempfile.mkdtemp())
+        self._deps_dir = self._cache_root / "deps"
+        self._patcher_cache = patch("nextmv.cache._CACHE_DIR", self._cache_root)
+        self._patcher_deps = patch("nextmv.cache._DEPS_CACHE_DIR", self._deps_dir)
+        self._patcher_cache.start()
+        self._patcher_deps.start()
+
+    def tearDown(self):
+        self._patcher_cache.stop()
+        self._patcher_deps.stop()
+        shutil.rmtree(str(self._cache_root), ignore_errors=True)
+
+    def test_wipes_and_recreates(self):
+        from nextmv import cache as cache_mod
+
+        # Populate the cache dir with some content.
+        leftover = self._cache_root / "somedata.txt"
+        leftover.write_text("data")
+
+        with (
+            patch.object(cache_mod, "_CACHE_DIR", self._cache_root),
+            patch.object(cache_mod, "_DEPS_CACHE_DIR", self._deps_dir),
+        ):
+            clear_cache()
+
+        self.assertTrue(self._cache_root.exists())
+        self.assertFalse(leftover.exists())
+        self.assertTrue(self._deps_dir.exists())  # recreated by create_cache()
+
+    def test_idempotent_when_already_empty(self):
+        from nextmv import cache as cache_mod
+
+        with (
+            patch.object(cache_mod, "_CACHE_DIR", self._cache_root),
+            patch.object(cache_mod, "_DEPS_CACHE_DIR", self._deps_dir),
+        ):
+            clear_cache()
+            clear_cache()  # second call should not raise
+
+        self.assertTrue(self._cache_root.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/nextmv/tests/test_cache.py
+++ b/nextmv/tests/test_cache.py
@@ -12,6 +12,7 @@ from unittest.mock import patch
 
 from nextmv.cache import (
     _CACHE_INFO_FILE,
+    _DEP_TARBALL_NAME,
     _MAX_DEP_BYTES,
     _MAX_DEPS,
     _evict_lru,
@@ -121,7 +122,7 @@ class TestGetCachedPackageTar(unittest.TestCase):
     def _make_pkg_tar_entry(self, key: str) -> Path:
         entry_dir = self._tmpdir / key
         entry_dir.mkdir(parents=True, exist_ok=True)
-        installed_tar = entry_dir / "installed.tar.gz"
+        installed_tar = entry_dir / _DEP_TARBALL_NAME
         with tarfile.open(str(installed_tar), "w:gz"):
             pass  # empty tar
         now = datetime.now(tz=timezone.utc).isoformat()
@@ -152,7 +153,7 @@ class TestGetCachedPackageTar(unittest.TestCase):
             result = get_cached_dep(key)
 
         self.assertIsNotNone(result)
-        self.assertTrue(str(result).endswith("installed.tar.gz"))
+        self.assertTrue(str(result).endswith(_DEP_TARBALL_NAME))
 
     def test_hit_updates_last_used_at(self):
         from nextmv import cache as cache_mod
@@ -182,7 +183,7 @@ class TestGetCachedPackageTar(unittest.TestCase):
         key = "noinfo"
         entry_dir = self._tmpdir / key
         entry_dir.mkdir(parents=True)
-        with tarfile.open(str(entry_dir / "installed.tar.gz"), "w:gz"):
+        with tarfile.open(str(entry_dir / _DEP_TARBALL_NAME), "w:gz"):
             pass  # no cache_info.json written
 
         with patch.object(cache_mod, "_DEPS_CACHE_DIR", self._tmpdir):
@@ -252,7 +253,7 @@ class TestStorePackageTar(unittest.TestCase):
 
         entry_dir = self._pkg_tars_dir / key
         self.assertTrue(entry_dir.is_dir())
-        self.assertTrue((entry_dir / "installed.tar.gz").is_file())
+        self.assertTrue((entry_dir / _DEP_TARBALL_NAME).is_file())
 
     def test_info_file_has_required_fields(self):
         from nextmv import cache as cache_mod
@@ -335,7 +336,7 @@ class TestEvictLruPackages(unittest.TestCase):
     def _add_entry(self, key: str, last_used: str, size_bytes: int = 0):
         entry_dir = self._pkg_tars_dir / key
         entry_dir.mkdir(parents=True, exist_ok=True)
-        installed_tar = entry_dir / "installed.tar.gz"
+        installed_tar = entry_dir / _DEP_TARBALL_NAME
         if size_bytes > 0:
             data = os.urandom(size_bytes)
             with tarfile.open(str(installed_tar), "w:gz") as tar:

--- a/nextmv/tests/test_cache.py
+++ b/nextmv/tests/test_cache.py
@@ -27,7 +27,7 @@ class TestClearCache(unittest.TestCase):
         self._cache_root = Path(tempfile.mkdtemp())
         self._pkg_tars_dir = self._cache_root / "pkg_tars"
         self._patcher_cache = patch("nextmv.cache._CACHE_DIR", self._cache_root)
-        self._patcher_pkg = patch("nextmv.cache._PKG_TARS_CACHE_DIR", self._pkg_tars_dir)
+        self._patcher_pkg = patch("nextmv.cache._DEPS_CACHE_DIR", self._pkg_tars_dir)
         self._patcher_cache.start()
         self._patcher_pkg.start()
 
@@ -45,7 +45,7 @@ class TestClearCache(unittest.TestCase):
 
         with (
             patch.object(cache_mod, "_CACHE_DIR", self._cache_root),
-            patch.object(cache_mod, "_PKG_TARS_CACHE_DIR", self._pkg_tars_dir),
+            patch.object(cache_mod, "_DEPS_CACHE_DIR", self._pkg_tars_dir),
         ):
             clear_cache()
 
@@ -58,7 +58,7 @@ class TestClearCache(unittest.TestCase):
 
         with (
             patch.object(cache_mod, "_CACHE_DIR", self._cache_root),
-            patch.object(cache_mod, "_PKG_TARS_CACHE_DIR", self._pkg_tars_dir),
+            patch.object(cache_mod, "_DEPS_CACHE_DIR", self._pkg_tars_dir),
         ):
             clear_cache()
             clear_cache()  # second call should not raise
@@ -111,7 +111,7 @@ class TestPackageCacheKey(unittest.TestCase):
 class TestGetCachedPackageTar(unittest.TestCase):
     def setUp(self):
         self._tmpdir = Path(tempfile.mkdtemp())
-        self._patch = patch("nextmv.cache._PKG_TARS_CACHE_DIR", self._tmpdir)
+        self._patch = patch("nextmv.cache._DEPS_CACHE_DIR", self._tmpdir)
         self._patch.start()
 
     def tearDown(self):
@@ -138,7 +138,7 @@ class TestGetCachedPackageTar(unittest.TestCase):
     def test_miss_returns_none(self):
         from nextmv import cache as cache_mod
 
-        with patch.object(cache_mod, "_PKG_TARS_CACHE_DIR", self._tmpdir):
+        with patch.object(cache_mod, "_DEPS_CACHE_DIR", self._tmpdir):
             result = get_cached_dep("nonexistent-key")
         self.assertIsNone(result)
 
@@ -148,7 +148,7 @@ class TestGetCachedPackageTar(unittest.TestCase):
         key = "abc123"
         self._make_pkg_tar_entry(key)
 
-        with patch.object(cache_mod, "_PKG_TARS_CACHE_DIR", self._tmpdir):
+        with patch.object(cache_mod, "_DEPS_CACHE_DIR", self._tmpdir):
             result = get_cached_dep(key)
 
         self.assertIsNotNone(result)
@@ -167,7 +167,7 @@ class TestGetCachedPackageTar(unittest.TestCase):
         with open(info_file, "w") as f:
             json.dump(info, f)
 
-        with patch.object(cache_mod, "_PKG_TARS_CACHE_DIR", self._tmpdir):
+        with patch.object(cache_mod, "_DEPS_CACHE_DIR", self._tmpdir):
             get_cached_dep(key)
 
         with open(info_file) as f:
@@ -185,7 +185,7 @@ class TestGetCachedPackageTar(unittest.TestCase):
         with tarfile.open(str(entry_dir / "installed.tar.gz"), "w:gz"):
             pass  # no cache_info.json written
 
-        with patch.object(cache_mod, "_PKG_TARS_CACHE_DIR", self._tmpdir):
+        with patch.object(cache_mod, "_DEPS_CACHE_DIR", self._tmpdir):
             result = get_cached_dep(key)
 
         self.assertIsNone(result)
@@ -201,7 +201,7 @@ class TestGetCachedPackageTar(unittest.TestCase):
             json.dump({"created_at": now, "last_used_at": now, "python_version": "3.11", "platform": "p"}, f)
         # No installed.tar.gz written.
 
-        with patch.object(cache_mod, "_PKG_TARS_CACHE_DIR", self._tmpdir):
+        with patch.object(cache_mod, "_DEPS_CACHE_DIR", self._tmpdir):
             result = get_cached_dep(key)
 
         self.assertIsNone(result)
@@ -213,7 +213,7 @@ class TestStorePackageTar(unittest.TestCase):
         self._cache_root = Path(tempfile.mkdtemp())
         self._pkg_tars_dir = self._cache_root / "pkg_tars"
         self._patcher_cache = patch("nextmv.cache._CACHE_DIR", self._cache_root)
-        self._patcher_pkg = patch("nextmv.cache._PKG_TARS_CACHE_DIR", self._pkg_tars_dir)
+        self._patcher_pkg = patch("nextmv.cache._DEPS_CACHE_DIR", self._pkg_tars_dir)
         self._patcher_cache.start()
         self._patcher_pkg.start()
 
@@ -237,11 +237,13 @@ class TestStorePackageTar(unittest.TestCase):
 
         with (
             patch.object(cache_mod, "_CACHE_DIR", self._cache_root),
-            patch.object(cache_mod, "_PKG_TARS_CACHE_DIR", self._pkg_tars_dir),
+            patch.object(cache_mod, "_DEPS_CACHE_DIR", self._pkg_tars_dir),
         ):
             store_dep(
                 key,
                 tar,
+                "pkg",
+                "1.0.0",
                 "3.11",
                 "aarch64-unknown-linux-gnu",
                 max_entries=_MAX_DEPS,
@@ -260,11 +262,13 @@ class TestStorePackageTar(unittest.TestCase):
 
         with (
             patch.object(cache_mod, "_CACHE_DIR", self._cache_root),
-            patch.object(cache_mod, "_PKG_TARS_CACHE_DIR", self._pkg_tars_dir),
+            patch.object(cache_mod, "_DEPS_CACHE_DIR", self._pkg_tars_dir),
         ):
             store_dep(
                 key,
                 tar,
+                "pkg",
+                "1.0.0",
                 "3.11",
                 "aarch64-unknown-linux-gnu",
                 max_entries=_MAX_DEPS,
@@ -289,11 +293,13 @@ class TestStorePackageTar(unittest.TestCase):
 
         with (
             patch.object(cache_mod, "_CACHE_DIR", self._cache_root),
-            patch.object(cache_mod, "_PKG_TARS_CACHE_DIR", self._pkg_tars_dir),
+            patch.object(cache_mod, "_DEPS_CACHE_DIR", self._pkg_tars_dir),
         ):
             store_dep(
                 key,
                 tar,
+                "pkg",
+                "1.0.0",
                 "3.11",
                 "aarch64-unknown-linux-gnu",
                 max_entries=_MAX_DEPS,
@@ -302,6 +308,8 @@ class TestStorePackageTar(unittest.TestCase):
             store_dep(
                 key,
                 tar,
+                "pkg",
+                "1.0.0",
                 "3.11",
                 "aarch64-unknown-linux-gnu",
                 max_entries=_MAX_DEPS,
@@ -317,7 +325,7 @@ class TestEvictLruPackages(unittest.TestCase):
         self._cache_root = Path(tempfile.mkdtemp())
         self._pkg_tars_dir = self._cache_root / "pkg_tars"
         self._pkg_tars_dir.mkdir(parents=True)
-        self._patcher = patch("nextmv.cache._PKG_TARS_CACHE_DIR", self._pkg_tars_dir)
+        self._patcher = patch("nextmv.cache._DEPS_CACHE_DIR", self._pkg_tars_dir)
         self._patcher.start()
 
     def tearDown(self):
@@ -354,7 +362,7 @@ class TestEvictLruPackages(unittest.TestCase):
         self._add_entry("k1", "2026-01-01T00:00:00+00:00")
         self._add_entry("k2", "2026-01-02T00:00:00+00:00")
 
-        with patch.object(cache_mod, "_PKG_TARS_CACHE_DIR", self._pkg_tars_dir):
+        with patch.object(cache_mod, "_DEPS_CACHE_DIR", self._pkg_tars_dir):
             evicted = _evict_lru(max_entries=10, max_bytes=_MAX_DEP_BYTES)
 
         self.assertEqual(evicted, 0)
@@ -368,7 +376,7 @@ class TestEvictLruPackages(unittest.TestCase):
         self._add_entry("middle", "2025-06-01T00:00:00+00:00")
         self._add_entry("newest", "2026-01-01T00:00:00+00:00")
 
-        with patch.object(cache_mod, "_PKG_TARS_CACHE_DIR", self._pkg_tars_dir):
+        with patch.object(cache_mod, "_DEPS_CACHE_DIR", self._pkg_tars_dir):
             evicted = _evict_lru(max_entries=2, max_bytes=_MAX_DEP_BYTES)
 
         self.assertEqual(evicted, 1)
@@ -382,7 +390,7 @@ class TestEvictLruPackages(unittest.TestCase):
         self._add_entry("big_old", "2025-01-01T00:00:00+00:00", size_bytes=10 * 1024)
         self._add_entry("big_new", "2026-01-01T00:00:00+00:00", size_bytes=10 * 1024)
 
-        with patch.object(cache_mod, "_PKG_TARS_CACHE_DIR", self._pkg_tars_dir):
+        with patch.object(cache_mod, "_DEPS_CACHE_DIR", self._pkg_tars_dir):
             evicted = _evict_lru(max_entries=200, max_bytes=15 * 1024)
 
         self.assertEqual(evicted, 1)
@@ -393,7 +401,7 @@ class TestEvictLruPackages(unittest.TestCase):
         from nextmv import cache as cache_mod
 
         missing = self._cache_root / "nonexistent"
-        with patch.object(cache_mod, "_PKG_TARS_CACHE_DIR", missing):
+        with patch.object(cache_mod, "_DEPS_CACHE_DIR", missing):
             evicted = _evict_lru(max_entries=10, max_bytes=_MAX_DEP_BYTES)
 
         self.assertEqual(evicted, 0)

--- a/nextmv/tests/test_cache.py
+++ b/nextmv/tests/test_cache.py
@@ -1,7 +1,10 @@
 """Tests for the nextmv.cache module."""
 
+import io
 import json
+import os
 import shutil
+import tarfile
 import tempfile
 import unittest
 from datetime import datetime, timezone
@@ -23,12 +26,15 @@ from nextmv.cache import (
 def _write_fake_entry(key: str, last_used_at: str, size_bytes: int = 0) -> None:
     """Write a minimal cache entry for use in tests."""
     entry_dir = _DEPS_CACHE_DIR / key
-    deps_dir = entry_dir / ".nextmv" / "python" / "deps"
-    deps_dir.mkdir(parents=True, exist_ok=True)
+    entry_dir.mkdir(parents=True, exist_ok=True)
 
-    if size_bytes > 0:
-        dummy_file = deps_dir / "dummy.pth"
-        dummy_file.write_bytes(b"x" * size_bytes)
+    deps_tar = entry_dir / "deps.tar.gz"
+    with tarfile.open(str(deps_tar), "w:gz") as tar:
+        if size_bytes > 0:
+            data = b"x" * size_bytes
+            info = tarfile.TarInfo(name=".nextmv/python/deps/dummy.pth")
+            info.size = size_bytes
+            tar.addfile(info, io.BytesIO(data))
 
     info = {
         "created_at": last_used_at,
@@ -87,8 +93,10 @@ class TestGetCachedDeps(unittest.TestCase):
         from nextmv import cache as cache_mod
 
         key = "abc123"
-        deps_dir = Path(self._tmpdir) / key / "deps"
-        deps_dir.mkdir(parents=True)
+        deps_tar = Path(self._tmpdir) / key / "deps.tar.gz"
+        deps_tar.parent.mkdir(parents=True)
+        with tarfile.open(str(deps_tar), "w:gz"):
+            pass  # empty tar
         info_file = Path(self._tmpdir) / key / _CACHE_INFO_FILE
         now = datetime.now(tz=timezone.utc).isoformat()
         with open(info_file, "w") as f:
@@ -100,14 +108,16 @@ class TestGetCachedDeps(unittest.TestCase):
             result = get_cached_deps(key)
 
         self.assertIsNotNone(result)
-        self.assertTrue(str(result).endswith("deps"))
+        self.assertTrue(str(result).endswith("deps.tar.gz"))
 
     def test_hit_updates_last_used_at(self):
         from nextmv import cache as cache_mod
 
         key = "upd456"
-        deps_dir = Path(self._tmpdir) / key / "deps"
-        deps_dir.mkdir(parents=True)
+        deps_tar = Path(self._tmpdir) / key / "deps.tar.gz"
+        deps_tar.parent.mkdir(parents=True)
+        with tarfile.open(str(deps_tar), "w:gz"):
+            pass  # empty tar
         info_file = Path(self._tmpdir) / key / _CACHE_INFO_FILE
         old_time = "2020-01-01T00:00:00+00:00"
         with open(info_file, "w") as f:
@@ -135,9 +145,10 @@ class TestGetCachedDeps(unittest.TestCase):
         from nextmv import cache as cache_mod
 
         key = "noinfo"
-        deps_dir = Path(self._tmpdir) / key / "deps"
-        deps_dir.mkdir(parents=True)
-        # No cache_info.json written.
+        deps_tar = Path(self._tmpdir) / key / "deps.tar.gz"
+        deps_tar.parent.mkdir(parents=True)
+        with tarfile.open(str(deps_tar), "w:gz"):
+            pass  # empty tar, no cache_info.json written
 
         with patch.object(cache_mod, "_DEPS_CACHE_DIR", Path(self._tmpdir)):
             result = get_cached_deps(key)
@@ -240,8 +251,11 @@ class TestStoreDeps(unittest.TestCase):
                 max_bytes=_DEFAULT_MAX_BYTES,
             )
 
-        cached_pkg = self._cache_root / "deps" / key / "deps" / "somepackage.py"
-        self.assertTrue(cached_pkg.exists())
+        deps_tar = self._cache_root / "deps" / key / "deps.tar.gz"
+        self.assertTrue(deps_tar.is_file())
+        with tarfile.open(str(deps_tar), "r:gz") as tar:
+            names = tar.getnames()
+        self.assertIn(".nextmv/python/deps/somepackage.py", names)
 
 
 class TestEvictLru(unittest.TestCase):
@@ -258,10 +272,15 @@ class TestEvictLru(unittest.TestCase):
 
     def _add_entry(self, key: str, last_used: str, size_bytes: int = 0):
         entry_dir = self._deps_dir / key
-        deps_dir = entry_dir / "deps"
-        deps_dir.mkdir(parents=True, exist_ok=True)
-        if size_bytes > 0:
-            (deps_dir / "dummy.bin").write_bytes(b"x" * size_bytes)
+        entry_dir.mkdir(parents=True, exist_ok=True)
+        deps_tar = entry_dir / "deps.tar.gz"
+        with tarfile.open(str(deps_tar), "w:gz") as tar:
+            if size_bytes > 0:
+                # Use incompressible random data so gzip cannot shrink it.
+                data = os.urandom(size_bytes)
+                info = tarfile.TarInfo(name=".nextmv/python/deps/dummy.bin")
+                info.size = size_bytes
+                tar.addfile(info, io.BytesIO(data))
         info = {
             "created_at": last_used,
             "last_used_at": last_used,
@@ -303,8 +322,9 @@ class TestEvictLru(unittest.TestCase):
     def test_evicts_by_size_cap(self):
         from nextmv import cache as cache_mod
 
-        # Use large files (10 KiB each) so cache_info.json overhead is negligible.
-        # Total ≈ 20 KiB; cap at 15 KiB → only the older entry should be evicted.
+        # Each deps.tar.gz holds ~10 KiB of random (incompressible) data.
+        # Use a cap that sits between one and two entries so exactly the oldest
+        # is evicted.
         self._add_entry("big_old", "2025-01-01T00:00:00+00:00", size_bytes=10 * 1024)
         self._add_entry("big_new", "2026-01-01T00:00:00+00:00", size_bytes=10 * 1024)
 


### PR DESCRIPTION
# Description

This PR is about introducing a cache for storing Python dependencies for applications. The intent is that when we are re-pushing an app whose dependencies don't change, we don't have to re-download and compress all dependencies.

- Current behavior:
  - Dependencies are read from `pyproject.toml` or `requirements.txt`.
  - They are downloaded from the appropriate package index.
  - They are bundled with the application files (what is listed in the `app.yaml`), and everything is tarred and compressed.
  - Whenever we push again, the whole process is repeated.
- New behavior:
  - Dependencies are read from `pyproject.toml` or `requirements.txt`.
  - A lockfile is generated (with `uv pip`) to create precise requirements for the application.
  - For each dependency of the lockfile:
    - Compile the cache key from the name, version, python version, and platform.
    - Check if the key is already in the cache. If it is, return the artifact (more on this below). If it isn't, mark the dep as it will be needed for downloading.
  - All dependencies that were marked are now downloaded from the appropriate package index.
  - For each dependency, an artifact is generated. The artifact is a g-zipped tarball.
  - The artifact, along with metadata, is saved to the cache for future use.
  - All artifacts (cached + newly-built) are concatenated together using tar operations.
  - The app files (what is listed in the `app.yaml`) are added to the dependency compressed tarball.
  - Whenever we push again, we go through the cache again. That means that if a dep is found in the cache, it is used.

The cache is evicted with a LRU (least recently used) policy, and sensible defaults of 2000 elements / 5 GiB are used. The cache is evicted whenever new dependencies are added to the cache.  Note that the cache work on a dependency by dependency basis, meaning that if a single dependency changes, we don't need to re-download everything, just the one that changed.

Additionally:
- The `cache.py` module was added to the SDK exposing cache functionalities.
- The `nextmv cache delete` and `nextmv cache get` commands were introduced to the CLI so that users may inspect and delete the cache.
- The `--no-cache` option is introduced to `nextmv cloud app push` so that people can choose to push an application without relying on the cache. The corresponding SDK option is `no_cache` in the `cloud.Application.push` method.

## Demo

To demonstrate the functionality of the cache, _the actual push to `cloud`_ was disabled. That way we are only comparing the download and compression operations.

1. Starting with a fresh cache, push the `python-ampl-facilitylocation` app to the cloud.

<img width="1126" height="144" alt="image" src="https://github.com/user-attachments/assets/6ef1cde3-1f77-4881-8694-254667f8c400" />

About 56 seconds total.

2. Let's simply run the command again.

<img width="1126" height="147" alt="image" src="https://github.com/user-attachments/assets/18e201da-67df-4e82-ae31-296083873cfc" />

About 2.8 seconds total. Blazing fast ⚡.

3. What happens if I change a single dependency? In this case, I am upgrading `pandas` to the latest version.

<img width="1129" height="159" alt="image" src="https://github.com/user-attachments/assets/e5ffc17e-9b68-4119-b8c5-9a09e7772ef2" />

About 6.1 seconds total, pretty good and _way_ faster than doing all the deps.

4. And if I run the same command again with the latest `pandas` version?

<img width="1126" height="145" alt="image" src="https://github.com/user-attachments/assets/8937a1b3-d5a3-4f6e-8d9e-9277f8c74c4f" />

Everything was loaded from the cache, nice!

5. I changed my mind, let me go back to the original `pandas` version, before the upgrade.

<img width="1120" height="148" alt="image" src="https://github.com/user-attachments/assets/a3b53436-3b9a-42cc-ae19-fcf8bd4fffec" />

Cool, as expected, everything is loaded from the cache.

6. For comparison, I switched to the `develop` branch. Let's run the same process using the old logic.

<img width="958" height="109" alt="image" src="https://github.com/user-attachments/assets/ab22c6b3-c4c7-4da5-a921-6cfadf925713" />

About 46.7 seconds. The new process, starting fresh, is _slower_ because of the individual compression of the dependencies. But that is a tradeoff that is worth it given the speedup that is gained is subsequent pushes.