### PR TITLE
Display nice error messages for HTTP errors in CLI and enable the `--debug` option in every command

### DIFF
--- a/nextmv/nextmv/__about__.py
+++ b/nextmv/nextmv/__about__.py
@@ -1,1 +1,1 @@
-__version__ = "v1.8.0"
+__version__ = "v1.9.0.dev0"

--- a/nextmv/nextmv/cli/cache/delete.py
+++ b/nextmv/nextmv/cli/cache/delete.py
@@ -6,14 +6,14 @@ import typer
 
 from nextmv.cache import clear_cache, format_bytes
 from nextmv.cli.message import confirmation, info, success
-from nextmv.cli.options import YesOption
+from nextmv.cli.options import DebugOption, YesOption
 
 # Set up subcommand application.
 app = typer.Typer()
 
 
 @app.command()
-def delete(yes: YesOption = False) -> None:
+def delete(yes: YesOption = False, _: DebugOption = False) -> None:
     """
     Deletes the Nextmv cache and resets it to an empty state.
 

--- a/nextmv/nextmv/cli/cache/get.py
+++ b/nextmv/nextmv/cli/cache/get.py
@@ -6,13 +6,14 @@ import typer
 
 from nextmv.cache import get_cache
 from nextmv.cli.message import print_json, success
+from nextmv.cli.options import DebugOption
 
 # Set up subcommand application.
 app = typer.Typer()
 
 
 @app.command()
-def get() -> None:
+def get(_: DebugOption = False) -> None:
     """
     Gets general information about the Nextmv cache.
 

--- a/nextmv/nextmv/cli/cloud/acceptance/create.py
+++ b/nextmv/nextmv/cli/cloud/acceptance/create.py
@@ -9,7 +9,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import enum_values, error, in_progress, print_json, success
-from nextmv.cli.options import AppIDOption, ProfileOption
+from nextmv.cli.options import AppIDOption, DebugOption, ProfileOption
 from nextmv.cloud.acceptance_test import Comparison, Metric, MetricToleranceType, MetricType, StatisticType
 from nextmv.polling import default_polling_options
 
@@ -267,6 +267,7 @@ def create(
             rich_help_panel="Output control",
         ),
     ] = False,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     cloud_app, _ = build_cloud_app(app_id=app_id, profile=profile)

--- a/nextmv/nextmv/cli/cloud/acceptance/delete.py
+++ b/nextmv/nextmv/cli/cloud/acceptance/delete.py
@@ -6,7 +6,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import confirmation, info, success
-from nextmv.cli.options import AcceptanceTestIDOption, AppIDOption, ProfileOption, YesOption
+from nextmv.cli.options import AcceptanceTestIDOption, AppIDOption, DebugOption, ProfileOption, YesOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -17,6 +17,7 @@ def delete(
     app_id: AppIDOption,
     acceptance_test_id: AcceptanceTestIDOption,
     yes: YesOption = False,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/acceptance/get.py
+++ b/nextmv/nextmv/cli/cloud/acceptance/get.py
@@ -9,7 +9,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import in_progress, print_json, success
-from nextmv.cli.options import AcceptanceTestIDOption, AppIDOption, ProfileOption
+from nextmv.cli.options import AcceptanceTestIDOption, AppIDOption, DebugOption, ProfileOption
 from nextmv.polling import default_polling_options
 
 # Set up subcommand application.
@@ -45,6 +45,7 @@ def get(
             "Specify output location with --output.",
         ),
     ] = False,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/acceptance/list.py
+++ b/nextmv/nextmv/cli/cloud/acceptance/list.py
@@ -9,7 +9,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import in_progress, print_json, success
-from nextmv.cli.options import AppIDOption, ProfileOption
+from nextmv.cli.options import AppIDOption, DebugOption, ProfileOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -27,6 +27,7 @@ def list(
             metavar="OUTPUT_PATH",
         ),
     ] = None,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/acceptance/update.py
+++ b/nextmv/nextmv/cli/cloud/acceptance/update.py
@@ -9,7 +9,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import in_progress, print_json, success
-from nextmv.cli.options import AcceptanceTestIDOption, AppIDOption, ProfileOption
+from nextmv.cli.options import AcceptanceTestIDOption, AppIDOption, DebugOption, ProfileOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -46,6 +46,7 @@ def update(
             metavar="OUTPUT_PATH",
         ),
     ] = None,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/account/create.py
+++ b/nextmv/nextmv/cli/cloud/account/create.py
@@ -7,7 +7,7 @@ from typing import Annotated
 import typer
 
 from nextmv.cli.message import in_progress, print_json
-from nextmv.cli.options import ProfileOption
+from nextmv.cli.options import DebugOption, ProfileOption
 from nextmv.cloud.account import Account
 from nextmv.cloud.client import Client
 
@@ -36,6 +36,7 @@ def create(
             metavar="NAME",
         ),
     ],
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/account/delete.py
+++ b/nextmv/nextmv/cli/cloud/account/delete.py
@@ -6,7 +6,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_account
 from nextmv.cli.message import confirmation, info, success
-from nextmv.cli.options import AccountIDOption, ProfileOption, YesOption
+from nextmv.cli.options import AccountIDOption, DebugOption, ProfileOption, YesOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -16,6 +16,7 @@ app = typer.Typer()
 def delete(
     account_id: AccountIDOption,
     yes: YesOption = False,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/account/get.py
+++ b/nextmv/nextmv/cli/cloud/account/get.py
@@ -8,7 +8,7 @@ from typing import Annotated
 import typer
 
 from nextmv.cli.message import in_progress, print_json, success
-from nextmv.cli.options import AccountIDOption, ProfileOption
+from nextmv.cli.options import AccountIDOption, DebugOption, ProfileOption
 from nextmv.cloud.account import Account
 from nextmv.cloud.client import Client
 
@@ -28,6 +28,7 @@ def get(
             metavar="OUTPUT_PATH",
         ),
     ] = None,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/account/update.py
+++ b/nextmv/nextmv/cli/cloud/account/update.py
@@ -9,7 +9,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_account
 from nextmv.cli.message import in_progress, print_json, success
-from nextmv.cli.options import AccountIDOption, ProfileOption
+from nextmv.cli.options import AccountIDOption, DebugOption, ProfileOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -36,6 +36,7 @@ def update(
             metavar="OUTPUT_PATH",
         ),
     ] = None,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/app/create.py
+++ b/nextmv/nextmv/cli/cloud/app/create.py
@@ -7,7 +7,7 @@ from typing import Annotated
 import typer
 
 from nextmv.cli.message import in_progress, print_json
-from nextmv.cli.options import ProfileOption
+from nextmv.cli.options import DebugOption, ProfileOption
 from nextmv.cloud.application import Application
 from nextmv.cloud.client import Client
 
@@ -79,6 +79,7 @@ def create(
             metavar="NAME",
         ),
     ] = None,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/app/delete.py
+++ b/nextmv/nextmv/cli/cloud/app/delete.py
@@ -6,7 +6,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import confirmation, info, success
-from nextmv.cli.options import AppIDOption, ProfileOption, YesOption
+from nextmv.cli.options import AppIDOption, DebugOption, ProfileOption, YesOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -16,6 +16,7 @@ app = typer.Typer()
 def delete(
     app_id: AppIDOption,
     yes: YesOption = False,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/app/exists.py
+++ b/nextmv/nextmv/cli/cloud/app/exists.py
@@ -5,7 +5,7 @@ This module defines the cloud app exists command for the Nextmv CLI.
 import typer
 
 from nextmv.cli.message import in_progress, print_json
-from nextmv.cli.options import AppIDOption, ProfileOption
+from nextmv.cli.options import AppIDOption, DebugOption, ProfileOption
 from nextmv.cloud.application import Application
 from nextmv.cloud.client import Client
 
@@ -16,6 +16,7 @@ app = typer.Typer()
 @app.command()
 def exists(
     app_id: AppIDOption,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/app/get.py
+++ b/nextmv/nextmv/cli/cloud/app/get.py
@@ -8,7 +8,7 @@ from typing import Annotated
 import typer
 
 from nextmv.cli.message import in_progress, print_json, success
-from nextmv.cli.options import AppIDOption, ProfileOption
+from nextmv.cli.options import AppIDOption, DebugOption, ProfileOption
 from nextmv.cloud.application import Application
 from nextmv.cloud.client import Client
 
@@ -28,6 +28,7 @@ def get(
             metavar="OUTPUT_PATH",
         ),
     ] = None,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/app/list.py
+++ b/nextmv/nextmv/cli/cloud/app/list.py
@@ -8,7 +8,7 @@ from typing import Annotated
 import typer
 
 from nextmv.cli.message import in_progress, print_json, success
-from nextmv.cli.options import ProfileOption
+from nextmv.cli.options import DebugOption, ProfileOption
 from nextmv.cloud.application import list_applications
 from nextmv.cloud.client import Client
 
@@ -27,6 +27,7 @@ def list(
             metavar="OUTPUT_PATH",
         ),
     ] = None,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/app/push.py
+++ b/nextmv/nextmv/cli/cloud/app/push.py
@@ -11,7 +11,7 @@ from rich.prompt import Prompt
 
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import confirmation, error, in_progress, info, success
-from nextmv.cli.options import AppIDOption, ProfileOption
+from nextmv.cli.options import AppIDOption, DebugOption, ProfileOption
 from nextmv.cloud.application import Application
 from nextmv.manifest import Manifest
 
@@ -100,6 +100,7 @@ def push(
             rich_help_panel="Instance control",
         ),
     ] = None,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/app/update.py
+++ b/nextmv/nextmv/cli/cloud/app/update.py
@@ -9,7 +9,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import error, in_progress, print_json, success
-from nextmv.cli.options import AppIDOption, ProfileOption
+from nextmv.cli.options import AppIDOption, DebugOption, ProfileOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -63,6 +63,7 @@ def update(
             metavar="OUTPUT_PATH",
         ),
     ] = None,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/batch/create.py
+++ b/nextmv/nextmv/cli/cloud/batch/create.py
@@ -9,7 +9,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import error, in_progress, print_json, success
-from nextmv.cli.options import AppIDOption, ProfileOption
+from nextmv.cli.options import AppIDOption, DebugOption, ProfileOption
 from nextmv.cloud.batch_experiment import BatchExperimentRun
 from nextmv.polling import default_polling_options
 
@@ -113,6 +113,7 @@ def create(
             rich_help_panel="Output control",
         ),
     ] = False,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/batch/delete.py
