### PR TITLE
Enables run comparison in the SDK and CLI, for both `cloud` and `local`

### DIFF
--- a/nextmv/nextmv/__init__.py
+++ b/nextmv/nextmv/__init__.py
@@ -58,6 +58,7 @@ from .polling import DEFAULT_POLLING_OPTIONS as DEFAULT_POLLING_OPTIONS
 from .polling import PollingOptions as PollingOptions
 from .polling import default_polling_options as default_polling_options
 from .polling import poll as poll
+from .run import ComparisonValues as ComparisonValues
 from .run import ErrorLog as ErrorLog
 from .run import ExternalRunResult as ExternalRunResult
 from .run import Format as Format
@@ -68,6 +69,7 @@ from .run import MetricsIndicator as MetricsIndicator
 from .run import OptionsSummaryItem as OptionsSummaryItem
 from .run import OptionSummary as OptionSummary
 from .run import Run as Run
+from .run import RunComparison as RunComparison
 from .run import RunConfiguration as RunConfiguration
 from .run import RunInfoMetrics as RunInfoMetrics
 from .run import RunInformation as RunInformation

--- a/nextmv/nextmv/cli/cloud/run/__init__.py
+++ b/nextmv/nextmv/cli/cloud/run/__init__.py
@@ -6,6 +6,7 @@ import typer
 
 from nextmv.cli.cloud.run.cancel import app as cancel_app
 from nextmv.cli.cloud.run.clone import app as clone_app
+from nextmv.cli.cloud.run.compare import app as compare_app
 from nextmv.cli.cloud.run.create import app as create_app
 from nextmv.cli.cloud.run.delete import app as delete_app
 from nextmv.cli.cloud.run.get import app as get_app
@@ -20,6 +21,7 @@ from nextmv.cli.cloud.run.track import app as track_app
 app = typer.Typer()
 app.add_typer(cancel_app)
 app.add_typer(clone_app)
+app.add_typer(compare_app)
 app.add_typer(create_app)
 app.add_typer(delete_app)
 app.add_typer(get_app)

--- a/nextmv/nextmv/cli/cloud/run/compare.py
+++ b/nextmv/nextmv/cli/cloud/run/compare.py
@@ -27,8 +27,7 @@ def compare(
         typer.Option(
             "--run-ids",
             "-r",
-            help="List of run IDs to compare (max 20). "
-            "Pass multiple run IDs by repeating the flag, or separating with commas.",
+            help="List of run IDs to compare. Pass multiple run IDs by repeating the flag, or separating with commas.",
             metavar="RUN_IDS",
         ),
     ],
