### PR TITLE
Fixes system certs application for uv sub-processes

### DIFF
--- a/nextmv/nextmv/__about__.py
+++ b/nextmv/nextmv/__about__.py
@@ -1,1 +1,1 @@
-__version__ = "v1.9.1.dev0"
+__version__ = "v1.9.1.dev1"

--- a/nextmv/nextmv/__about__.py
+++ b/nextmv/nextmv/__about__.py
@@ -1,1 +1,1 @@
-__version__ = "v1.9.0"
+__version__ = "v1.9.1.dev0"

--- a/nextmv/nextmv/auth.py
+++ b/nextmv/nextmv/auth.py
@@ -124,6 +124,41 @@ def apply_system_certs() -> None:
         os.environ["UV_SYSTEM_CERTS"] = "true"
 
 
+def resolve_system_certs(profile: str | None = None) -> bool:
+    """
+    Apply system certificates if enabled via environment variable or profile config.
+
+    Resolution order:
+    1. ``NEXTMV_SYSTEM_CERTS`` env var (``1``, ``true``, ``yes`` → enabled).
+    2. ``system_certs`` flag on the given profile (or the default profile).
+
+    Returns ``True`` if system certificates were applied, ``False`` otherwise.
+
+    Parameters
+    ----------
+    profile : str | None
+        The profile name.  If ``None``, the default (top-level) profile is used.
+
+    Returns
+    -------
+    bool
+        Whether system certificates were applied.
+    """
+    from nextmv.config import get_system_certs, load_config
+
+    env_val = os.environ.get("NEXTMV_SYSTEM_CERTS", "").strip().lower()
+    if env_val in ("1", "true", "yes"):
+        apply_system_certs()
+        return True
+
+    config = load_config()
+    if get_system_certs(config, profile):
+        apply_system_certs()
+        return True
+
+    return False
+
+
 # >>> Token storage
 
 