+++ b/nextmv/nextmv/cli/cloud/batch/delete.py
@@ -6,7 +6,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import confirmation, info, success
-from nextmv.cli.options import AppIDOption, BatchExperimentIDOption, ProfileOption, YesOption
+from nextmv.cli.options import AppIDOption, BatchExperimentIDOption, DebugOption, ProfileOption, YesOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -17,6 +17,7 @@ def delete(
     app_id: AppIDOption,
     batch_experiment_id: BatchExperimentIDOption,
     yes: YesOption = False,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/batch/get.py
+++ b/nextmv/nextmv/cli/cloud/batch/get.py
@@ -9,7 +9,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import in_progress, print_json, success
-from nextmv.cli.options import AppIDOption, BatchExperimentIDOption, ProfileOption
+from nextmv.cli.options import AppIDOption, BatchExperimentIDOption, DebugOption, ProfileOption
 from nextmv.polling import default_polling_options
 
 # Set up subcommand application.
@@ -45,6 +45,7 @@ def get(
             "Specify output location with --output.",
         ),
     ] = False,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/batch/list.py
+++ b/nextmv/nextmv/cli/cloud/batch/list.py
@@ -9,7 +9,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import in_progress, print_json, success
-from nextmv.cli.options import AppIDOption, ProfileOption
+from nextmv.cli.options import AppIDOption, DebugOption, ProfileOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -27,6 +27,7 @@ def list(
             metavar="OUTPUT_PATH",
         ),
     ] = None,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/batch/metadata.py
+++ b/nextmv/nextmv/cli/cloud/batch/metadata.py
@@ -9,7 +9,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import in_progress, print_json, success
-from nextmv.cli.options import AppIDOption, BatchExperimentIDOption, ProfileOption
+from nextmv.cli.options import AppIDOption, BatchExperimentIDOption, DebugOption, ProfileOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -28,6 +28,7 @@ def metadata(
             metavar="OUTPUT_PATH",
         ),
     ] = None,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/batch/update.py
+++ b/nextmv/nextmv/cli/cloud/batch/update.py
@@ -9,7 +9,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import in_progress, print_json, success
-from nextmv.cli.options import AppIDOption, BatchExperimentIDOption, ProfileOption
+from nextmv.cli.options import AppIDOption, BatchExperimentIDOption, DebugOption, ProfileOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -46,6 +46,7 @@ def update(
             metavar="OUTPUT_PATH",
         ),
     ] = None,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/data/upload.py
+++ b/nextmv/nextmv/cli/cloud/data/upload.py
@@ -12,7 +12,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import error, in_progress, success
-from nextmv.cli.options import AppIDOption, ProfileOption
+from nextmv.cli.options import AppIDOption, DebugOption, ProfileOption
 from nextmv.cloud.application import Application
 
 # Set up subcommand application.
@@ -42,6 +42,7 @@ def upload(
             metavar="INPUT_PATH",
         ),
     ] = None,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/ensemble/create.py
+++ b/nextmv/nextmv/cli/cloud/ensemble/create.py
@@ -8,7 +8,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import enum_values, error, in_progress, print_json
-from nextmv.cli.options import AppIDOption, ProfileOption
+from nextmv.cli.options import AppIDOption, DebugOption, ProfileOption
 from nextmv.cloud.ensemble import EvaluationRule, RuleObjective, RuleTolerance, RuleToleranceType, RunGroup
 
 # Set up subcommand application.
@@ -217,6 +217,7 @@ def create(
             metavar="ENSEMBLE_DEFINITION_ID",
         ),
     ] = None,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     cloud_app, _ = build_cloud_app(app_id=app_id, profile=profile)

--- a/nextmv/nextmv/cli/cloud/ensemble/delete.py
+++ b/nextmv/nextmv/cli/cloud/ensemble/delete.py
@@ -6,7 +6,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import confirmation, info, success
-from nextmv.cli.options import AppIDOption, EnsembleDefinitionIDOption, ProfileOption, YesOption
+from nextmv.cli.options import AppIDOption, DebugOption, EnsembleDefinitionIDOption, ProfileOption, YesOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -17,6 +17,7 @@ def delete(
     app_id: AppIDOption,
     ensemble_definition_id: EnsembleDefinitionIDOption,
     yes: YesOption = False,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/ensemble/get.py
+++ b/nextmv/nextmv/cli/cloud/ensemble/get.py
@@ -9,7 +9,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import in_progress, print_json, success
-from nextmv.cli.options import AppIDOption, EnsembleDefinitionIDOption, ProfileOption
+from nextmv.cli.options import AppIDOption, DebugOption, EnsembleDefinitionIDOption, ProfileOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -28,6 +28,7 @@ def get(
             metavar="OUTPUT_PATH",
         ),
     ] = None,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/ensemble/list.py
+++ b/nextmv/nextmv/cli/cloud/ensemble/list.py
@@ -9,7 +9,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import in_progress, print_json, success
-from nextmv.cli.options import AppIDOption, ProfileOption
+from nextmv.cli.options import AppIDOption, DebugOption, ProfileOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -27,6 +27,7 @@ def list(
             metavar="OUTPUT_PATH",
         ),
     ] = None,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/ensemble/update.py
+++ b/nextmv/nextmv/cli/cloud/ensemble/update.py
@@ -9,7 +9,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import error, in_progress, print_json, success
-from nextmv.cli.options import AppIDOption, EnsembleDefinitionIDOption, ProfileOption
+from nextmv.cli.options import AppIDOption, DebugOption, EnsembleDefinitionIDOption, ProfileOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -46,6 +46,7 @@ def update(
             metavar="OUTPUT_PATH",
         ),
     ] = None,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/input_set/create.py
+++ b/nextmv/nextmv/cli/cloud/input_set/create.py
@@ -10,7 +10,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import error, in_progress, print_json
-from nextmv.cli.options import AppIDOption, ProfileOption
+from nextmv.cli.options import AppIDOption, DebugOption, ProfileOption
 from nextmv.cloud.input_set import ManagedInput
 from nextmv.safe import safe_id
 
@@ -105,6 +105,7 @@ def create(
             metavar="START_TIME",
         ),
     ] = None,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/input_set/delete.py
+++ b/nextmv/nextmv/cli/cloud/input_set/delete.py
@@ -6,7 +6,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import confirmation, info, success
-from nextmv.cli.options import AppIDOption, InputSetIDOption, ProfileOption, YesOption
+from nextmv.cli.options import AppIDOption, DebugOption, InputSetIDOption, ProfileOption, YesOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -17,6 +17,7 @@ def delete(
     app_id: AppIDOption,
     input_set_id: InputSetIDOption,
     yes: YesOption = False,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/input_set/get.py
+++ b/nextmv/nextmv/cli/cloud/input_set/get.py
@@ -9,7 +9,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import in_progress, print_json, success
-from nextmv.cli.options import AppIDOption, InputSetIDOption, ProfileOption
+from nextmv.cli.options import AppIDOption, DebugOption, InputSetIDOption, ProfileOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -28,6 +28,7 @@ def get(
             metavar="OUTPUT_PATH",
         ),
     ] = None,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/input_set/list.py
+++ b/nextmv/nextmv/cli/cloud/input_set/list.py
@@ -9,7 +9,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import in_progress, print_json, success
-from nextmv.cli.options import AppIDOption, ProfileOption
+from nextmv.cli.options import AppIDOption, DebugOption, ProfileOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -27,6 +27,7 @@ def list(
             metavar="OUTPUT_PATH",
         ),
     ] = None,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/input_set/update.py
+++ b/nextmv/nextmv/cli/cloud/input_set/update.py
@@ -9,7 +9,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import error, in_progress, print_json, success
-from nextmv.cli.options import AppIDOption, InputSetIDOption, ProfileOption
+from nextmv.cli.options import AppIDOption, DebugOption, InputSetIDOption, ProfileOption
 from nextmv.cloud.input_set import ManagedInput
 
 # Set up subcommand application.
@@ -56,6 +56,7 @@ def update(
             metavar="OUTPUT_PATH",
         ),
     ] = None,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/instance/create.py
+++ b/nextmv/nextmv/cli/cloud/instance/create.py
@@ -8,7 +8,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import enum_values, error, in_progress, parse_content_format, print_json
-from nextmv.cli.options import AppIDOption, ProfileOption, VersionIDOption
+from nextmv.cli.options import AppIDOption, DebugOption, ProfileOption, VersionIDOption
 from nextmv.cloud.instance import InstanceConfiguration
 from nextmv.content_format import ContentFormat
 from nextmv.input import InputFormat
@@ -127,6 +127,7 @@ def create(
             rich_help_panel="Instance configuration",
         ),
     ] = None,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/instance/delete.py
+++ b/nextmv/nextmv/cli/cloud/instance/delete.py
@@ -6,7 +6,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import confirmation, info, success
-from nextmv.cli.options import AppIDOption, InstanceIDOption, ProfileOption, YesOption
+from nextmv.cli.options import AppIDOption, DebugOption, InstanceIDOption, ProfileOption, YesOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -17,6 +17,7 @@ def delete(
     app_id: AppIDOption,
     instance_id: InstanceIDOption,
     yes: YesOption = False,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/instance/exists.py
+++ b/nextmv/nextmv/cli/cloud/instance/exists.py
@@ -6,7 +6,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import in_progress, print_json
-from nextmv.cli.options import AppIDOption, InstanceIDOption, ProfileOption
+from nextmv.cli.options import AppIDOption, DebugOption, InstanceIDOption, ProfileOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -16,6 +16,7 @@ app = typer.Typer()
 def exists(
     app_id: AppIDOption,
     instance_id: InstanceIDOption,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/instance/get.py
+++ b/nextmv/nextmv/cli/cloud/instance/get.py
@@ -9,7 +9,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import in_progress, print_json, success
-from nextmv.cli.options import AppIDOption, InstanceIDOption, ProfileOption
+from nextmv.cli.options import AppIDOption, DebugOption, InstanceIDOption, ProfileOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -28,6 +28,7 @@ def get(
             metavar="OUTPUT_PATH",
         ),
     ] = None,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/instance/list.py
+++ b/nextmv/nextmv/cli/cloud/instance/list.py
@@ -9,7 +9,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import in_progress, print_json, success
-from nextmv.cli.options import AppIDOption, ProfileOption
+from nextmv.cli.options import AppIDOption, DebugOption, ProfileOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -27,6 +27,7 @@ def list(
             metavar="OUTPUT_PATH",
         ),
     ] = None,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/instance/update.py