@@ -55,13 +54,11 @@ def compare(
     """
     Compare multiple Nextmv Cloud application runs.
 
-    The number of run IDs provided through the --run-ids flag must be between
-    [magenta]1[/magenta] and [magenta]20[/magenta]. By default this command
-    prints a human-readable table to [magenta]stdout[/magenta]. You may use the
-    --flat option to print the comparison result to [magenta]stdout[/magenta]
-    as [magenta]json[/magenta] instead. When the --output option is used, the
-    --flat flag is automatically activated and the result is saved as
-    [magenta]json[/magenta].
+    By default this command prints a human-readable table to
+    [magenta]stdout[/magenta]. You may use the --flat option to print the
+    comparison result to [magenta]stdout[/magenta] as [magenta]json[/magenta]
+    instead. When the --output option is used, the --flat flag is automatically
+    activated and the result is saved as [magenta]json[/magenta].
 
     [bold][underline]Examples[/underline][/bold]
 
@@ -86,9 +83,6 @@ def compare(
         sub_ids = run_id.split(",")
         for sub_id in sub_ids:
             run_id_list.append(sub_id.strip())
-
-    if len(run_id_list) < 1 or len(run_id_list) > 20:
-        error("The number of run IDs to compare must be between [magenta]1[/magenta] and [magenta]20[/magenta].")
 
     found = set()
     for run_id in run_id_list:

--- a/nextmv/nextmv/cli/cloud/run/compare.py
+++ b/nextmv/nextmv/cli/cloud/run/compare.py
@@ -1,0 +1,219 @@
+"""
+This module defines the cloud run compare command for the Nextmv CLI.
+"""
+
+import json
+from typing import Annotated
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from nextmv.cli.configuration.config import build_cloud_app
+from nextmv.cli.message import error, in_progress, print_json, rule, success
+from nextmv.cli.options import AppIDOption, DebugOption, ProfileOption
+from nextmv.run import RunComparison
+
+# Set up subcommand application.
+app = typer.Typer()
+console = Console()
+
+
+@app.command()
+def compare(
+    app_id: AppIDOption,
+    run_ids: Annotated[
+        list[str],
+        typer.Option(
+            "--run-ids",
+            "-r",
+            help="List of run IDs to compare (max 20). "
+            "Pass multiple run IDs by repeating the flag, or separating with commas.",
+            metavar="RUN_IDS",
+        ),
+    ],
+    flat: Annotated[
+        bool,
+        typer.Option(
+            "--flat",
+            "-f",
+            help="Print the comparison result as [magenta]json[/magenta], instead of a table.",
+        ),
+    ] = False,
+    output: Annotated[
+        str | None,
+        typer.Option(
+            "--output",
+            "-o",
+            help="Saves the comparison result to this location. Activates the --flat option.",
+            metavar="OUTPUT_PATH",
+        ),
+    ] = None,
+    _: DebugOption = False,
+    profile: ProfileOption = None,
+) -> None:
+    """
+    Compare multiple Nextmv Cloud application runs.
+
+    The number of run IDs provided through the --run-ids flag must be between
+    [magenta]1[/magenta] and [magenta]20[/magenta]. By default this command
+    prints a human-readable table to [magenta]stdout[/magenta]. You may use the
+    --flat option to print the comparison result to [magenta]stdout[/magenta]
+    as [magenta]json[/magenta] instead. When the --output option is used, the
+    --flat flag is automatically activated and the result is saved as
+    [magenta]json[/magenta].
+
+    [bold][underline]Examples[/underline][/bold]
+
+    - Compare two runs belonging to an app with ID [magenta]hare-app[/magenta]
+      repeating the --run-ids flag.
+        $ [dim]nextmv cloud run compare --app-id hare-app --run-ids fluff --run-ids white[/dim]
+
+    - Compare three runs belonging to an app with ID [magenta]hare-app[/magenta]
+      separating the run IDs with commas.
+        $ [dim]nextmv cloud run compare --app-id hare-app --run-ids fluff,white,thumper[/dim]
+
+    - Compare two runs and print the result as [magenta]json[/magenta].
+        $ [dim]nextmv cloud run compare --app-id hare-app --run-ids fluff,white --flat[/dim]
+
+    - Compare two runs and save the result to a file named [magenta]comparison.json[/magenta].
+        $ [dim]nextmv cloud run compare --app-id hare-app --run-ids fluff,white --output comparison.json[/dim]
+    """
+
+    # Parse the run IDs to gather the final list.
+    run_id_list = []
+    for run_id in run_ids:
+        sub_ids = run_id.split(",")
+        for sub_id in sub_ids:
+            run_id_list.append(sub_id.strip())
+
+    if len(run_id_list) < 1 or len(run_id_list) > 20:
+        error("The number of run IDs to compare must be between [magenta]1[/magenta] and [magenta]20[/magenta].")
+
+    found = set()
+    for run_id in run_id_list:
+        if run_id in found:
+            error(f"Duplicate run ID found: [magenta]{run_id}[/magenta]. Please provide unique run IDs for comparison.")
+
+        found.add(run_id)
+
+    cloud_app, _ = build_cloud_app(app_id=app_id, profile=profile)
+    in_progress(msg="Comparing runs...")
+    comparison = cloud_app.compare_runs(run_ids=run_id_list)
+    comparison_dict = comparison.to_flat_dict()
+
+    if output is not None and output != "":
+        with open(output, "w") as f:
+            json.dump(comparison_dict, f, indent=2)
+
+        success(msg=f"Run comparison saved to [magenta]{output}[/magenta].")
+
+        return
+
+    if flat:
+        print_json(comparison_dict)
+        return
+
+    _print_table(comparison)
+
+
+def _print_table(comparison: RunComparison) -> None:
+    """
+    Auxiliary function to handle the printing of the comparison result as
+    tables. This mostly orchestrates calling tables for different elements of
+    the comparison.
+
+    Parameters
+    ----------
+    comparison: RunComparison
+        The object containing the results of the run comparison.
+    """
+
+    table_styling_kwargs = {
+        "border_style": "cyan",
+        "header_style": "cyan",
+        "title_style": "magenta bold",
+        "title_justify": "left",
+    }
+
+    _print_comparison_table(
+        title="Information",
+        first_column="Field",
+        run_ids=comparison.run_ids,
+        data=comparison.information,
+        table_styling_kwargs=table_styling_kwargs,
+        highlight_differences=False,
+    )
+
+    _print_comparison_table(
+        title="Metadata",
+        first_column="Field",
+        run_ids=comparison.run_ids,
+        data=comparison.metadata,
+        table_styling_kwargs=table_styling_kwargs,
+    )
+
+    if comparison.metrics:
+        _print_comparison_table(
+            title="Metrics",
+            first_column="Metric",
+            run_ids=comparison.run_ids,
+            data=comparison.metrics,
+            table_styling_kwargs=table_styling_kwargs,
+        )
+
+    if comparison.options:
+        _print_comparison_table(
+            title="Options",
+            first_column="Option",
+            run_ids=comparison.run_ids,
+            data=comparison.options,
+            table_styling_kwargs=table_styling_kwargs,
+        )
+
+
+def _print_comparison_table(
+    title: str,
+    first_column: str,
+    run_ids: list[str],
+    data: dict,
+    table_styling_kwargs: dict,
+    highlight_differences: bool = True,
+) -> None:
+    """
+    Auxiliary function to print a specific section of the comparison result as
+    a table.
+
+    Parameters
+    ----------
+    title: str
+        The title of the table to be printed.
+    first_column: str
+        The name of the first column of the table, which contains the name of
+        the field/metric/option being compared.
+    run_ids: list[str]
+        The list of run IDs being compared. This is used to print the values of
+        each field/metric/option for each run in the correct order.
+    data: dict
+        The actual data to be printed in the table. This is a dictionary where
+        the keys are the names of the fields/metrics/options being compared,
+        and the values are ComparisonValues objects that contain the values for
+        each run and whether there are differences across runs.
+    table_styling_kwargs: dict
+        A dictionary containing styling options for the table, such as border style, header style, title style, etc.
+    highlight_differences: bool
+        Whether to highlight rows with differences across runs.
+    """
+
+    table = Table(first_column, *run_ids, title=title, **table_styling_kwargs)
+
+    for field, comp_values in data.items():
+        style_kwargs = {"style": "italic yellow"} if highlight_differences and comp_values.has_differences else {}
+        table.add_row(
+            field,
+            *[str(comp_values.values.get(run_id, "")) for run_id in run_ids],
+            **style_kwargs,
+        )
+
+    rule()
+    console.print(table)

--- a/nextmv/nextmv/cli/local/run/__init__.py
+++ b/nextmv/nextmv/cli/local/run/__init__.py
@@ -5,6 +5,7 @@ This module defines the local run command tree for the Nextmv CLI.
 import typer
 
 from nextmv.cli.local.run.clone import app as clone_app
+from nextmv.cli.local.run.compare import app as compare_app
 from nextmv.cli.local.run.create import app as create_app
 from nextmv.cli.local.run.get import app as get_app
 from nextmv.cli.local.run.information import app as information_app
@@ -17,6 +18,7 @@ from nextmv.cli.local.run.visuals import app as visuals_app
 # Set up subcommand application.
 app = typer.Typer()
 app.add_typer(clone_app)
+app.add_typer(compare_app)
 app.add_typer(create_app)
 app.add_typer(get_app)
 app.add_typer(information_app)

--- a/nextmv/nextmv/cli/local/run/compare.py
+++ b/nextmv/nextmv/cli/local/run/compare.py
@@ -26,8 +26,7 @@ def compare(
         typer.Option(
             "--run-ids",
             "-r",
-            help="List of run IDs to compare (max 20). "
-            "Pass multiple run IDs by repeating the flag, or separating with commas.",
+            help="List of run IDs to compare. Pass multiple run IDs by repeating the flag, or separating with commas.",
             metavar="RUN_IDS",
         ),
     ],
@@ -55,13 +54,11 @@ def compare(
     """
     Compare multiple Nextmv local application runs.
 
-    The number of run IDs provided through the --run-ids flag must be between
-    [magenta]1[/magenta] and [magenta]20[/magenta]. By default this command
-    prints a human-readable table to [magenta]stdout[/magenta]. You may use the
-    --flat option to print the comparison result to [magenta]stdout[/magenta]
-    as [magenta]json[/magenta] instead. When the --output option is used, the
-    --flat flag is automatically activated and the result is saved as
-    [magenta]json[/magenta].
+    By default this command prints a human-readable table to
+    [magenta]stdout[/magenta]. You may use the --flat option to print the
+    comparison result to [magenta]stdout[/magenta] as [magenta]json[/magenta]
+    instead. When the --output option is used, the --flat flag is automatically
+    activated and the result is saved as [magenta]json[/magenta].
 
     [bold][underline]Examples[/underline][/bold]
 
@@ -86,9 +83,6 @@ def compare(
         sub_ids = run_id.split(",")
         for sub_id in sub_ids:
             run_id_list.append(sub_id.strip())
-
-    if len(run_id_list) < 1 or len(run_id_list) > 20:
-        error("The number of run IDs to compare must be between [magenta]1[/magenta] and [magenta]20[/magenta].")
 
     found = set()
     for run_id in run_id_list:

--- a/nextmv/nextmv/cli/local/run/compare.py
+++ b/nextmv/nextmv/cli/local/run/compare.py
@@ -1,0 +1,219 @@
+"""
+This module defines the local run compare command for the Nextmv CLI.
+"""
+
+import json
+from typing import Annotated
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from nextmv.cli.configuration.config import build_local_app
+from nextmv.cli.message import error, in_progress, print_json, rule, success
+from nextmv.cli.options import DebugOption, LocalAppIDOption, LocalAppSrcOption
+from nextmv.run import RunComparison
+
+# Set up subcommand application.
+app = typer.Typer()
+console = Console()
+
+
+@app.command()
+def compare(
+    run_ids: Annotated[
+        list[str],
+        typer.Option(
+            "--run-ids",
+            "-r",
+            help="List of run IDs to compare (max 20). "
+            "Pass multiple run IDs by repeating the flag, or separating with commas.",
+            metavar="RUN_IDS",
+        ),
+    ],
+    app_id: LocalAppIDOption = None,
+    app_src: LocalAppSrcOption = ".",
+    flat: Annotated[
+        bool,
+        typer.Option(
+            "--flat",
+            "-f",
+            help="Print the comparison result as [magenta]json[/magenta], instead of a table.",
+        ),
+    ] = False,
+    output: Annotated[
+        str | None,
+        typer.Option(
+            "--output",
+            "-o",
+            help="Saves the comparison result to this location. Activates the --flat option.",
+            metavar="OUTPUT_PATH",
+        ),
+    ] = None,
+    _: DebugOption = False,
+) -> None:
+    """
+    Compare multiple Nextmv local application runs.
+
+    The number of run IDs provided through the --run-ids flag must be between
+    [magenta]1[/magenta] and [magenta]20[/magenta]. By default this command
+    prints a human-readable table to [magenta]stdout[/magenta]. You may use the
+    --flat option to print the comparison result to [magenta]stdout[/magenta]
+    as [magenta]json[/magenta] instead. When the --output option is used, the
+    --flat flag is automatically activated and the result is saved as
+    [magenta]json[/magenta].
+
+    [bold][underline]Examples[/underline][/bold]
+
+    - Compare two runs belonging to an app with ID [magenta]hare-app[/magenta]
+      repeating the --run-ids flag.
+        $ [dim]nextmv local run compare --app-id hare-app --run-ids fluff --run-ids white[/dim]
+
+    - Compare three runs belonging to an app with ID [magenta]hare-app[/magenta]
+      separating the run IDs with commas.
+        $ [dim]nextmv local run compare --app-id hare-app --run-ids fluff,white,thumper[/dim]
+
+    - Compare two runs and print the result as [magenta]json[/magenta].
+        $ [dim]nextmv local run compare --app-id hare-app --run-ids fluff,white --flat[/dim]
+
+    - Compare two runs and save the result to a file named [magenta]comparison.json[/magenta].
+        $ [dim]nextmv local run compare --app-id hare-app --run-ids fluff,white --output comparison.json[/dim]
+    """
+
+    # Parse the run IDs to gather the final list.
+    run_id_list = []
+    for run_id in run_ids:
+        sub_ids = run_id.split(",")
+        for sub_id in sub_ids:
+            run_id_list.append(sub_id.strip())
+
+    if len(run_id_list) < 1 or len(run_id_list) > 20:
+        error("The number of run IDs to compare must be between [magenta]1[/magenta] and [magenta]20[/magenta].")
+
+    found = set()
+    for run_id in run_id_list:
+        if run_id in found:
+            error(f"Duplicate run ID found: [magenta]{run_id}[/magenta]. Please provide unique run IDs for comparison.")
+
+        found.add(run_id)
+
+    local_app = build_local_app(app_src, app_id)
+    in_progress(msg="Comparing runs...")
+    comparison = local_app.compare_runs(run_ids=run_id_list)
+    comparison_dict = comparison.to_flat_dict()
+
+    if output is not None and output != "":
+        with open(output, "w") as f:
+            json.dump(comparison_dict, f, indent=2)
+
+        success(msg=f"Run comparison saved to [magenta]{output}[/magenta].")
+
+        return
+
+    if flat:
+        print_json(comparison_dict)
+        return
+
+    _print_table(comparison)
+
+
+def _print_table(comparison: RunComparison) -> None:
+    """
+    Auxiliary function to handle the printing of the comparison result as
+    tables. This mostly orchestrates calling tables for different elements of
+    the comparison.
+
+    Parameters
+    ----------
+    comparison: RunComparison
+        The object containing the results of the run comparison.
+    """
+
+    table_styling_kwargs = {
+        "border_style": "cyan",
+        "header_style": "cyan",
+        "title_style": "magenta bold",
+        "title_justify": "left",
+    }
+
+    _print_comparison_table(
+        title="Information",
+        first_column="Field",
+        run_ids=comparison.run_ids,
+        data=comparison.information,
+        table_styling_kwargs=table_styling_kwargs,
+        highlight_differences=False,
+    )
+
+    _print_comparison_table(
+        title="Metadata",
+        first_column="Field",
+        run_ids=comparison.run_ids,
+        data=comparison.metadata,
+        table_styling_kwargs=table_styling_kwargs,
+    )
+
+    if comparison.metrics:
+        _print_comparison_table(
+            title="Metrics",
+            first_column="Metric",
+            run_ids=comparison.run_ids,
+            data=comparison.metrics,
+            table_styling_kwargs=table_styling_kwargs,
+        )
+
+    if comparison.options:
+        _print_comparison_table(
+            title="Options",
+            first_column="Option",
+            run_ids=comparison.run_ids,
+            data=comparison.options,
+            table_styling_kwargs=table_styling_kwargs,
+        )
+
+
+def _print_comparison_table(
+    title: str,
+    first_column: str,
+    run_ids: list[str],
+    data: dict,
+    table_styling_kwargs: dict,
+    highlight_differences: bool = True,
+) -> None:
+    """
+    Auxiliary function to print a specific section of the comparison result as
+    a table.
+
+    Parameters
+    ----------
+    title: str
+        The title of the table to be printed.
+    first_column: str
+        The name of the first column of the table, which contains the name of
+        the field/metric/option being compared.
+    run_ids: list[str]
+        The list of run IDs being compared. This is used to print the values of
+        each field/metric/option for each run in the correct order.
+    data: dict
+        The actual data to be printed in the table. This is a dictionary where
+        the keys are the names of the fields/metrics/options being compared,
+        and the values are ComparisonValues objects that contain the values for
+        each run and whether there are differences across runs.
+    table_styling_kwargs: dict
+        A dictionary containing styling options for the table, such as border style, header style, title style, etc.
+    highlight_differences: bool
+        Whether to highlight rows with differences across runs.
+    """
+
+    table = Table(first_column, *run_ids, title=title, **table_styling_kwargs)
+
+    for field, comp_values in data.items():
+        style_kwargs = {"style": "italic yellow"} if highlight_differences and comp_values.has_differences else {}
+        table.add_row(
+            field,
+            *[str(comp_values.values.get(run_id, "")) for run_id in run_ids],
+            **style_kwargs,
+        )
+
+    rule()
+    console.print(table)

--- a/nextmv/nextmv/cloud/application/_run.py
+++ b/nextmv/nextmv/cloud/application/_run.py
@@ -9,7 +9,8 @@ import shutil
 import sys
 import tarfile
 import tempfile
-from collections.abc import Callable
+from collections import defaultdict
+from collections.abc import Callable, Iterable
 from typing import TYPE_CHECKING, Any
 
 import rich
@@ -28,9 +29,11 @@ from nextmv.options import Options
 from nextmv.output import ASSETS_KEY, STATISTICS_KEY, Asset, Output, Statistics
 from nextmv.polling import DEFAULT_POLLING_OPTIONS, PollingOptions, poll
 from nextmv.run import (
+    ComparisonValues,
     ExternalRunResult,
     Metadata,
     Run,
+    RunComparison,
     RunConfiguration,
     RunInformation,
     RunLog,
@@ -410,6 +413,81 @@ class ApplicationRunMixin:
             polling_options=polling_options,
             output_dir_path=output_dir_path,
         )
+
+    def compare_runs(self: "Application", run_ids: Iterable[str]) -> RunComparison:
+        """
+        Compare multiple runs by their IDs.
+
+        The number of provided runs must be between 1 and 20.
+
+        Parameters
+        ----------
+        run_ids: Iterable[str]
+            An iterable of run IDs to compare. The number of provided runs must
+            be between 1 and 20.
+
+        Returns
+        -------
+        ComparedRuns
+            An object containing the comparison of the runs.
+
+        Raises
+        ------
+        ValueError
+            If the number of provided runs is less than 1 or greater than 20.
+        requests.HTTPError
+            If any of the responses when fetching run information is not 2xx.
+        """
+
+        if len(run_ids) < 1 or len(run_ids) > 20:
+            raise ValueError("You must provide between 1 and 20 run IDs to compare.")
+
+        unique_run_ids = set(run_ids)
+        if len(unique_run_ids) != len(run_ids):
+            raise ValueError("Duplicate run IDs provided. Please provide unique run IDs for comparison.")
+
+        run_infos = [self.run_information(run_id) for run_id in run_ids]
+
+        compared_metrics = defaultdict(ComparisonValues)
+        compared_options = defaultdict(ComparisonValues)
+        compared_metadata = defaultdict(ComparisonValues)
+        compared_info = defaultdict(ComparisonValues)
+        run_ids = []
+
+        for run_info in run_infos:
+            run_id = run_info.id
+            run_ids.append(run_id)
+
+            # Gather the info and metadata.
+            compared_info = _process_information_comparison(run_id, run_info, compared_info)
+            metadata = run_info.metadata
+            compared_metadata = _process_metadata_comparison(run_id, metadata, compared_metadata)
+
+            # Gather the metrics.
+            metrics = metadata.metrics
+            if metrics:
+                for k, v in metrics.items():
+                    if isinstance(v, (int, float)):
+                        v = round(v, 5)
+
+                    compared_metrics[k].values[run_id] = v
+
+            # Gather the options.
+            options = metadata.options
+            if options:
+                for k, v in options.active_options.items():
+                    compared_options[k].values[run_id] = v
+
+        comp = RunComparison(
+            run_ids=run_ids,
+            information=compared_info,
+            metadata=compared_metadata,
+            metrics=compared_metrics if compared_metrics else None,
+            options=compared_options if compared_options else None,
+        )
+        comp.determine_differences()
+
+        return comp
 
     def download_asset_content(
         self: "Application",
@@ -2288,3 +2366,57 @@ class ApplicationRunMixin:
             return tracking.input_id
 
         return None
+
+
+def _process_information_comparison(
+    run_id: str,
+    run_info: RunInformation,
+    compared_info: dict[str, ComparisonValues],
+) -> dict[str, ComparisonValues]:
+    """
+    Auxiliary function to process the run information of a run and make nice
+    comparisons of the different fields.
+    """
+
+    info_dict = run_info.to_dict()
+    for k, v in info_dict.items():
+        if k in {"metadata", "console_url"}:
+            continue
+
+        compared_info[k].values[run_id] = v
+
+    return compared_info
+
+
+def _process_metadata_comparison(
+    run_id: str,
+    metadata: Metadata,
+    compared_metadata: dict[str, ComparisonValues],
+) -> dict[str, ComparisonValues]:
+    """
+    Auxiliary function to process the metadata of a run and make nice
+    comparisons of the different fields.
+    """
+
+    meta_dict = metadata.to_dict()
+    for key, value in meta_dict.items():
+        if key in {"metrics", "options"}:
+            continue
+        elif key == "format":
+            compared_metadata["content_format"].values[run_id] = metadata.content_format.value
+        elif key == "integration":
+            integ_dict = value
+            for k, v in integ_dict.items():
+                compared_metadata[k].values[run_id] = v
+        elif key == "run_type":
+            compared_metadata[key].values[run_id] = metadata.run_type.run_type.value
+        elif key == "tracking":
+            track_dict = value
+            for k, v in track_dict.items():
+                compared_metadata[k].values[run_id] = v
+        elif key == "status_v2":
+            compared_metadata["status"].values[run_id] = metadata.status_v2.value
+        else:
+            compared_metadata[key].values[run_id] = value
+
+    return compared_metadata

--- a/nextmv/nextmv/cloud/application/_run.py
+++ b/nextmv/nextmv/cloud/application/_run.py
@@ -418,13 +418,10 @@ class ApplicationRunMixin:
         """
         Compare multiple runs by their IDs.
 
-        The number of provided runs must be between 1 and 20.
-
         Parameters
         ----------
         run_ids: Iterable[str]
-            An iterable of run IDs to compare. The number of provided runs must
-            be between 1 and 20.
+            An iterable of run IDs to compare.
 
         Returns
         -------
@@ -438,9 +435,6 @@ class ApplicationRunMixin:
         requests.HTTPError
             If any of the responses when fetching run information is not 2xx.
         """
-
-        if len(run_ids) < 1 or len(run_ids) > 20:
-            raise ValueError("You must provide between 1 and 20 run IDs to compare.")
 
         unique_run_ids = set(run_ids)
         if len(unique_run_ids) != len(run_ids):

--- a/nextmv/nextmv/local/application.py
+++ b/nextmv/nextmv/local/application.py
@@ -683,13 +683,10 @@ class Application(BaseModel):
         """
         Compare multiple runs by their IDs.
 
-        The number of provided runs must be between 1 and 20.
-
         Parameters
         ----------
         run_ids: Iterable[str]
-            An iterable of run IDs to compare. The number of provided runs must
-            be between 1 and 20.
+            An iterable of run IDs to compare.
 
         Returns
         -------
@@ -701,9 +698,6 @@ class Application(BaseModel):
         ValueError
             If the number of provided runs is less than 1 or greater than 20.
         """
-
-        if len(run_ids) < 1 or len(run_ids) > 20:
-            raise ValueError("You must provide between 1 and 20 run IDs to compare.")
 
         unique_run_ids = set(run_ids)
         if len(unique_run_ids) != len(run_ids):

--- a/nextmv/nextmv/local/application.py
+++ b/nextmv/nextmv/local/application.py
@@ -16,7 +16,8 @@ import shutil
 import sys
 import tempfile
 import webbrowser
-from collections.abc import Callable
+from collections import defaultdict
+from collections.abc import Callable, Iterable
 from datetime import datetime, timezone
 from typing import Any
 
@@ -46,11 +47,13 @@ from nextmv.options import Options
 from nextmv.output import ASSETS_KEY, METRICS_KEY, OUTPUTS_KEY, SOLUTIONS_KEY, STATISTICS_KEY, OutputFormat
 from nextmv.polling import DEFAULT_POLLING_OPTIONS, PollingOptions, poll
 from nextmv.run import (
+    ComparisonValues,
     ErrorLog,
     Format,
     FormatInput,
     Metadata,
     Run,
+    RunComparison,
     RunConfiguration,
     RunInformation,
     RunOptions,
@@ -675,6 +678,79 @@ class Application(BaseModel):
             polling_options=polling_options,
             output_dir_path=output_dir_path,
         )
+
+    def compare_runs(self: "Application", run_ids: Iterable[str]) -> RunComparison:
+        """
+        Compare multiple runs by their IDs.
+
+        The number of provided runs must be between 1 and 20.
+
+        Parameters
+        ----------
+        run_ids: Iterable[str]
+            An iterable of run IDs to compare. The number of provided runs must
+            be between 1 and 20.
+
+        Returns
+        -------
+        ComparedRuns
+            An object containing the comparison of the runs.
+
+        Raises
+        ------
+        ValueError
+            If the number of provided runs is less than 1 or greater than 20.
+        """
+
+        if len(run_ids) < 1 or len(run_ids) > 20:
+            raise ValueError("You must provide between 1 and 20 run IDs to compare.")
+
+        unique_run_ids = set(run_ids)
+        if len(unique_run_ids) != len(run_ids):
+            raise ValueError("Duplicate run IDs provided. Please provide unique run IDs for comparison.")
+
+        run_infos = [self.run_information(run_id) for run_id in run_ids]
+
+        compared_metrics = defaultdict(ComparisonValues)
+        compared_options = defaultdict(ComparisonValues)
+        compared_metadata = defaultdict(ComparisonValues)
+        compared_info = defaultdict(ComparisonValues)
+        run_ids = []
+
+        for run_info in run_infos:
+            run_id = run_info.id
+            run_ids.append(run_id)
+
+            # Gather the info and metadata.
+            compared_info = _process_information_comparison(run_id, run_info, compared_info)
+            metadata = run_info.metadata
+            compared_metadata = _process_metadata_comparison(run_id, metadata, compared_metadata)
+
+            # Gather the metrics.
+            metrics = metadata.metrics
+            if metrics:
+                for k, v in metrics.items():
+                    if isinstance(v, (int, float)):
+                        v = round(v, 5)
+
+                    compared_metrics[k].values[run_id] = v
+
+            # Gather the options.
+            options = metadata.options
+            if options:
+                for k, v in options.active_options.items():
+                    compared_options[k].values[run_id] = v
+
+        comp = RunComparison(
+            run_ids=run_ids,
+            information=compared_info,
+            metadata=compared_metadata,
+            metrics=compared_metrics if compared_metrics else None,
+            options=compared_options if compared_options else None,
+        )
+        comp.determine_differences()
+
+        return comp
 
     def is_registered(self) -> bool:
         """
@@ -2493,3 +2569,57 @@ class Application(BaseModel):
         new_run_config.resolve(input=new_input, dir_path=new_input_dir_path)
 
         return new_run_config
+
+
+def _process_information_comparison(
+    run_id: str,
+    run_info: RunInformation,
+    compared_info: dict[str, ComparisonValues],
+) -> dict[str, ComparisonValues]:
+    """
+    Auxiliary function to process the run information of a run and make nice
+    comparisons of the different fields.
+    """
+
+    info_dict = run_info.to_dict()
+    for k, v in info_dict.items():
+        if k in {"metadata", "console_url"}:
+            continue
+
+        compared_info[k].values[run_id] = v
+
+    return compared_info
+
+
+def _process_metadata_comparison(
+    run_id: str,
+    metadata: Metadata,
+    compared_metadata: dict[str, ComparisonValues],
+) -> dict[str, ComparisonValues]:
+    """
+    Auxiliary function to process the metadata of a run and make nice
+    comparisons of the different fields.
+    """
+
+    meta_dict = metadata.to_dict()
+    for key, value in meta_dict.items():
+        if key in {"metrics", "options"}:
+            continue
+        elif key == "format":
+            compared_metadata["content_format"].values[run_id] = metadata.content_format.value
+        elif key == "integration":
+            integ_dict = value
+            for k, v in integ_dict.items():
+                compared_metadata[k].values[run_id] = v
+        elif key == "run_type":
+            compared_metadata[key].values[run_id] = metadata.run_type.run_type.value
+        elif key == "tracking":
+            track_dict = value
+            for k, v in track_dict.items():
+                compared_metadata[k].values[run_id] = v
+        elif key == "status_v2":
+            compared_metadata["status"].values[run_id] = metadata.status_v2.value
+        else:
+            compared_metadata[key].values[run_id] = value
+
+    return compared_metadata

--- a/nextmv/nextmv/run.py
+++ b/nextmv/nextmv/run.py
@@ -2068,3 +2068,166 @@ class TrackedRun:
             return "\\n".join(self.logs)
 
         raise TypeError("Logs must be a string or a list of strings.")
+
+
+class ComparisonValues(BaseModel):
+    """
+    This class holds the comparison values of a field that is part of a
+    `RunComparison`.
+
+    You can import the `ComparisonValues` class directly from `nextmv`:
+
+    ```python
+    from nextmv import ComparisonValues
+    ```
+
+    Parameters
+    ----------
+    has_differences : bool
+        `True` if the values are not all the same. For example, if
+        we have runs `foo` and `bar` with `execution_class` `fluff` and `tail`,
+        then `has_differences` would be `False`, because `fluff` and `tail` are
+        different.
+    values : dict[str, Any]
+        Maps the run ID with actual value of the field being compared.
+    """
+
+    has_differences: bool = False
+    """
+    `True` if the values are not all the same. For example, if
+    we have runs `foo` and `bar` with `execution_class` `fluff` and `tail`,
+    then `has_differences` would be `False`, because `fluff` and `tail` are
+    different.
+    """
+    values: dict[str, Any] | None = Field(
+        default_factory=dict,
+    )
+    """
+    Maps the run ID with actual value of the field being compared.
+    """
+
+    def determine_differences(self) -> None:
+        """
+        Determines whether the values being compared are different across runs
+        and sets the `has_differences` field accordingly.
+        """
+
+        if self.values is None:
+            self.has_differences = False
+            return
+
+        unique_values = set(self.values.values())
+        self.has_differences = len(unique_values) > 1
+
+
+class RunComparison(BaseModel):
+    """
+    This class is a holding object for the results of a run comparison.
+
+    You can import the `RunComparison` class directly from `nextmv`:
+
+    ```python
+    from nextmv import RunComparison
+    ```
+
+    Parameters
+    ----------
+    run_ids : list[str]
+        The list of run IDs that are part of this comparison.
+    information : dict[str, ComparisonValues]
+        The comparison for the information fields. The keys for the dictionary are
+        the names of the information fields. The `ComparisonValues` class holds the
+        actual values of the field for the different runs.
+    metadata : dict[str, ComparisonValues]
+        The comparison for the metadata fields. The keys for the dictionary are
+        the names of the metadata fields. The `ComparisonValues` class holds the
+        actual values of the field for the different runs.
+    metrics : dict[str, ComparisonValues], optional
+        The comparison for the metrics. The keys for the dictionary are
+        the names of the metrics. The `ComparisonValues` class holds the
+        actual values of the metric for the different runs.
+    options : dict[str, ComparisonValues], optional
+        The comparison for the options. The keys for the dictionary are
+        the names of the options. The `ComparisonValues` class holds the
+        actual values of the option for the different runs.
+    """
+
+    run_ids: list[str]
+    """The list of run IDs that are part of this comparison."""
+    information: dict[str, ComparisonValues]
+    """
+    The comparison for the information fields. The keys for the dictionary are
+    the names of the information fields. The `ComparisonValues` class holds the
+    actual values of the field for the different runs.
+    """
+    metadata: dict[str, ComparisonValues]
+    """
+    The comparison for the metadata. The keys for the dictionary are the
+    names of the metadata fields. The `ComparisonValues` class holds the
+    actual values of the field for the different runs.
+    """
+    metrics: dict[str, ComparisonValues] | None = None
+    """
+    The comparison for the metrics. The keys for the dictionary are the
+    names of the metrics. The `ComparisonValues` class holds the
+    actual values of the metric for the different runs.
+    """
+    options: dict[str, ComparisonValues] | None = None
+    """
+    The comparison for the options. The keys for the dictionary are the
+    names of the options. The `ComparisonValues` class holds the
+    actual values of the option for the different runs.
+    """
+
+    def determine_differences(self) -> None:
+        """
+        Determines whether there are differences across runs for each of the
+        fields being compared and sets the `has_differences` field in the
+        corresponding `ComparisonValues` accordingly.
+        """
+
+        for comparison_values in self.information.values():
+            comparison_values.determine_differences()
+
+        for comparison_values in self.metadata.values():
+            comparison_values.determine_differences()
+
+        if self.metrics is not None:
+            for comparison_values in self.metrics.values():
+                comparison_values.determine_differences()
+
+        if self.options is not None:
+            for comparison_values in self.options.values():
+                comparison_values.determine_differences()
+
+    def to_flat_dict(self) -> dict[str, Any]:
+        """
+        Converts the `RunComparison` object to a dictionary that eliminates the
+        nesting caused by the `ComparisonValues` class. It takes the dictionary
+        of values that maps the run ID with its value for a field and assigns
+        it to each of the field keys of an attribute.
+
+        Returns
+        -------
+        dict[str, Any]
+            A dictionary representation of the `RunComparison` object that
+            eliminates the nesting caused by the `ComparisonValues` class.
+        """
+
+        flat_dict = {
+            "run_ids": self.run_ids,
+            "information": {field: comparison_values.values for field, comparison_values in self.information.items()},
+            "metadata": {field: comparison_values.values for field, comparison_values in self.metadata.items()},
+        }
+
+        if self.metrics is not None:
+            flat_dict["metrics"] = {
+                field: comparison_values.values for field, comparison_values in self.metrics.items()
+            }
+
+        if self.options is not None:
+            flat_dict["options"] = {
+                field: comparison_values.values for field, comparison_values in self.options.items()
+            }
+
+        return flat_dict

--- a/nextmv/nextmv/run.py
+++ b/nextmv/nextmv/run.py
@@ -2084,9 +2084,9 @@ class ComparisonValues(BaseModel):
     Parameters
     ----------
     has_differences : bool
-        `True` if the values are not all the same. For example, if
-        we have runs `foo` and `bar` with `execution_class` `fluff` and `tail`,
-        then `has_differences` would be `False`, because `fluff` and `tail` are
+        `True` if the values are not all the same. For example, if we have runs
+        `foo` and `bar` with `execution_class` `fluff` and `tail`, then
+        `has_differences` would be `True`, because `fluff` and `tail` are
         different.
     values : dict[str, Any]
         Maps the run ID with actual value of the field being compared.
@@ -2094,9 +2094,9 @@ class ComparisonValues(BaseModel):
 
     has_differences: bool = False
     """
-    `True` if the values are not all the same. For example, if
-    we have runs `foo` and `bar` with `execution_class` `fluff` and `tail`,
-    then `has_differences` would be `False`, because `fluff` and `tail` are
+    `True` if the values are not all the same. For example, if we have runs
+    `foo` and `bar` with `execution_class` `fluff` and `tail`, then
+    `has_differences` would be `True`, because `fluff` and `tail` are
     different.
     """
     values: dict[str, Any] | None = Field(default_factory=dict)

--- a/nextmv/nextmv/run.py
+++ b/nextmv/nextmv/run.py
@@ -2099,9 +2099,7 @@ class ComparisonValues(BaseModel):
     then `has_differences` would be `False`, because `fluff` and `tail` are
     different.
     """
-    values: dict[str, Any] | None = Field(
-        default_factory=dict,
-    )
+    values: dict[str, Any] | None = Field(default_factory=dict)
     """
     Maps the run ID with actual value of the field being compared.
     """


### PR DESCRIPTION
# Description

Enables run comparison.

- SDK: `cloud.Application.compare_runs()` and `local.Application.compare_runs()` methods were added.
- CLI: `nextmv cloud run compare` and `nextmv local run compare` commands were added.

This feature allows up to 20 runs to be compared, although I don't know how nicely that renders...

By default, tables are printed with the CLI

<img width="1702" height="720" alt="image" src="https://github.com/user-attachments/assets/5994ef21-8860-4138-82c0-06688d1c83b7" />

You can use the `--flat` flag to print `json`. The `--flat` naming is not great, but it is meant to be the same flag that is used in `community list`: specifying `--flag` "turns off" table mode... I can also name it something else, no biggie.

<img width="1718" height="747" alt="image" src="https://github.com/user-attachments/assets/bca65750-1ad0-43ca-b5a1-229b06853f6b" />

Specifying the `--output` flag enables `--flat` mode and saves the file as `json`.