--- a/nextmv/nextmv/auth.py
+++ b/nextmv/nextmv/auth.py
@@ -96,12 +96,16 @@ DEFAULT_AUTH_SESSION = "default"
 
 def apply_system_certs() -> None:
     """
-    Patch the Python SSL module to use the operating system's certificate store.
+    Patch the Python SSL module to use the operating system's certificate store
+    and propagate the configuration to child processes.
 
     Calls :func:`truststore.inject_into_ssl`, which replaces the default
     ``ssl.create_default_context`` factory so that all subsequent TLS
     connections (including those made by ``requests``) trust the OS certificate
     store instead of the bundled ``certifi`` CA bundle.
+
+    Also sets ``UV_SYSTEM_CERTS=true`` in the process environment so that
+    ``uv`` child processes also trust the OS certificate store.
 
     This is a global, process-wide side effect.  Calling it multiple times is
     harmless (it is idempotent).
@@ -114,6 +118,10 @@ def apply_system_certs() -> None:
     import truststore
 
     truststore.inject_into_ssl()
+
+    # Propagate to uv child processes — uv respects this env var natively.
+    if "UV_SYSTEM_CERTS" not in os.environ:
+        os.environ["UV_SYSTEM_CERTS"] = "true"
 
 
 # >>> Token storage

--- a/nextmv/nextmv/cli/configuration/create.py
+++ b/nextmv/nextmv/cli/configuration/create.py
@@ -224,6 +224,12 @@ def _resolve_auth_type(
     """Determine the authentication type from flags or interactive prompt."""
     # Explicit API key always wins.
     if api_key is not None and api_key.strip():
+        if auth_type == AuthType.PKCE:
+            warning(
+                "The [magenta]NEXTMV_API_KEY[/magenta] environment variable is set and takes precedence "
+                "over the requested [magenta]pkce[/magenta] auth type. "
+                "Unset [magenta]NEXTMV_API_KEY[/magenta] to create a [magenta]pkce[/magenta] profile."
+            )
         return AuthType.API_KEY
 
     # Explicit --auth-type flag (already validated by Typer).
@@ -287,7 +293,7 @@ def _create_api_key_profile(
 
     success("Configuration saved successfully.")
     message(f"[bold]Profile[/bold]: [magenta]{profile or 'Default'}[/magenta]", indents=1)
-    message(f"[bold]Type[/bold]: [magenta]{AuthType.API_KEY}[/magenta]", indents=1)
+    message(f"[bold]Type[/bold]: [magenta]{AuthType.API_KEY.value}[/magenta]", indents=1)
     message(f"[bold]API Key[/bold]: [magenta]{obscure_api_key(api_key)}[/magenta]", indents=1)
     if endpoint != DEFAULT_ENDPOINT:
         message(f"[bold]Endpoint[/bold]: [magenta]{endpoint}[/magenta]", indents=1)
@@ -402,7 +408,7 @@ def _create_pkce_profile(  # noqa: C901
 
     success("Configuration saved successfully.")
     message(f"[bold]Profile[/bold]: [magenta]{profile or 'Default'}[/magenta]", indents=1)
-    message(f"[bold]Type[/bold]: [magenta]{AuthType.PKCE}[/magenta]", indents=1)
+    message(f"[bold]Type[/bold]: [magenta]{AuthType.PKCE.value}[/magenta]", indents=1)
     message(f"[bold]Auth session[/bold]: [magenta]{effective_session}[/magenta]", indents=1)
     message(f"[bold]Team ID[/bold]: [magenta]{team_id}[/magenta]", indents=1)
     if endpoint != DEFAULT_ENDPOINT:

--- a/nextmv/nextmv/cli/local/run/create.py
+++ b/nextmv/nextmv/cli/local/run/create.py
@@ -9,6 +9,7 @@ from typing import Annotated, Any
 
 import typer
 
+from nextmv.auth import resolve_system_certs
 from nextmv.cli.configuration.config import build_local_app
 from nextmv.cli.local.run.get import handle_outputs
 from nextmv.cli.local.run.logs import handle_logs
@@ -229,6 +230,9 @@ def create(
             ),
         )
     run_options = build_run_options(options)
+
+    # Apply system certificates if enabled — must happen before spawning uv.
+    resolve_system_certs()
 
     # Start the run before deciding if we should poll or not.
     input_kwarg = resolve_input_kwarg(stdin=stdin, input=input)

--- a/nextmv/nextmv/cloud/client.py
+++ b/nextmv/nextmv/cloud/client.py
@@ -34,6 +34,7 @@ from nextmv.auth import (
     is_token_expired,
     load_tokens,
     refresh_tokens,
+    resolve_system_certs,
     save_tokens,
 )
 from nextmv.config import (
@@ -45,7 +46,6 @@ from nextmv.config import (
     get_auth_type,
     get_endpoint_oidc_config,
     get_profile_endpoint,
-    get_system_certs,
     get_team_id,
     load_config,
     load_sessions,
@@ -299,15 +299,10 @@ class Client:
         self.url = self.__resolve_endpoint(profile)
 
         # Resolve system_certs: explicit constructor arg > env var > config file.
-        if not self.system_certs:
-            env_val = os.environ.get("NEXTMV_SYSTEM_CERTS", "").strip().lower()
-            if env_val in ("1", "true", "yes"):
-                self.system_certs = True
-            else:
-                config = load_config()
-                self.system_certs = get_system_certs(config, profile)
         if self.system_certs:
             apply_system_certs()
+        elif resolve_system_certs(profile):
+            self.system_certs = True
 
         bearer_token, team_id = self.__resolve_bearer_token_for_pkce(profile)
         if bearer_token is not None:

--- a/nextmv/tests/cloud/test_client.py
+++ b/nextmv/tests/cloud/test_client.py
@@ -676,7 +676,7 @@ class TestSystemCerts(unittest.TestCase):
     def test_env_var_enables_system_certs(self):
         """NEXTMV_SYSTEM_CERTS=true enables system certs."""
         with patch("nextmv.cloud.client.load_config", return_value={"apikey": "k"}):
-            with patch("nextmv.cloud.client.apply_system_certs") as mock_apply:
+            with patch("nextmv.cloud.client.resolve_system_certs", return_value=True) as mock_apply:
                 with patch.dict(os.environ, {"NEXTMV_API_KEY": "k", "NEXTMV_SYSTEM_CERTS": "true"}):
                     client = Client()
                     self.assertTrue(client.system_certs)
@@ -685,41 +685,45 @@ class TestSystemCerts(unittest.TestCase):
     def test_env_var_one_enables_system_certs(self):
         """NEXTMV_SYSTEM_CERTS=1 enables system certs."""
         with patch("nextmv.cloud.client.load_config", return_value={"apikey": "k"}):
-            with patch.dict(os.environ, {"NEXTMV_API_KEY": "k", "NEXTMV_SYSTEM_CERTS": "1"}):
-                client = Client()
-                self.assertTrue(client.system_certs)
+            with patch("nextmv.cloud.client.resolve_system_certs", return_value=True):
+                with patch.dict(os.environ, {"NEXTMV_API_KEY": "k", "NEXTMV_SYSTEM_CERTS": "1"}):
+                    client = Client()
+                    self.assertTrue(client.system_certs)
 
     def test_env_var_yes_enables_system_certs(self):
         """NEXTMV_SYSTEM_CERTS=yes enables system certs."""
         with patch("nextmv.cloud.client.load_config", return_value={"apikey": "k"}):
-            with patch.dict(os.environ, {"NEXTMV_API_KEY": "k", "NEXTMV_SYSTEM_CERTS": "yes"}):
-                client = Client()
-                self.assertTrue(client.system_certs)
+            with patch("nextmv.cloud.client.resolve_system_certs", return_value=True):
+                with patch.dict(os.environ, {"NEXTMV_API_KEY": "k", "NEXTMV_SYSTEM_CERTS": "yes"}):
+                    client = Client()
+                    self.assertTrue(client.system_certs)
 
     def test_env_var_false_does_not_enable(self):
         """NEXTMV_SYSTEM_CERTS=false does not enable system certs."""
         with patch("nextmv.cloud.client.load_config", return_value={"apikey": "k"}):
-            with patch("nextmv.cloud.client.apply_system_certs") as mock_apply:
+            with patch("nextmv.cloud.client.resolve_system_certs", return_value=False) as mock_apply:
                 with patch.dict(os.environ, {"NEXTMV_API_KEY": "k", "NEXTMV_SYSTEM_CERTS": "false"}):
                     client = Client()
                     self.assertFalse(client.system_certs)
-                    mock_apply.assert_not_called()
+                    mock_apply.assert_called_once()
 
     def test_explicit_constructor_overrides_env(self):
         """system_certs=True on constructor takes precedence over env var."""
         with patch("nextmv.cloud.client.load_config", return_value={"apikey": "k"}):
-            with patch.dict(os.environ, {"NEXTMV_API_KEY": "k", "NEXTMV_SYSTEM_CERTS": "false"}):
-                client = Client(system_certs=True)
-                self.assertTrue(client.system_certs)
+            with patch("nextmv.cloud.client.apply_system_certs"):
+                with patch.dict(os.environ, {"NEXTMV_API_KEY": "k", "NEXTMV_SYSTEM_CERTS": "false"}):
+                    client = Client(system_certs=True)
+                    self.assertTrue(client.system_certs)
 
     def test_config_fallback_when_no_env(self):
         """Falls back to config when env var is not set."""
         config = {"apikey": "k", "system_certs": True}
         with patch("nextmv.cloud.client.load_config", return_value=config):
-            with patch.dict(os.environ, {"NEXTMV_API_KEY": "k"}, clear=False):
-                os.environ.pop("NEXTMV_SYSTEM_CERTS", None)
-                client = Client()
-                self.assertTrue(client.system_certs)
+            with patch("nextmv.cloud.client.resolve_system_certs", return_value=True):
+                with patch.dict(os.environ, {"NEXTMV_API_KEY": "k"}, clear=False):
+                    os.environ.pop("NEXTMV_SYSTEM_CERTS", None)
+                    client = Client()
+                    self.assertTrue(client.system_certs)
 
 
 def _future() -> str:

--- a/nextmv/tests/test_auth.py
+++ b/nextmv/tests/test_auth.py
@@ -2,6 +2,7 @@
 Unit tests for the PKCE auth helpers in nextmv.auth.
 """
 