+++ b/nextmv/nextmv/cli/cloud/instance/update.py
@@ -10,7 +10,7 @@ import typer
 from nextmv.cli.cloud.instance.create import build_config, build_options
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import enum_values, error, in_progress, parse_content_format, print_json, success
-from nextmv.cli.options import AppIDOption, InstanceIDOption, ProfileOption
+from nextmv.cli.options import AppIDOption, DebugOption, InstanceIDOption, ProfileOption
 from nextmv.content_format import ContentFormat
 from nextmv.input import InputFormat
 
@@ -132,6 +132,7 @@ def update(
             rich_help_panel="Instance configuration",
         ),
     ] = None,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/managed_input/create.py
+++ b/nextmv/nextmv/cli/cloud/managed_input/create.py
@@ -8,7 +8,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import enum_values, error, in_progress, parse_content_format, print_json
-from nextmv.cli.options import AppIDOption, ProfileOption
+from nextmv.cli.options import AppIDOption, DebugOption, ProfileOption
 from nextmv.content_format import ContentFormat
 from nextmv.input import InputFormat
 from nextmv.run import Format, FormatInput
@@ -77,6 +77,7 @@ def create(
             metavar="UPLOAD_ID",
         ),
     ] = None,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/managed_input/delete.py
+++ b/nextmv/nextmv/cli/cloud/managed_input/delete.py
@@ -6,7 +6,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import confirmation, info, success
-from nextmv.cli.options import AppIDOption, ManagedInputIDOption, ProfileOption, YesOption
+from nextmv.cli.options import AppIDOption, DebugOption, ManagedInputIDOption, ProfileOption, YesOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -17,6 +17,7 @@ def delete(
     app_id: AppIDOption,
     managed_input_id: ManagedInputIDOption,
     yes: YesOption = False,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/managed_input/get.py
+++ b/nextmv/nextmv/cli/cloud/managed_input/get.py
@@ -9,7 +9,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import in_progress, print_json, success
-from nextmv.cli.options import AppIDOption, ManagedInputIDOption, ProfileOption
+from nextmv.cli.options import AppIDOption, DebugOption, ManagedInputIDOption, ProfileOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -28,6 +28,7 @@ def get(
             metavar="OUTPUT_PATH",
         ),
     ] = None,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/managed_input/list.py
+++ b/nextmv/nextmv/cli/cloud/managed_input/list.py
@@ -9,7 +9,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import in_progress, print_json, success
-from nextmv.cli.options import AppIDOption, ProfileOption
+from nextmv.cli.options import AppIDOption, DebugOption, ProfileOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -27,6 +27,7 @@ def list(
             metavar="OUTPUT_PATH",
         ),
     ] = None,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/managed_input/update.py
+++ b/nextmv/nextmv/cli/cloud/managed_input/update.py
@@ -9,7 +9,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import error, in_progress, print_json, success
-from nextmv.cli.options import AppIDOption, ManagedInputIDOption, ProfileOption
+from nextmv.cli.options import AppIDOption, DebugOption, ManagedInputIDOption, ProfileOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -46,6 +46,7 @@ def update(
             metavar="OUTPUT_PATH",
         ),
     ] = None,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/marketplace/app/create.py
+++ b/nextmv/nextmv/cli/cloud/marketplace/app/create.py
@@ -7,7 +7,7 @@ from typing import Annotated
 import typer
 
 from nextmv.cli.message import in_progress, print_json
-from nextmv.cli.options import ProfileOption
+from nextmv.cli.options import DebugOption, ProfileOption
 from nextmv.cloud.client import Client
 from nextmv.cloud.marketplace import MarketplaceApplication
 
@@ -83,6 +83,7 @@ def create(
             metavar="FEATURES",
         ),
     ] = None,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/marketplace/app/get.py
+++ b/nextmv/nextmv/cli/cloud/marketplace/app/get.py
@@ -9,7 +9,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_marketplace_app
 from nextmv.cli.message import in_progress, print_json, success
-from nextmv.cli.options import MarketplaceAppIDOption, MarketplacePartnerIDOption, ProfileOption
+from nextmv.cli.options import DebugOption, MarketplaceAppIDOption, MarketplacePartnerIDOption, ProfileOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -28,6 +28,7 @@ def get(
             metavar="OUTPUT_PATH",
         ),
     ] = None,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/marketplace/app/list.py
+++ b/nextmv/nextmv/cli/cloud/marketplace/app/list.py
@@ -8,7 +8,7 @@ from typing import Annotated
 import typer
 
 from nextmv.cli.message import in_progress, print_json, success
-from nextmv.cli.options import ProfileOption
+from nextmv.cli.options import DebugOption, ProfileOption
 from nextmv.cloud.client import Client
 from nextmv.cloud.marketplace import list_marketplace_applications
 
@@ -37,6 +37,7 @@ def list(
             metavar="OUTPUT_PATH",
         ),
     ] = None,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/marketplace/app/update.py
+++ b/nextmv/nextmv/cli/cloud/marketplace/app/update.py
@@ -9,7 +9,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_marketplace_app
 from nextmv.cli.message import enum_values, in_progress, print_json, success
-from nextmv.cli.options import MarketplaceAppIDOption, MarketplacePartnerIDOption, ProfileOption
+from nextmv.cli.options import DebugOption, MarketplaceAppIDOption, MarketplacePartnerIDOption, ProfileOption
 from nextmv.cloud.marketplace import MarketplaceState
 
 # Set up subcommand application.
@@ -74,6 +74,7 @@ def update(
             metavar="TITLE",
         ),
     ] = None,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/marketplace/subscription/create.py
+++ b/nextmv/nextmv/cli/cloud/marketplace/subscription/create.py
@@ -7,7 +7,7 @@ from typing import Annotated
 import typer
 
 from nextmv.cli.message import in_progress, print_json
-from nextmv.cli.options import ProfileOption
+from nextmv.cli.options import DebugOption, ProfileOption
 from nextmv.cloud.client import Client
 from nextmv.cloud.marketplace import MarketplaceSubscription
 
@@ -28,6 +28,7 @@ def create(
             metavar="SUBSCRIPTION_ID",
         ),
     ],
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/marketplace/subscription/delete.py
+++ b/nextmv/nextmv/cli/cloud/marketplace/subscription/delete.py
@@ -6,7 +6,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_marketplace_subscription
 from nextmv.cli.message import confirmation, info, success
