### PR TITLE
Fixes YAML parsing by removing explicit newline characters (\n)

### DIFF
--- a/nextmv/nextmv/cloud/application/__init__.py
+++ b/nextmv/nextmv/cloud/application/__init__.py
@@ -793,59 +793,6 @@ class Application(
 
         return UploadURL.from_dict(response.json())
 
-    @staticmethod
-    def __convert_manifest_to_payload(manifest: Manifest) -> dict[str, Any]:  # noqa: C901
-        """Converts a manifest to a payload dictionary for the API."""
-
-        activation_request = {
-            "requirements": {
-                "executable_type": manifest.type,
-                "runtime": manifest.runtime,
-            },
-        }
-
-        if manifest.configuration is not None and manifest.configuration.content is not None:
-            content = manifest.configuration.content
-            io_config = {
-                "format": content.format,
-            }
-            if content.multi_file is not None:
-                multi_config = io_config["multi_file"] = {}
-                if content.multi_file.input is not None:
-                    multi_config["input_path"] = content.multi_file.input.path
-                if content.multi_file.output is not None:
-                    output_config = multi_config["output_configuration"] = {}
-                    if content.multi_file.output.statistics:
-                        output_config["statistics_path"] = content.multi_file.output.statistics
-                    if content.multi_file.output.metrics:
-                        output_config["metrics_path"] = content.multi_file.output.metrics
-                    if content.multi_file.output.assets:
-                        output_config["assets_path"] = content.multi_file.output.assets
-                    if content.multi_file.output.solutions:
-                        output_config["solutions_path"] = content.multi_file.output.solutions
-            activation_request["requirements"]["io_configuration"] = io_config
-
-        if manifest.configuration is not None and manifest.configuration.options is not None:
-            options = manifest.configuration.options.to_dict()
-            # Ignore local_only options since they are not meant to be used on the platform
-            if "items" in options:
-                options["items"] = [item for item in options["items"] if not item.get("local_only", False)]
-            if "format" in options and isinstance(options["format"], list):
-                # the endpoint expects a dictionary with a template key having a list of strings
-                # the app.yaml however defines format as a list of strings, so we need to convert it here
-                options["format"] = {
-                    "template": options["format"],
-                }
-            activation_request["requirements"]["options"] = options
-
-        if manifest.execution is not None:
-            if manifest.execution.entrypoint:
-                activation_request["requirements"]["entrypoint"] = manifest.execution.entrypoint
-            if manifest.execution.cwd:
-                activation_request["requirements"]["working_directory"] = manifest.execution.cwd
-
-        return activation_request
-
     def __update_app_binary(
         self,
         tar_file: str,
@@ -879,7 +826,7 @@ class Application(
         response = self.client.request(
             method="PUT",
             endpoint=endpoint,
-            payload=Application.__convert_manifest_to_payload(manifest=manifest),
+            payload=_convert_manifest_to_payload(manifest=manifest),
         )
 
         if verbose:
@@ -895,6 +842,59 @@ class Application(
             else:
                 log(f'💥️ Successfully pushed to application: "{self.id}".')
                 log(json.dumps(data, indent=2))
+
+
+def _convert_manifest_to_payload(manifest: Manifest) -> dict[str, Any]:  # noqa: C901
+    """Converts a manifest to a payload dictionary for the API."""
+
+    activation_request = {
+        "requirements": {
+            "executable_type": manifest.type,
+            "runtime": manifest.runtime,
+        },
+    }
+
+    if manifest.configuration is not None and manifest.configuration.content is not None:
+        content = manifest.configuration.content
+        io_config = {
+            "format": content.format,
+        }
+        if content.multi_file is not None:
+            multi_config = io_config["multi_file"] = {}
+            if content.multi_file.input is not None:
+                multi_config["input_path"] = content.multi_file.input.path
+            if content.multi_file.output is not None:
+                output_config = multi_config["output_configuration"] = {}
+                if content.multi_file.output.statistics:
+                    output_config["statistics_path"] = content.multi_file.output.statistics
+                if content.multi_file.output.metrics:
+                    output_config["metrics_path"] = content.multi_file.output.metrics
+                if content.multi_file.output.assets:
+                    output_config["assets_path"] = content.multi_file.output.assets
+                if content.multi_file.output.solutions:
+                    output_config["solutions_path"] = content.multi_file.output.solutions
+        activation_request["requirements"]["io_configuration"] = io_config
+
+    if manifest.configuration is not None and manifest.configuration.options is not None:
+        options = manifest.configuration.options.to_dict()
+        # Ignore local_only options since they are not meant to be used on the platform
+        if "items" in options:
+            options["items"] = [item for item in options["items"] if not item.get("local_only", False)]
+        if "format" in options and isinstance(options["format"], list):
+            # the endpoint expects a dictionary with a template key having a list of strings
+            # the app.yaml however defines format as a list of strings, so we need to convert it here
+            options["format"] = {
+                "template": options["format"],
+            }
+        activation_request["requirements"]["options"] = options
+
+    if manifest.execution is not None:
+        if manifest.execution.entrypoint:
+            activation_request["requirements"]["entrypoint"] = manifest.execution.entrypoint
+        if manifest.execution.cwd:
+            activation_request["requirements"]["working_directory"] = manifest.execution.cwd
+
+    return activation_request
 
 
 def list_applications(client: Client) -> list[Application]:

--- a/nextmv/nextmv/manifest.py
+++ b/nextmv/nextmv/manifest.py
@@ -67,19 +67,36 @@ MANIFEST_FILE_NAME
 
 import glob
 import os
+import re
 import shutil
 import sys
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any
+from typing import Annotated, Any
 
 import yaml
-from pydantic import AliasChoices, Field
+from pydantic import AliasChoices, BeforeValidator, Field
 
 from nextmv.account import AccountMemberRole
 from nextmv.base_model import BaseModel
 from nextmv.content_format import ContentFormat, InputFormat
 from nextmv.options import Option, Options, OptionsEnforcement
+
+
+def _normalize_yaml_str(v: str | None) -> str | None:
+    """
+    Replace newline sequences (from YAML block scalars) with a single space.
+    """
+
+    if v:
+        return re.sub(r"\s*\n\s*", " ", v).strip()
+
+    return v
+
+
+_YAMLStr = Annotated[str | None, BeforeValidator(_normalize_yaml_str)]
+"""String type that normalizes YAML block scalar newlines at parse time."""
+
 
 MANIFEST_FILE_NAME = "app.yaml"
 """Name of the app manifest file.
@@ -276,8 +293,9 @@ class ManifestBuild(BaseModel):
     'make build'
     """
 
-    command: str | None = None
-    """The command to run to build the app.
+    command: _YAMLStr = None
+    """
+    The command to run to build the app.
 
     This command will be executed without a shell, i.e., directly. The command
     must exit with a status of 0 to continue the push process of the app to
@@ -602,7 +620,7 @@ class ManifestOptionUI(BaseModel):
     """The type of control to use for the option in the Nextmv Cloud UI."""
     hidden_from: list[AccountMemberRole] | None = None
     """A list of team roles for which this option will be hidden in the UI."""
-    display_name: str | None = None
+    display_name: _YAMLStr = None
     """An optional display name for the option. This is useful for making
     the option more user-friendly in the UI.
     """
@@ -670,7 +688,7 @@ class ManifestOption(BaseModel):
 
     default: Any | None = None
     """The default value of the option"""
-    description: str | None = ""
+    description: _YAMLStr = ""
     """The description of the option"""
     required: bool = False
     """Whether the option is required or not"""
@@ -1437,9 +1455,7 @@ class Manifest(BaseModel):
     Python-specific attributes. Only for Python apps. Contains further
     Python-specific attributes.
     """
-    files: list[str] = Field(
-        min_length=1,
-    )
+    files: list[str] = Field(min_length=1)
     """The files to include (or exclude) in the app. This is mandatory."""
     configuration: ManifestConfiguration | None = None
     """
@@ -1457,7 +1473,7 @@ class Manifest(BaseModel):
     set environment variables when running the build command given as key-value
     pairs.
     """
-    pre_push: str | None = Field(
+    pre_push: _YAMLStr = Field(
         serialization_alias="pre-push",
         validation_alias=AliasChoices("pre-push", "pre_push"),
         default=None,


### PR DESCRIPTION
# Description

When parsing the `app.yaml` manifest using block scalar styles (`>`, `>-`, `|`, `|-`), the newlines some of them introduced were preserved as explicit newline characters `\n`. The API doesn't like this, so it returned a 400 bad request error. This PR addresses this behavior by stripping these newline characters and replacing them with spaces.