+import os
 import tempfile
 import unittest
 import urllib.parse
@@ -173,6 +174,35 @@ class TestApplySystemCerts(unittest.TestCase):
             apply_system_certs()
             apply_system_certs()
             self.assertEqual(mock_inject.call_count, 2)
+
+    def test_sets_uv_system_certs_env_var(self):
+        """UV_SYSTEM_CERTS is set so uv subprocesses trust the system cert store."""
+        import truststore  # noqa: F401
+        from nextmv.auth import apply_system_certs
+
+        old_val = os.environ.pop("UV_SYSTEM_CERTS", None)
+        try:
+            with patch("truststore.inject_into_ssl"):
+                apply_system_certs()
+            self.assertEqual(os.environ.get("UV_SYSTEM_CERTS"), "true")
+        finally:
+            if old_val is not None:
+                os.environ["UV_SYSTEM_CERTS"] = old_val
+            else:
+                os.environ.pop("UV_SYSTEM_CERTS", None)
+
+    def test_does_not_override_existing_uv_system_certs(self):
+        """If UV_SYSTEM_CERTS is already set, apply_system_certs does not overwrite it."""
+        import truststore  # noqa: F401
+        from nextmv.auth import apply_system_certs
+
+        os.environ["UV_SYSTEM_CERTS"] = "false"
+        try:
+            with patch("truststore.inject_into_ssl"):
+                apply_system_certs()
+            self.assertEqual(os.environ["UV_SYSTEM_CERTS"], "false")
+        finally:
+            os.environ.pop("UV_SYSTEM_CERTS", None)
 
 
 class TestValidateTokenResponse(unittest.TestCase):


### PR DESCRIPTION
# Description

Makes sure that all `uv` subprocesses invoked by CLI and other functionality correctly respect `--system-certs` when dictated by the user profile.

## Changes

- Sets `UV_SYSTEM_CERTS` on `apply_system_certs()` which makes all invocations of `uv` respect the `--system-certs` setting of the user profile.