-from nextmv.cli.options import MarketplaceSubscriptionIDOption, ProfileOption, YesOption
+from nextmv.cli.options import DebugOption, MarketplaceSubscriptionIDOption, ProfileOption, YesOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -17,6 +17,7 @@ def delete(
     subscription_id: MarketplaceSubscriptionIDOption,
     yes: YesOption = False,
     profile: ProfileOption = None,
+    _: DebugOption = False,
 ) -> None:
     """
     Delete a marketplace subscription.

--- a/nextmv/nextmv/cli/cloud/marketplace/subscription/get.py
+++ b/nextmv/nextmv/cli/cloud/marketplace/subscription/get.py
@@ -9,7 +9,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_marketplace_subscription
 from nextmv.cli.message import in_progress, print_json, success
-from nextmv.cli.options import MarketplaceSubscriptionIDOption, ProfileOption
+from nextmv.cli.options import DebugOption, MarketplaceSubscriptionIDOption, ProfileOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -27,6 +27,7 @@ def get(
             metavar="OUTPUT_PATH",
         ),
     ] = None,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/marketplace/subscription/list.py
+++ b/nextmv/nextmv/cli/cloud/marketplace/subscription/list.py
@@ -8,7 +8,7 @@ from typing import Annotated
 import typer
 
 from nextmv.cli.message import in_progress, print_json, success
-from nextmv.cli.options import ProfileOption
+from nextmv.cli.options import DebugOption, ProfileOption
 from nextmv.cloud.client import Client
 from nextmv.cloud.marketplace import list_marketplace_subscriptions
 
@@ -27,6 +27,7 @@ def list(
             metavar="OUTPUT_PATH",
         ),
     ] = None,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/marketplace/version/create.py
+++ b/nextmv/nextmv/cli/cloud/marketplace/version/create.py
@@ -8,7 +8,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_marketplace_app
 from nextmv.cli.message import in_progress, print_json
-from nextmv.cli.options import MarketplaceAppIDOption, MarketplacePartnerIDOption, ProfileOption
+from nextmv.cli.options import DebugOption, MarketplaceAppIDOption, MarketplacePartnerIDOption, ProfileOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -46,6 +46,7 @@ def create(
             metavar="VERSION_ID",
         ),
     ] = None,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/marketplace/version/get.py
+++ b/nextmv/nextmv/cli/cloud/marketplace/version/get.py
@@ -10,6 +10,7 @@ import typer
 from nextmv.cli.configuration.config import build_marketplace_app
 from nextmv.cli.message import in_progress, print_json, success
 from nextmv.cli.options import (
+    DebugOption,
     MarketplaceAppIDOption,
     MarketplacePartnerIDOption,
     MarketplaceVersionIDOption,
@@ -34,6 +35,7 @@ def get(
             metavar="OUTPUT_PATH",
         ),
     ] = None,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/marketplace/version/list.py
+++ b/nextmv/nextmv/cli/cloud/marketplace/version/list.py
@@ -9,7 +9,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_marketplace_app
 from nextmv.cli.message import in_progress, print_json, success
-from nextmv.cli.options import MarketplaceAppIDOption, MarketplacePartnerIDOption, ProfileOption
+from nextmv.cli.options import DebugOption, MarketplaceAppIDOption, MarketplacePartnerIDOption, ProfileOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -28,6 +28,7 @@ def list(
             metavar="OUTPUT_PATH",
         ),
     ] = None,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/marketplace/version/update.py
+++ b/nextmv/nextmv/cli/cloud/marketplace/version/update.py
@@ -10,6 +10,7 @@ import typer
 from nextmv.cli.configuration.config import build_marketplace_app
 from nextmv.cli.message import print_json, success
 from nextmv.cli.options import (
+    DebugOption,
     MarketplaceAppIDOption,
     MarketplacePartnerIDOption,
     MarketplaceVersionIDOption,
@@ -43,6 +44,7 @@ def update(
             metavar="OUTPUT_PATH",
         ),
     ] = None,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/run/cancel.py
+++ b/nextmv/nextmv/cli/cloud/run/cancel.py
@@ -6,7 +6,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import in_progress, success
-from nextmv.cli.options import AppIDOption, ProfileOption, RunIDOption
+from nextmv.cli.options import AppIDOption, DebugOption, ProfileOption, RunIDOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -16,6 +16,7 @@ app = typer.Typer()
 def cancel(
     app_id: AppIDOption,
     run_id: RunIDOption,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/run/clone.py
+++ b/nextmv/nextmv/cli/cloud/run/clone.py
@@ -12,7 +12,7 @@ from nextmv.cli.cloud.run.get import handle_outputs
 from nextmv.cli.cloud.run.logs import handle_logs
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import enum_values, parse_content_format, print_json, success
-from nextmv.cli.options import AppIDOption, ProfileOption
+from nextmv.cli.options import AppIDOption, DebugOption, ProfileOption
 from nextmv.content_format import ContentFormat
 from nextmv.input import InputFormat
 from nextmv.polling import default_polling_options
@@ -222,6 +222,7 @@ def clone(
             rich_help_panel="Run configuration",
         ),
     ] = -1,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/run/create.py
+++ b/nextmv/nextmv/cli/cloud/run/create.py
@@ -14,7 +14,7 @@ from nextmv.cli.cloud.run.get import handle_outputs
 from nextmv.cli.cloud.run.logs import handle_logs
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import enum_values, error, parse_content_format, print_json, success
-from nextmv.cli.options import AppIDOption, ProfileOption
+from nextmv.cli.options import AppIDOption, DebugOption, ProfileOption
 from nextmv.cloud.application import Application
 from nextmv.content_format import ContentFormat
 from nextmv.input import InputFormat
@@ -216,6 +216,7 @@ def create(
             rich_help_panel="Run configuration",
         ),
     ] = -1,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/run/delete.py
+++ b/nextmv/nextmv/cli/cloud/run/delete.py
@@ -6,7 +6,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import confirmation, info, success
-from nextmv.cli.options import AppIDOption, ProfileOption, RunIDOption, YesOption
+from nextmv.cli.options import AppIDOption, DebugOption, ProfileOption, RunIDOption, YesOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -17,6 +17,7 @@ def delete(
     app_id: AppIDOption,
     run_id: RunIDOption,
     yes: YesOption = False,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/run/get.py
+++ b/nextmv/nextmv/cli/cloud/run/get.py
@@ -9,7 +9,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import in_progress, info, print_json, success
-from nextmv.cli.options import AppIDOption, ProfileOption, RunIDOption
+from nextmv.cli.options import AppIDOption, DebugOption, ProfileOption, RunIDOption
 from nextmv.cloud.application import Application
 from nextmv.content_format import ContentFormat
 from nextmv.polling import PollingOptions, default_polling_options
@@ -49,6 +49,7 @@ def get(
             "Specify output location with --output.",
         ),
     ] = False,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/run/information.py
+++ b/nextmv/nextmv/cli/cloud/run/information.py
@@ -9,7 +9,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import in_progress, print_json, success
-from nextmv.cli.options import AppIDOption, ProfileOption, RunIDOption
+from nextmv.cli.options import AppIDOption, DebugOption, ProfileOption, RunIDOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -28,6 +28,7 @@ def information(
             metavar="OUTPUT_PATH",
         ),
     ] = None,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/run/input.py
+++ b/nextmv/nextmv/cli/cloud/run/input.py
@@ -9,7 +9,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import in_progress, print_json, success
-from nextmv.cli.options import AppIDOption, ProfileOption, RunIDOption
+from nextmv.cli.options import AppIDOption, DebugOption, ProfileOption, RunIDOption
 from nextmv.content_format import ContentFormat
 
 # Set up subcommand application.
@@ -29,6 +29,7 @@ def input(
             metavar="OUTPUT_PATH",
         ),
     ] = None,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/run/list.py
+++ b/nextmv/nextmv/cli/cloud/run/list.py
@@ -9,7 +9,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import enum_values, in_progress, print_json, success
-from nextmv.cli.options import AppIDOption, ProfileOption
+from nextmv.cli.options import AppIDOption, DebugOption, ProfileOption
 from nextmv.status import StatusV2
 
 # Set up subcommand application.
@@ -37,6 +37,7 @@ def list(
             metavar="STATUS",
         ),
     ] = None,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/run/logs.py
+++ b/nextmv/nextmv/cli/cloud/run/logs.py
@@ -11,7 +11,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import in_progress, success
-from nextmv.cli.options import AppIDOption, ProfileOption, RunIDOption
+from nextmv.cli.options import AppIDOption, DebugOption, ProfileOption, RunIDOption
 from nextmv.cloud.application import Application
 from nextmv.polling import PollingOptions, default_polling_options
 
@@ -48,6 +48,7 @@ def logs(
             metavar="TIMEOUT_SECONDS",
         ),
     ] = -1,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/run/metadata.py
+++ b/nextmv/nextmv/cli/cloud/run/metadata.py
@@ -9,7 +9,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import in_progress, print_json, success, warning
-from nextmv.cli.options import AppIDOption, ProfileOption, RunIDOption
+from nextmv.cli.options import AppIDOption, DebugOption, ProfileOption, RunIDOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -28,6 +28,7 @@ def metadata(
             metavar="OUTPUT_PATH",
         ),
     ] = None,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/run/track.py
+++ b/nextmv/nextmv/cli/cloud/run/track.py
@@ -12,7 +12,7 @@ import typer
 from nextmv.cli.cloud.run.create import build_run_config
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import enum_values, error, in_progress, parse_content_format, print_json, warning
-from nextmv.cli.options import AppIDOption, ProfileOption
+from nextmv.cli.options import AppIDOption, DebugOption, ProfileOption
 from nextmv.content_format import ContentFormat
 from nextmv.input import InputFormat
 from nextmv.run import RunType, TrackedRun, TrackedRunStatus
@@ -148,6 +148,7 @@ def track(
             rich_help_panel="Run configuration",
         ),
     ] = "latest",
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/scenario/create.py
+++ b/nextmv/nextmv/cli/cloud/scenario/create.py
@@ -9,7 +9,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import error, in_progress, print_json, success
-from nextmv.cli.options import AppIDOption, ProfileOption
+from nextmv.cli.options import AppIDOption, DebugOption, ProfileOption
 from nextmv.cloud.scenario import Scenario
 from nextmv.polling import default_polling_options
 
@@ -104,6 +104,7 @@ def create(
             rich_help_panel="Output control",
         ),
     ] = False,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/scenario/delete.py
+++ b/nextmv/nextmv/cli/cloud/scenario/delete.py
@@ -6,7 +6,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import confirmation, info, success
-from nextmv.cli.options import AppIDOption, ProfileOption, ScenarioTestIDOption, YesOption
+from nextmv.cli.options import AppIDOption, DebugOption, ProfileOption, ScenarioTestIDOption, YesOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -17,6 +17,7 @@ def delete(
     app_id: AppIDOption,
     scenario_test_id: ScenarioTestIDOption,
     yes: YesOption = False,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/scenario/get.py
+++ b/nextmv/nextmv/cli/cloud/scenario/get.py
@@ -9,7 +9,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import in_progress, print_json, success
-from nextmv.cli.options import AppIDOption, ProfileOption, ScenarioTestIDOption
+from nextmv.cli.options import AppIDOption, DebugOption, ProfileOption, ScenarioTestIDOption
 from nextmv.polling import default_polling_options
 
 # Set up subcommand application.
@@ -45,6 +45,7 @@ def get(
             "Specify output location with --output.",
         ),
     ] = False,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/scenario/list.py
+++ b/nextmv/nextmv/cli/cloud/scenario/list.py
@@ -9,7 +9,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import in_progress, print_json, success
-from nextmv.cli.options import AppIDOption, ProfileOption
+from nextmv.cli.options import AppIDOption, DebugOption, ProfileOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -27,6 +27,7 @@ def list(
             metavar="OUTPUT_PATH",
         ),
     ] = None,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/scenario/metadata.py
+++ b/nextmv/nextmv/cli/cloud/scenario/metadata.py
@@ -9,7 +9,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import in_progress, print_json, success
-from nextmv.cli.options import AppIDOption, ProfileOption, ScenarioTestIDOption
+from nextmv.cli.options import AppIDOption, DebugOption, ProfileOption, ScenarioTestIDOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -28,6 +28,7 @@ def metadata(
             metavar="OUTPUT_PATH",
         ),
     ] = None,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/scenario/update.py
+++ b/nextmv/nextmv/cli/cloud/scenario/update.py
@@ -9,7 +9,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import in_progress, print_json, success
-from nextmv.cli.options import AppIDOption, ProfileOption, ScenarioTestIDOption
+from nextmv.cli.options import AppIDOption, DebugOption, ProfileOption, ScenarioTestIDOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -46,6 +46,7 @@ def update(
             metavar="OUTPUT_PATH",
         ),
     ] = None,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/secrets/create.py
+++ b/nextmv/nextmv/cli/cloud/secrets/create.py
@@ -8,7 +8,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import enum_values, error, in_progress, print_json
-from nextmv.cli.options import AppIDOption, ProfileOption
+from nextmv.cli.options import AppIDOption, DebugOption, ProfileOption
 from nextmv.cloud.secrets import Secret, SecretType
 
 # Set up subcommand application.
@@ -59,6 +59,7 @@ def create(
             metavar="SECRETS_COLLECTION_ID",
         ),
     ] = None,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/secrets/delete.py
+++ b/nextmv/nextmv/cli/cloud/secrets/delete.py
@@ -6,7 +6,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import confirmation, info, success
-from nextmv.cli.options import AppIDOption, ProfileOption, SecretsCollectionIDOption, YesOption
+from nextmv.cli.options import AppIDOption, DebugOption, ProfileOption, SecretsCollectionIDOption, YesOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -17,6 +17,7 @@ def delete(
     app_id: AppIDOption,
     secrets_collection_id: SecretsCollectionIDOption,
     yes: YesOption = False,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/secrets/get.py
+++ b/nextmv/nextmv/cli/cloud/secrets/get.py
@@ -9,7 +9,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import in_progress, print_json, success
-from nextmv.cli.options import AppIDOption, ProfileOption, SecretsCollectionIDOption
+from nextmv.cli.options import AppIDOption, DebugOption, ProfileOption, SecretsCollectionIDOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -28,6 +28,7 @@ def get(
             metavar="OUTPUT_PATH",
         ),
     ] = None,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/secrets/list.py
+++ b/nextmv/nextmv/cli/cloud/secrets/list.py
@@ -9,7 +9,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import in_progress, print_json, success
-from nextmv.cli.options import AppIDOption, ProfileOption
+from nextmv.cli.options import AppIDOption, DebugOption, ProfileOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -27,6 +27,7 @@ def list(
             metavar="OUTPUT_PATH",
         ),
     ] = None,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/secrets/update.py
+++ b/nextmv/nextmv/cli/cloud/secrets/update.py
@@ -10,7 +10,7 @@ import typer
 from nextmv.cli.cloud.secrets.create import build_secrets
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import enum_values, error, in_progress, print_json, success
-from nextmv.cli.options import AppIDOption, ProfileOption, SecretsCollectionIDOption
+from nextmv.cli.options import AppIDOption, DebugOption, ProfileOption, SecretsCollectionIDOption
 from nextmv.cloud.secrets import SecretType
 
 # Set up subcommand application.
@@ -62,6 +62,7 @@ def update(
             metavar="SECRETS",
         ),
     ] = None,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/shadow/create.py
+++ b/nextmv/nextmv/cli/cloud/shadow/create.py
@@ -10,7 +10,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import error, in_progress, print_json
-from nextmv.cli.options import AppIDOption, ProfileOption
+from nextmv.cli.options import AppIDOption, DebugOption, ProfileOption
 from nextmv.cloud.shadow import StartEvents, TerminationEvents
 
 # Set up subcommand application.
@@ -92,6 +92,7 @@ def create(
             metavar="TERMINATION_TIME",
         ),
     ] = None,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/shadow/delete.py
+++ b/nextmv/nextmv/cli/cloud/shadow/delete.py
@@ -6,7 +6,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import confirmation, info, success
-from nextmv.cli.options import AppIDOption, ProfileOption, ShadowTestIDOption, YesOption
+from nextmv.cli.options import AppIDOption, DebugOption, ProfileOption, ShadowTestIDOption, YesOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -17,6 +17,7 @@ def delete(
     app_id: AppIDOption,
     shadow_test_id: ShadowTestIDOption,
     yes: YesOption = False,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/shadow/get.py
+++ b/nextmv/nextmv/cli/cloud/shadow/get.py
@@ -9,7 +9,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import in_progress, print_json, success
-from nextmv.cli.options import AppIDOption, ProfileOption, ShadowTestIDOption
+from nextmv.cli.options import AppIDOption, DebugOption, ProfileOption, ShadowTestIDOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -28,6 +28,7 @@ def get(
             metavar="OUTPUT_PATH",
         ),
     ] = None,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/shadow/list.py
+++ b/nextmv/nextmv/cli/cloud/shadow/list.py
@@ -9,7 +9,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import in_progress, print_json, success
-from nextmv.cli.options import AppIDOption, ProfileOption
+from nextmv.cli.options import AppIDOption, DebugOption, ProfileOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -27,6 +27,7 @@ def list(
             metavar="OUTPUT_PATH",
         ),
     ] = None,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/shadow/metadata.py
+++ b/nextmv/nextmv/cli/cloud/shadow/metadata.py
@@ -9,7 +9,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import in_progress, print_json, success
-from nextmv.cli.options import AppIDOption, ProfileOption, ShadowTestIDOption
+from nextmv.cli.options import AppIDOption, DebugOption, ProfileOption, ShadowTestIDOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -28,6 +28,7 @@ def metadata(
             metavar="OUTPUT_PATH",
         ),
     ] = None,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/shadow/start.py
+++ b/nextmv/nextmv/cli/cloud/shadow/start.py
@@ -6,7 +6,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import in_progress, success
-from nextmv.cli.options import AppIDOption, ProfileOption, ShadowTestIDOption
+from nextmv.cli.options import AppIDOption, DebugOption, ProfileOption, ShadowTestIDOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -16,6 +16,7 @@ app = typer.Typer()
 def start(
     app_id: AppIDOption,
     shadow_test_id: ShadowTestIDOption,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/shadow/stop.py
+++ b/nextmv/nextmv/cli/cloud/shadow/stop.py
@@ -8,7 +8,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import enum_values, in_progress, success
-from nextmv.cli.options import AppIDOption, ProfileOption, ShadowTestIDOption
+from nextmv.cli.options import AppIDOption, DebugOption, ProfileOption, ShadowTestIDOption
 from nextmv.cloud.shadow import StopIntent
 
 # Set up subcommand application.
@@ -28,6 +28,7 @@ def stop(
         ),
     ],
     shadow_test_id: ShadowTestIDOption,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/shadow/update.py
+++ b/nextmv/nextmv/cli/cloud/shadow/update.py
@@ -9,7 +9,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import in_progress, print_json, success
-from nextmv.cli.options import AppIDOption, ProfileOption, ShadowTestIDOption
+from nextmv.cli.options import AppIDOption, DebugOption, ProfileOption, ShadowTestIDOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -46,6 +46,7 @@ def update(
             metavar="OUTPUT_PATH",
         ),
     ] = None,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/sso/create.py
+++ b/nextmv/nextmv/cli/cloud/sso/create.py
@@ -8,7 +8,7 @@ from typing import Annotated
 import typer
 
 from nextmv.cli.message import in_progress, success
-from nextmv.cli.options import ProfileOption
+from nextmv.cli.options import DebugOption, ProfileOption
 from nextmv.cloud.client import Client
 from nextmv.cloud.sso import SSOConfiguration
 
@@ -53,6 +53,7 @@ def create(
             metavar="METADATA_DOCUMENT",
         ),
     ] = None,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/sso/delete.py
+++ b/nextmv/nextmv/cli/cloud/sso/delete.py
@@ -6,7 +6,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_sso_config
 from nextmv.cli.message import confirmation, info, success
-from nextmv.cli.options import ProfileOption, YesOption
+from nextmv.cli.options import DebugOption, ProfileOption, YesOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -15,6 +15,7 @@ app = typer.Typer()
 @app.command()
 def delete(
     yes: YesOption = False,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/sso/disable.py
+++ b/nextmv/nextmv/cli/cloud/sso/disable.py
@@ -8,7 +8,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_sso_config
 from nextmv.cli.message import confirmation, info, success
-from nextmv.cli.options import ProfileOption
+from nextmv.cli.options import DebugOption, ProfileOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -24,6 +24,7 @@ def disable(
             help="Agree to disable confirmation prompt. Useful for non-interactive sessions.",
         ),
     ] = False,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/sso/domain/delete.py
+++ b/nextmv/nextmv/cli/cloud/sso/domain/delete.py
@@ -8,7 +8,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_sso_config
 from nextmv.cli.message import confirmation, in_progress, info, success
-from nextmv.cli.options import ProfileOption, YesOption
+from nextmv.cli.options import DebugOption, ProfileOption, YesOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -26,6 +26,7 @@ def delete(
         ),
     ],
     yes: YesOption = False,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/sso/enable.py
+++ b/nextmv/nextmv/cli/cloud/sso/enable.py
@@ -8,7 +8,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_sso_config
 from nextmv.cli.message import confirmation, info, success
-from nextmv.cli.options import ProfileOption
+from nextmv.cli.options import DebugOption, ProfileOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -24,6 +24,7 @@ def enable(
             help="Agree to enable confirmation prompt. Useful for non-interactive sessions.",
         ),
     ] = False,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/sso/get.py
+++ b/nextmv/nextmv/cli/cloud/sso/get.py
@@ -8,7 +8,7 @@ from typing import Annotated
 import typer
 
 from nextmv.cli.message import in_progress, print_json, success
-from nextmv.cli.options import ProfileOption
+from nextmv.cli.options import DebugOption, ProfileOption
 from nextmv.cloud.client import Client
 from nextmv.cloud.sso import SSOConfiguration
 
@@ -27,6 +27,7 @@ def get(
             metavar="OUTPUT_PATH",
         ),
     ] = None,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/sso/update.py
+++ b/nextmv/nextmv/cli/cloud/sso/update.py
@@ -8,7 +8,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_sso_config
 from nextmv.cli.message import in_progress, success
-from nextmv.cli.options import ProfileOption
+from nextmv.cli.options import DebugOption, ProfileOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -34,6 +34,7 @@ def update(
             metavar="METADATA_DOCUMENT",
         ),
     ] = None,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/switchback/create.py
+++ b/nextmv/nextmv/cli/cloud/switchback/create.py
@@ -9,7 +9,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import in_progress, print_json
-from nextmv.cli.options import AppIDOption, ProfileOption
+from nextmv.cli.options import AppIDOption, DebugOption, ProfileOption
 from nextmv.cloud.switchback import TestComparisonSingle
 
 # Set up subcommand application.
@@ -98,6 +98,7 @@ def create(
             metavar="START",
         ),
     ] = None,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/switchback/delete.py
+++ b/nextmv/nextmv/cli/cloud/switchback/delete.py
@@ -6,7 +6,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import confirmation, info, success
-from nextmv.cli.options import AppIDOption, ProfileOption, SwitchbackTestIDOption, YesOption
+from nextmv.cli.options import AppIDOption, DebugOption, ProfileOption, SwitchbackTestIDOption, YesOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -17,6 +17,7 @@ def delete(
     app_id: AppIDOption,
     switchback_test_id: SwitchbackTestIDOption,
     yes: YesOption = False,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/switchback/get.py
+++ b/nextmv/nextmv/cli/cloud/switchback/get.py
@@ -9,7 +9,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import in_progress, print_json, success
-from nextmv.cli.options import AppIDOption, ProfileOption, SwitchbackTestIDOption
+from nextmv.cli.options import AppIDOption, DebugOption, ProfileOption, SwitchbackTestIDOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -28,6 +28,7 @@ def get(
             metavar="OUTPUT_PATH",
         ),
     ] = None,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/switchback/list.py
+++ b/nextmv/nextmv/cli/cloud/switchback/list.py
@@ -9,7 +9,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import in_progress, print_json, success
-from nextmv.cli.options import AppIDOption, ProfileOption
+from nextmv.cli.options import AppIDOption, DebugOption, ProfileOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -27,6 +27,7 @@ def list(
             metavar="OUTPUT_PATH",
         ),
     ] = None,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/switchback/metadata.py
+++ b/nextmv/nextmv/cli/cloud/switchback/metadata.py
@@ -9,7 +9,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import in_progress, print_json, success
-from nextmv.cli.options import AppIDOption, ProfileOption, SwitchbackTestIDOption
+from nextmv.cli.options import AppIDOption, DebugOption, ProfileOption, SwitchbackTestIDOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -28,6 +28,7 @@ def metadata(
             metavar="OUTPUT_PATH",
         ),
     ] = None,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/switchback/start.py
+++ b/nextmv/nextmv/cli/cloud/switchback/start.py
@@ -6,7 +6,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import in_progress, success
-from nextmv.cli.options import AppIDOption, ProfileOption, SwitchbackTestIDOption
+from nextmv.cli.options import AppIDOption, DebugOption, ProfileOption, SwitchbackTestIDOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -16,6 +16,7 @@ app = typer.Typer()
 def start(
     app_id: AppIDOption,
     switchback_test_id: SwitchbackTestIDOption,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/switchback/stop.py
+++ b/nextmv/nextmv/cli/cloud/switchback/stop.py
@@ -8,7 +8,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import enum_values, in_progress, success
-from nextmv.cli.options import AppIDOption, ProfileOption, SwitchbackTestIDOption
+from nextmv.cli.options import AppIDOption, DebugOption, ProfileOption, SwitchbackTestIDOption
 from nextmv.cloud.shadow import StopIntent
 
 # Set up subcommand application.
@@ -28,6 +28,7 @@ def stop(
         ),
     ],
     switchback_test_id: SwitchbackTestIDOption,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/switchback/update.py
+++ b/nextmv/nextmv/cli/cloud/switchback/update.py
@@ -9,7 +9,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import in_progress, print_json, success
-from nextmv.cli.options import AppIDOption, ProfileOption, SwitchbackTestIDOption
+from nextmv.cli.options import AppIDOption, DebugOption, ProfileOption, SwitchbackTestIDOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -46,6 +46,7 @@ def update(
             metavar="OUTPUT_PATH",
         ),
     ] = None,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/upload/create.py
+++ b/nextmv/nextmv/cli/cloud/upload/create.py
@@ -6,7 +6,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import in_progress, print_json, success
-from nextmv.cli.options import AppIDOption, ProfileOption
+from nextmv.cli.options import AppIDOption, DebugOption, ProfileOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -15,6 +15,7 @@ app = typer.Typer()
 @app.command()
 def create(
     app_id: AppIDOption,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/version/create.py
+++ b/nextmv/nextmv/cli/cloud/version/create.py
@@ -8,7 +8,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import in_progress, print_json
-from nextmv.cli.options import AppIDOption, ProfileOption
+from nextmv.cli.options import AppIDOption, DebugOption, ProfileOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -53,6 +53,7 @@ def create(
             metavar="VERSION_ID",
         ),
     ] = None,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/version/delete.py
+++ b/nextmv/nextmv/cli/cloud/version/delete.py
@@ -6,7 +6,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import confirmation, info, success
-from nextmv.cli.options import AppIDOption, ProfileOption, VersionIDOption, YesOption
+from nextmv.cli.options import AppIDOption, DebugOption, ProfileOption, VersionIDOption, YesOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -17,6 +17,7 @@ def delete(
     app_id: AppIDOption,
     version_id: VersionIDOption,
     yes: YesOption = False,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/version/exists.py
+++ b/nextmv/nextmv/cli/cloud/version/exists.py
@@ -6,7 +6,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import in_progress, print_json
-from nextmv.cli.options import AppIDOption, ProfileOption, VersionIDOption
+from nextmv.cli.options import AppIDOption, DebugOption, ProfileOption, VersionIDOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -16,6 +16,7 @@ app = typer.Typer()
 def exists(
     app_id: AppIDOption,
     version_id: VersionIDOption,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/version/get.py
+++ b/nextmv/nextmv/cli/cloud/version/get.py
@@ -9,7 +9,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import in_progress, print_json, success
-from nextmv.cli.options import AppIDOption, ProfileOption, VersionIDOption
+from nextmv.cli.options import AppIDOption, DebugOption, ProfileOption, VersionIDOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -28,6 +28,7 @@ def get(
             metavar="OUTPUT_PATH",
         ),
     ] = None,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/version/list.py
+++ b/nextmv/nextmv/cli/cloud/version/list.py
@@ -9,7 +9,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import in_progress, print_json, success
-from nextmv.cli.options import AppIDOption, ProfileOption
+from nextmv.cli.options import AppIDOption, DebugOption, ProfileOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -27,6 +27,7 @@ def list(
             metavar="OUTPUT_PATH",
         ),
     ] = None,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/cloud/version/update.py
+++ b/nextmv/nextmv/cli/cloud/version/update.py
@@ -9,7 +9,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_cloud_app
 from nextmv.cli.message import error, in_progress, print_json, success
-from nextmv.cli.options import AppIDOption, ProfileOption, VersionIDOption
+from nextmv.cli.options import AppIDOption, DebugOption, ProfileOption, VersionIDOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -46,6 +46,7 @@ def update(
             metavar="OUTPUT_PATH",
         ),
     ] = None,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/community/clone.py
+++ b/nextmv/nextmv/cli/community/clone.py
@@ -7,7 +7,7 @@ from typing import Annotated
 import typer
 
 from nextmv.cli.message import error
-from nextmv.cli.options import ProfileOption
+from nextmv.cli.options import DebugOption, ProfileOption
 from nextmv.cloud.client import Client
 from nextmv.cloud.community import clone_community_app
 
@@ -42,6 +42,7 @@ def clone(
             metavar="VERSION",
         ),
     ] = LATEST_VERSION,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/community/list.py
+++ b/nextmv/nextmv/cli/community/list.py
@@ -10,7 +10,7 @@ from rich.console import Console
 from rich.table import Table
 
 from nextmv.cli.message import error
-from nextmv.cli.options import ProfileOption
+from nextmv.cli.options import DebugOption, ProfileOption
 from nextmv.cloud.client import Client
 from nextmv.cloud.community import CommunityApp, list_community_apps
 
@@ -31,6 +31,7 @@ def list(
         ),
     ] = None,
     flat: Annotated[bool, typer.Option("--flat", "-f", help="Flatten the list output.")] = False,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/configuration/create.py
+++ b/nextmv/nextmv/cli/configuration/create.py
@@ -16,6 +16,7 @@ from nextmv.cli.configuration.config import (
     save_config,
 )
 from nextmv.cli.message import error, message, success, warning
+from nextmv.cli.options import DebugOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -54,6 +55,7 @@ def create(
             metavar="PROFILE_NAME",
         ),
     ] = None,
+    _: DebugOption = False,
 ) -> None:
     """
     Create a new configuration or update an existing one.

--- a/nextmv/nextmv/cli/configuration/delete.py
+++ b/nextmv/nextmv/cli/configuration/delete.py
@@ -8,7 +8,7 @@ import typer
 
 from nextmv.cli.configuration.config import load_config, save_config
 from nextmv.cli.message import confirmation, error, info, success
-from nextmv.cli.options import YesOption
+from nextmv.cli.options import DebugOption, YesOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -27,6 +27,7 @@ def delete(
         ),
     ],
     yes: YesOption = False,
+    _: DebugOption = False,
 ) -> None:
     """
     Delete a profile from the configuration.

--- a/nextmv/nextmv/cli/configuration/list.py
+++ b/nextmv/nextmv/cli/configuration/list.py
@@ -8,6 +8,7 @@ from rich.table import Table
 
 from nextmv.cli.configuration.config import API_KEY_KEY, ENDPOINT_KEY, load_config, non_profile_keys, obscure_api_key
 from nextmv.cli.message import error
+from nextmv.cli.options import DebugOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -15,7 +16,7 @@ console = Console()
 
 
 @app.command()
-def list() -> None:
+def list(_: DebugOption = False) -> None:
     """
     List the current configuration and all profiles.
 

--- a/nextmv/nextmv/cli/init.py
+++ b/nextmv/nextmv/cli/init.py
@@ -19,6 +19,7 @@ from nextmv import cloud, local
 from nextmv.cli.cloud.app.push import handle_push
 from nextmv.cli.configuration.config import build_cloud_app, load_config, obscure_api_key
 from nextmv.cli.message import choice, confirmation, directory_path, error, in_progress, info, message, rule, success
+from nextmv.cli.options import DebugOption
 from nextmv.cloud.community import _get_valid_path
 from nextmv.content_format import ContentFormat
 from nextmv.manifest import ManifestType, initialize_manifest
@@ -52,7 +53,7 @@ class ExecutedCommand:
 
 
 @app.command()
-def init() -> None:
+def init(_: DebugOption = False) -> None:
     """
     Get started with the Nextmv CLI.
 

--- a/nextmv/nextmv/cli/local/app/delete.py
+++ b/nextmv/nextmv/cli/local/app/delete.py
@@ -7,7 +7,7 @@ import os
 import typer
 
 from nextmv.cli.message import confirmation, info, success, warning
-from nextmv.cli.options import LocalAppIDOption, LocalAppSrcOption, YesOption
+from nextmv.cli.options import DebugOption, LocalAppIDOption, LocalAppSrcOption, YesOption
 from nextmv.local.registry import Registry
 
 # Set up subcommand application.
@@ -19,6 +19,7 @@ def delete(
     app_id: LocalAppIDOption = None,
     app_src: LocalAppSrcOption = None,
     yes: YesOption = False,
+    _: DebugOption = False,
 ) -> None:
     """
     Deletes a Nextmv application from the local registry.

--- a/nextmv/nextmv/cli/local/app/get.py
+++ b/nextmv/nextmv/cli/local/app/get.py
@@ -9,7 +9,7 @@ from typing import Annotated
 import typer
 
 from nextmv.cli.message import in_progress, print_json, success, warning
-from nextmv.cli.options import LocalAppIDOption, LocalAppSrcOption
+from nextmv.cli.options import DebugOption, LocalAppIDOption, LocalAppSrcOption
 from nextmv.local.application import Application
 from nextmv.local.registry import Registry
 
@@ -30,6 +30,7 @@ def get(
             metavar="OUTPUT_PATH",
         ),
     ] = None,
+    _: DebugOption = False,
 ) -> None:
     """
     Get a registered local Nextmv application.

--- a/nextmv/nextmv/cli/local/app/list.py
+++ b/nextmv/nextmv/cli/local/app/list.py
@@ -8,6 +8,7 @@ from typing import Annotated
 import typer
 
 from nextmv.cli.message import in_progress, print_json, success
+from nextmv.cli.options import DebugOption
 from nextmv.local.registry import Registry
 
 # Set up subcommand application.
@@ -25,6 +26,7 @@ def list(
             metavar="OUTPUT_PATH",
         ),
     ] = None,
+    _: DebugOption = False,
 ) -> None:
     """
     List all local registered Nextmv applications.

--- a/nextmv/nextmv/cli/local/app/register.py
+++ b/nextmv/nextmv/cli/local/app/register.py
@@ -9,7 +9,7 @@ from typing import Annotated
 import typer
 
 from nextmv.cli.message import in_progress, print_json, success
-from nextmv.cli.options import LocalAppIDOption, LocalAppSrcOption
+from nextmv.cli.options import DebugOption, LocalAppIDOption, LocalAppSrcOption
 from nextmv.local.registry import Registry
 
 # Set up subcommand application.
@@ -38,6 +38,7 @@ def register(
             metavar="OUTPUT_PATH",
         ),
     ] = None,
+    _: DebugOption = False,
 ) -> None:
     """
     Register a local Nextmv application.

--- a/nextmv/nextmv/cli/local/app/registered.py
+++ b/nextmv/nextmv/cli/local/app/registered.py
@@ -7,7 +7,7 @@ import os
 import typer
 
 from nextmv.cli.message import in_progress, print_json
-from nextmv.cli.options import LocalAppIDOption, LocalAppSrcOption
+from nextmv.cli.options import DebugOption, LocalAppIDOption, LocalAppSrcOption
 from nextmv.local.registry import Registry
 
 # Set up subcommand application.
@@ -18,6 +18,7 @@ app = typer.Typer()
 def registered(
     app_id: LocalAppIDOption = None,
     app_src: LocalAppSrcOption = None,
+    _: DebugOption = False,
 ) -> None:
     """
     Check if a Nextmv application is registered locally.

--- a/nextmv/nextmv/cli/local/app/sync.py
+++ b/nextmv/nextmv/cli/local/app/sync.py
@@ -9,7 +9,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_cloud_app, build_local_app
 from nextmv.cli.message import in_progress
-from nextmv.cli.options import LocalAppIDOption, LocalAppSrcOption, ProfileOption
+from nextmv.cli.options import DebugOption, LocalAppIDOption, LocalAppSrcOption, ProfileOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -47,6 +47,7 @@ def sync(
             metavar="RUN_IDS",
         ),
     ] = None,
+    _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
     """

--- a/nextmv/nextmv/cli/local/app/update.py
+++ b/nextmv/nextmv/cli/local/app/update.py
@@ -10,7 +10,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_local_app
 from nextmv.cli.message import in_progress, print_json, success
-from nextmv.cli.options import LocalAppIDOption, LocalAppSrcOption
+from nextmv.cli.options import DebugOption, LocalAppIDOption, LocalAppSrcOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -47,6 +47,7 @@ def update(
             metavar="OUTPUT_PATH",
         ),
     ] = None,
+    _: DebugOption = False,
 ) -> None:
     """
     Update a registered local Nextmv application.

--- a/nextmv/nextmv/cli/local/run/clone.py
+++ b/nextmv/nextmv/cli/local/run/clone.py
@@ -12,7 +12,7 @@ from nextmv.cli.local.run.create import build_run_options, resolve_input_kwarg
 from nextmv.cli.local.run.get import handle_outputs
 from nextmv.cli.local.run.logs import handle_logs
 from nextmv.cli.message import enum_values, parse_content_format, print_json, success
-from nextmv.cli.options import LocalAppIDOption, LocalAppSrcOption
+from nextmv.cli.options import DebugOption, LocalAppIDOption, LocalAppSrcOption
 from nextmv.content_format import ContentFormat
 from nextmv.input import InputFormat
 from nextmv.polling import default_polling_options
@@ -140,6 +140,7 @@ def clone(
             rich_help_panel="Run configuration",
         ),
     ] = -1,
+    _: DebugOption = False,
 ) -> None:
     """
     Clone an existing local application run.

--- a/nextmv/nextmv/cli/local/run/create.py
+++ b/nextmv/nextmv/cli/local/run/create.py
@@ -13,7 +13,7 @@ from nextmv.cli.configuration.config import build_local_app
 from nextmv.cli.local.run.get import handle_outputs
 from nextmv.cli.local.run.logs import handle_logs
 from nextmv.cli.message import enum_values, error, parse_content_format, print_json, success
-from nextmv.cli.options import LocalAppIDOption, LocalAppSrcOption
+from nextmv.cli.options import DebugOption, LocalAppIDOption, LocalAppSrcOption
 from nextmv.content_format import ContentFormat
 from nextmv.input import InputFormat
 from nextmv.polling import default_polling_options
@@ -131,6 +131,7 @@ def create(
             rich_help_panel="Run configuration",
         ),
     ] = -1,
+    _: DebugOption = False,
 ) -> None:
     """
     Create a new local application run.

--- a/nextmv/nextmv/cli/local/run/get.py
+++ b/nextmv/nextmv/cli/local/run/get.py
@@ -10,7 +10,7 @@ import typer
 from nextmv import local
 from nextmv.cli.configuration.config import build_local_app
 from nextmv.cli.message import in_progress, info, print_json, success, warning
-from nextmv.cli.options import LocalAppIDOption, LocalAppSrcOption, RunIDOption
+from nextmv.cli.options import DebugOption, LocalAppIDOption, LocalAppSrcOption, RunIDOption
 from nextmv.content_format import ContentFormat
 from nextmv.polling import PollingOptions, default_polling_options
 from nextmv.status import StatusV2
@@ -51,6 +51,7 @@ def get(
             "Specify output location with --output.",
         ),
     ] = False,
+    _: DebugOption = False,
 ) -> None:
     """
     Get the result (output) of a Nextmv local application run.

--- a/nextmv/nextmv/cli/local/run/information.py
+++ b/nextmv/nextmv/cli/local/run/information.py
@@ -9,7 +9,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_local_app
 from nextmv.cli.message import in_progress, print_json, success
-from nextmv.cli.options import LocalAppIDOption, LocalAppSrcOption, RunIDOption
+from nextmv.cli.options import DebugOption, LocalAppIDOption, LocalAppSrcOption, RunIDOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -29,6 +29,7 @@ def information(
             metavar="OUTPUT_PATH",
         ),
     ] = None,
+    _: DebugOption = False,
 ) -> None:
     """
     Get the information of a Nextmv local application run.

--- a/nextmv/nextmv/cli/local/run/input.py
+++ b/nextmv/nextmv/cli/local/run/input.py
@@ -9,7 +9,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_local_app
 from nextmv.cli.message import in_progress, print_json, success
-from nextmv.cli.options import LocalAppIDOption, LocalAppSrcOption, ProfileOption, RunIDOption
+from nextmv.cli.options import DebugOption, LocalAppIDOption, LocalAppSrcOption, RunIDOption
 from nextmv.content_format import ContentFormat
 
 # Set up subcommand application.
@@ -30,7 +30,7 @@ def input(
             metavar="OUTPUT_PATH",
         ),
     ] = None,
-    profile: ProfileOption = None,
+    _: DebugOption = False,
 ) -> None:
     """
     Get the input of a local application run.

--- a/nextmv/nextmv/cli/local/run/list.py
+++ b/nextmv/nextmv/cli/local/run/list.py
@@ -9,7 +9,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_local_app
 from nextmv.cli.message import enum_values, in_progress, print_json, success
-from nextmv.cli.options import LocalAppIDOption, LocalAppSrcOption
+from nextmv.cli.options import DebugOption, LocalAppIDOption, LocalAppSrcOption
 from nextmv.status import StatusV2
 
 # Set up subcommand application.
@@ -38,6 +38,7 @@ def list(
             metavar="STATUS",
         ),
     ] = None,
+    _: DebugOption = False,
 ) -> None:
     """
     Get the list of runs for a Nextmv local application.

--- a/nextmv/nextmv/cli/local/run/logs.py
+++ b/nextmv/nextmv/cli/local/run/logs.py
@@ -11,7 +11,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_local_app
 from nextmv.cli.message import in_progress, success
-from nextmv.cli.options import LocalAppIDOption, LocalAppSrcOption, RunIDOption
+from nextmv.cli.options import DebugOption, LocalAppIDOption, LocalAppSrcOption, RunIDOption
 from nextmv.local.application import Application
 from nextmv.polling import PollingOptions, default_polling_options
 
@@ -49,6 +49,7 @@ def logs(
             metavar="TIMEOUT_SECONDS",
         ),
     ] = -1,
+    _: DebugOption = False,
 ) -> None:
     """
     Get the logs of a local application run.

--- a/nextmv/nextmv/cli/local/run/metadata.py
+++ b/nextmv/nextmv/cli/local/run/metadata.py
@@ -9,7 +9,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_local_app
 from nextmv.cli.message import in_progress, print_json, success, warning
-from nextmv.cli.options import LocalAppIDOption, LocalAppSrcOption, RunIDOption
+from nextmv.cli.options import DebugOption, LocalAppIDOption, LocalAppSrcOption, RunIDOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -29,6 +29,7 @@ def metadata(
             metavar="OUTPUT_PATH",
         ),
     ] = None,
+    _: DebugOption = False,
 ) -> None:
     """
     This command is deprecated, use [code]nextmv local run information[/code] instead.

--- a/nextmv/nextmv/cli/local/run/visuals.py
+++ b/nextmv/nextmv/cli/local/run/visuals.py
@@ -6,7 +6,7 @@ import typer
 
 from nextmv.cli.configuration.config import build_local_app
 from nextmv.cli.message import in_progress, print_json, success
-from nextmv.cli.options import LocalAppIDOption, LocalAppSrcOption, RunIDOption
+from nextmv.cli.options import DebugOption, LocalAppIDOption, LocalAppSrcOption, RunIDOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -17,6 +17,7 @@ def visuals(
     run_id: RunIDOption,
     app_id: LocalAppIDOption = None,
     app_src: LocalAppSrcOption = ".",
+    _: DebugOption = False,
 ) -> None:
     """
     Get the visuals of a Nextmv local application run.

--- a/nextmv/nextmv/cli/main.py
+++ b/nextmv/nextmv/cli/main.py
@@ -20,7 +20,7 @@ import sys
 import warnings
 from typing import Annotated
 
-import rich
+import requests
 import typer
 from typer import rich_utils
 
@@ -268,7 +268,7 @@ def _remove_go_cli() -> None:
         success(f"Deleted [italic red]deprecated[/italic red] [magenta]{GO_CLI_PATH}[/magenta].")
 
 
-def setup_encoding() -> None:
+def _setup_encoding() -> None:
     """
     Configure UTF-8 encoding for Windows platforms to make sure emojis and rich text do
     not cause encoding errors.
@@ -300,6 +300,47 @@ def setup_encoding() -> None:
             pass
 
 
+def _handle_http_exception(e: requests.HTTPError) -> None:
+    """
+    Handle HTTP exceptions by showing user-friendly error messages based on the
+    status code.
+
+    Parameters
+    ----------
+    e : requests.HTTPError
+        The HTTP error to handle.
+    """
+    if e.response.status_code == 401:
+        # This means that you are authenticated and your role gives you
+        # permission to access, but you fail an additional check like a
+        # paid account check.
+        error(
+            msg="You are not authorized to perform this action. "
+            "Please contact [link=https://www.nextmv.io/contact][bold]Nextmv support[/bold][/link].",
+            should_exit=False,
+        )
+    elif e.response.status_code == 403:
+        # Can mean one of two things: either you are not authenticated, or
+        # your role does not permit you to perform the action.
+        error(msg="You are not authorized or do not have permission to perform this action.", should_exit=False)
+    elif e.response.status_code == 400:
+        # This means that the request was malformed. The error message from
+        # the server should give more details on what was wrong with the
+        # request.
+        error(msg=f"You made a bad request: {e.response.text}", should_exit=False)
+    elif e.response.status_code == 404:
+        error(msg="The requested resource was not found. It may have been deleted.", should_exit=False)
+    elif e.response.status_code == 429:
+        error(msg="You have hit a rate limit. Please wait a moment before trying again.", should_exit=False)
+    elif e.response.status_code >= 500:
+        error(msg="There was an unexpected error in Nextmv Cloud. Please try again later.", should_exit=False)
+    else:
+        error(msg=str(e).rstrip("\n"), should_exit=False)
+
+    # Exit here to avoid printing more of the traceback.
+    sys.exit(1)
+
+
 def main() -> None:
     """
     Entry point for the CLI with global exception handling.
@@ -309,7 +350,7 @@ def main() -> None:
     """
 
     # Improve compatibility with Windows terminals.
-    setup_encoding()
+    _setup_encoding()
 
     # Suppress SDK-level DeprecationWarnings so only CLI warnings are shown.
     warnings.filterwarnings("ignore", category=NextmvDeprecationWarning)
@@ -319,35 +360,41 @@ def main() -> None:
     # distributions.
     if len(sys.argv) > 1 and sys.argv[1] == "--run-script":
         if len(sys.argv) < 3:
-            rich.print("[red]Error:[/red] --run-script requires a script path.", file=sys.stderr)
+            error("--run-script requires a script path.", should_exit=False)
             sys.exit(1)
+
         script_path = sys.argv[2]
         sys.argv = sys.argv[2:]  # script becomes argv[0]; its own args follow
         runpy.run_path(script_path, run_name="__main__")
         sys.exit(0)
     elif len(sys.argv) > 1 and sys.argv[1] == "--run-uv":
         if len(sys.argv) < 3:
-            rich.print("[red]Error:[/red] --run-uv requires arguments for 'uv run'.", file=sys.stderr)
+            error("--run-uv requires arguments for 'uv run'.", should_exit=False)
             sys.exit(1)
+
         uv_bin = _find_uv_binary()
         uv_args = [uv_bin, "run"] + sys.argv[2:]
         os.execv(uv_bin, uv_args)
 
     # This is where we actually launch the CLI (the Typer app defined above).
-    # We wrap it in a try-except block to catch any exceptions and print a
-    # clean error message.
+    # If debug mode is active, we want to print the raw Python traceback for
+    # easier debugging. Otherwise, we catch exceptions and process them to
+    # print out nice error messages.
+    should_debug = "--debug" in sys.argv
+    if should_debug:
+        app()
+        return
+
     try:
         app()
+    # Capture "special" HTTP errors to enrich them.
+    except requests.HTTPError as e:
+        _handle_http_exception(e)
     except (typer.Exit, typer.Abort, SystemExit):
         raise
     except Exception as e:
-        # We do not use the messages.error function here because doing so would
-        # raise a Typer exception, which would print a traceback.
-        msg = str(e).rstrip("\n")
-        if not msg.endswith("."):
-            msg += "."
-
-        rich.print(f"[red]Error:[/red] {msg}", file=sys.stderr)
+        # We do not exit to avoid a Typer exception, which would print a traceback.
+        error(msg=str(e).rstrip("\n"), should_exit=False)
         sys.exit(1)
 
 

--- a/nextmv/nextmv/cli/manifest/init.py
+++ b/nextmv/nextmv/cli/manifest/init.py
@@ -8,6 +8,7 @@ import questionary
 import typer
 
 from nextmv.cli.message import choice, confirmation, directory_path, enum_values, error, parse_content_format, success
+from nextmv.cli.options import DebugOption
 from nextmv.content_format import ContentFormat
 from nextmv.input import InputFormat
 from nextmv.manifest import ManifestType, initialize_manifest
@@ -63,6 +64,7 @@ def init(
             help="Do not add options (parameters) to the manifest. Useful for non-interactive sessions.",
         ),
     ] = None,
+    _: DebugOption = False,
 ) -> None:
     """
     Initialize an [magenta]app.yaml[/magenta] (app manifest) file.

--- a/nextmv/nextmv/cli/manifest/validate.py
+++ b/nextmv/nextmv/cli/manifest/validate.py
@@ -7,6 +7,7 @@ from typing import Annotated
 import typer
 
 from nextmv.cli.message import error, success
+from nextmv.cli.options import DebugOption
 from nextmv.manifest import MANIFEST_FILE_NAME, Manifest
 
 # Set up subcommand application.
@@ -24,6 +25,7 @@ def validate(
             metavar="DIRPATH",
         ),
     ] = ".",
+    _: DebugOption = False,
 ) -> None:
     """
     Validate an [magenta]app.yaml[/magenta] (app manifest) file.

--- a/nextmv/nextmv/cli/mcp/serve.py
+++ b/nextmv/nextmv/cli/mcp/serve.py
@@ -6,6 +6,7 @@ import typer
 
 from nextmv.cli.mcp.server import create_server
 from nextmv.cli.message import error
+from nextmv.cli.options import DebugOption
 
 # Set up subcommand application.
 app = typer.Typer()
@@ -26,11 +27,11 @@ def serve(
         typer.Option(
             "--transport",
             "-t",
-            help="Transport protocol. "
-            "Allowed values: [magenta]stdio[/magenta], [magenta]streamable-http[/magenta].",
+            help="Transport protocol. Allowed values: [magenta]stdio[/magenta], [magenta]streamable-http[/magenta].",
             metavar="TRANSPORT",
         ),
     ] = "stdio",
+    _: DebugOption = False,
 ) -> None:
     """
     Start the Nextmv MCP server.

--- a/nextmv/nextmv/cli/message.py
+++ b/nextmv/nextmv/cli/message.py
@@ -122,27 +122,30 @@ def warning(msg: str) -> None:
     console.print(f":construction: [yellow] Warning:[/yellow] {msg}")
 
 
-def error(msg: str) -> None:
+def error(msg: str, should_exit: bool = True) -> None:
     """
-    Pretty-print an error message and exit with code 1. Your message should end
+    Pretty-print an error message and optionally exit with code 1. Your message should end
     with a period.
 
     Parameters
     ----------
     msg : str
         The error message to display.
+    should_exit : bool, optional
+        Whether to exit the program with code 1. Default is True.
 
     Raises
     ------
     typer.Exit
-        Exits the program with code 1.
+        Exits the program with code 1 if `should_exit` is True.
     """
 
     msg = _format(msg)
     console = Console(file=sys.stderr, highlight=False)
     console.print(f":x: [red]Error:[/red] {msg}")
 
-    raise typer.Exit(code=1)
+    if should_exit:
+        raise typer.Exit(code=1)
 
 
 def print_json(data: dict[str, Any] | list[dict[str, Any]]) -> None:

--- a/nextmv/nextmv/cli/options.py
+++ b/nextmv/nextmv/cli/options.py
@@ -316,3 +316,14 @@ YesOption = Annotated[
         help="Agree to deletion confirmation prompt. Useful for non-interactive sessions.",
     ),
 ]
+
+# debug option - can be used in any command to enable debug mode.
+# Define it as follows in commands or callbacks, as necessary:
+# _: DebugOption = False,
+DebugOption = Annotated[
+    bool,
+    typer.Option(
+        "--debug",
+        help="Enable debug mode, which will print out the full traceback in case of errors.",
+    ),
+]

--- a/nextmv/nextmv/cli/options.py
+++ b/nextmv/nextmv/cli/options.py
@@ -20,6 +20,7 @@ ProfileOption = Annotated[
         help="Profile to use for this action. Use [code]nextmv configuration[/code] to manage profiles.",
         envvar="NEXTMV_PROFILE",
         metavar="PROFILE_NAME",
+        rich_help_panel="General",
     ),
 ]
 
@@ -325,5 +326,6 @@ DebugOption = Annotated[
     typer.Option(
         "--debug",
         help="Enable debug mode, which will print out the full traceback in case of errors.",
+        rich_help_panel="General",
     ),
 ]

--- a/nextmv/nextmv/cli/version.py
+++ b/nextmv/nextmv/cli/version.py
@@ -5,13 +5,14 @@ This module defines the version command for the Nextmv CLI.
 import typer
 
 from nextmv.__about__ import __version__
+from nextmv.cli.options import DebugOption
 
 # Set up subcommand application.
 app = typer.Typer()
 
 
 @app.command()
-def version() -> None:
+def version(_: DebugOption = False) -> None:
     """
     Show the current version of the Nextmv CLI.
 

--- a/nextmv/nextmv/cloud/client.py
+++ b/nextmv/nextmv/cloud/client.py
@@ -445,9 +445,12 @@ class Client:
         try:
             response.raise_for_status()
         except requests.HTTPError as e:
-            raise requests.HTTPError(
+            err = requests.HTTPError(
                 f"request to {endpoint} failed with status code {response.status_code} and message: {response.text}"
-            ) from e
+            )
+            err.response = response
+
+            raise err from e
 
         return response
 
@@ -568,10 +571,12 @@ class Client:
         try:
             response.raise_for_status()
         except requests.HTTPError as e:
-            raise requests.HTTPError(
+            err = requests.HTTPError(
                 f"upload to presigned URL {url} failed with "
                 f"status code {response.status_code} and message: {response.text}"
-            ) from e
+            )
+            err.response = response
+            raise err from e
 
     def __resolve_profile(self) -> str | None:
         """


### PR DESCRIPTION
# Description

- Catch HTTP exceptions and display some nice error messages.
- Creates the `--debug` option and adds it to every command. When this option is used, we don't pretty-print errors, but rather dump the entire Python traceback so that it is easy to spot the bug.

