### PR TITLE
Fixes pkce flow for accounts setup with 3rd party SSO providers

### DIFF
--- a/nextmv/nextmv/__about__.py
+++ b/nextmv/nextmv/__about__.py
@@ -1,1 +1,1 @@
-__version__ = "v1.9.1"
+__version__ = "v1.9.2.dev0"

--- a/nextmv/nextmv/auth.py
+++ b/nextmv/nextmv/auth.py
@@ -91,6 +91,14 @@ DEFAULT_AUTH_SESSION = "default"
 # >>> Token storage
 
 
+# >>> Shared helpers
+
+
+def _strip_scheme(url: str) -> str:
+    """Strip a leading ``https://`` or ``http://`` scheme and trailing slash."""
+    return url.strip().removeprefix("https://").removeprefix("http://").rstrip("/")
+
+
 # >>> TLS helpers
 
 
@@ -759,6 +767,7 @@ def run_pkce_flow(
     oidc_discovery_url: str | None = None,
     client_id: str | None = None,
     force: bool = False,
+    identity_provider: str | None = None,
 ) -> dict[str, Any]:
     """
     Execute the full PKCE authorization-code flow.
@@ -788,6 +797,10 @@ def run_pkce_flow(
         which clears any active browser session, and chains all authorization
         parameters onto it so that the provider immediately presents the login
         page.  Defaults to ``False``.
+    identity_provider : str | None
+        When set, adds ``identity_provider=<value>`` to the authorization URL
+        so that Cognito delegates to a third-party SSO provider.  Use
+        :func:`fetch_sso_provider` to resolve the identifier from a domain.
 
     Returns
     -------
@@ -823,6 +836,8 @@ def run_pkce_flow(
         "code_challenge": code_challenge,
         "state": state,
     }
+    if identity_provider:
+        auth_params["identity_provider"] = identity_provider
 
     if force:
         # Use the logout endpoint to clear the Cognito session, then chain the
@@ -917,8 +932,8 @@ def fetch_organizations(access_token: str, endpoint: str) -> list[dict[str, Any]
             f"Refusing to send tokens over plain HTTP for endpoint {endpoint!r}. Use https:// or a bare hostname."
         )
     # Strip https:// if present so we always build a consistent URL.
-    bare = endpoint.removeprefix("https://").removeprefix("http://")
-    url = f"https://{bare.rstrip('/')}/v1/internal/me/organization"
+    bare = _strip_scheme(endpoint)
+    url = f"https://{bare}/v1/internal/me/organization"
     resp = requests.get(
         url,
         headers={"Authorization": f"Bearer {access_token}", "Content-Type": "application/json"},
@@ -926,3 +941,37 @@ def fetch_organizations(access_token: str, endpoint: str) -> list[dict[str, Any]
     )
     resp.raise_for_status()
     return resp.json()
+
+
+def fetch_sso_provider(domain: str, endpoint: str) -> str | None:
+    """
+    Check whether a third-party SSO provider is enabled for *domain*.
+
+    Calls ``GET https://<endpoint>/v1/enterprise/sso/domain?domain=<domain>``
+    (no authentication required).  Returns the ``domain_identifier`` if SSO is
+    enabled, or ``None`` otherwise.
+
+    Parameters
+    ----------
+    domain : str
+        The email domain to check, e.g. ``"nextmv.io"``.
+    endpoint : str
+        The API endpoint hostname, e.g. ``"api.cloud.nextmv.io"``.
+
+    Returns
+    -------
+    str | None
+        The ``domain_identifier`` when SSO is enabled, ``None`` otherwise.
+    """
+    if endpoint.startswith("http://"):
+        raise ValueError(
+            f"Refusing to connect over plain HTTP for endpoint {endpoint!r}. Use https:// or a bare hostname."
+        )
+    bare = _strip_scheme(endpoint)
+    url = f"https://{bare}/v1/enterprise/sso/domain?domain={domain}"
+    resp = requests.get(url, timeout=10)
+    resp.raise_for_status()
+    body: dict[str, str] = resp.json()
+    if body.get("enabled") and body.get("domain_identifier"):
+        return body["domain_identifier"]
+    return None

--- a/nextmv/nextmv/cli/auth/login.py
+++ b/nextmv/nextmv/cli/auth/login.py
@@ -13,7 +13,7 @@ from typing import Annotated
 
 import typer
 
-from nextmv.auth import apply_system_certs, run_pkce_flow, save_tokens
+from nextmv.auth import apply_system_certs, fetch_sso_provider, run_pkce_flow, save_tokens
 from nextmv.cli.message import error, in_progress, info, success, warning
 from nextmv.config import (
     CLIENT_ID_KEY,
@@ -23,6 +23,7 @@ from nextmv.config import (
     get_auth_type,
     get_endpoint_oidc_config,
     get_profile_endpoint,
+    get_sso_domain,
     get_system_certs,
     list_pkce_profiles,
     load_config,
@@ -129,6 +130,7 @@ def _run_login(profiles_to_login: list[str | None], config: dict, sessions: dict
     seen_sessions: dict[tuple[str, str], list[str]] = {}  # (session, endpoint) -> [display_name, ...]
     session_oidc: dict[tuple[str, str], tuple[str | None, str | None]] = {}
     session_system_certs: dict[tuple[str, str], bool] = {}
+    session_sso_domain: dict[tuple[str, str], str | None] = {}
 
     for prof in profiles_to_login:
         display_name = prof if prof is not None else "default"
@@ -148,11 +150,26 @@ def _run_login(profiles_to_login: list[str | None], config: dict, sessions: dict
         session_oidc[key] = (oidc_cfg.get(OIDC_DISCOVERY_URL_KEY), oidc_cfg.get(CLIENT_ID_KEY))
         if get_system_certs(config, prof):
             session_system_certs[key] = True
+        sso = get_sso_domain(config, prof)
+        if sso and key not in session_sso_domain:
+            session_sso_domain[key] = sso
 
     for (session, endpoint), profile_names in seen_sessions.items():
         oidc_discovery_url, oidc_client_id = session_oidc[(session, endpoint)]
         if session_system_certs.get((session, endpoint), False):
             apply_system_certs()
+
+        identity_provider: str | None = None
+        sso_domain = session_sso_domain.get((session, endpoint))
+        if sso_domain:
+            try:
+                identity_provider = fetch_sso_provider(sso_domain, endpoint)
+            except Exception:
+                warning(
+                    f"Failed to check SSO status for domain [magenta]{sso_domain}[/magenta]. "
+                    "Falling back to standard login."
+                )
+
         profiles_display = ", ".join(f"[magenta]{n}[/magenta]" for n in profile_names)
         in_progress(
             f"Logging in to session [magenta]{session}[/magenta] "
@@ -164,6 +181,7 @@ def _run_login(profiles_to_login: list[str | None], config: dict, sessions: dict
                 oidc_discovery_url=oidc_discovery_url,
                 client_id=oidc_client_id,
                 force=force,
+                identity_provider=identity_provider,
             )
             save_tokens(session, tokens)
             success(f"Logged in to session [magenta]{session}[/magenta] successfully.")

--- a/nextmv/nextmv/cli/auth/login.py
+++ b/nextmv/nextmv/cli/auth/login.py
@@ -121,7 +121,7 @@ def login(
     _run_login(profiles_to_login, config, sessions, force)
 
 
-def _run_login(profiles_to_login: list[str | None], config: dict, sessions: dict, force: bool) -> None:
+def _run_login(profiles_to_login: list[str | None], config: dict, sessions: dict, force: bool) -> None:  # noqa: C901
     """Run the login flow for the given list of profiles."""
     failed: list[str] = []
     # Deduplicate: one browser flow per unique (session, endpoint) pair.

--- a/nextmv/nextmv/cli/configuration/create.py
+++ b/nextmv/nextmv/cli/configuration/create.py
@@ -487,7 +487,7 @@ def _set_or_pop(d: dict, key: str, value: Any) -> None:
         d.pop(key, None)
 
 
-def _ensure_token(
+def _ensure_token(  # noqa: C901
     session: str,
     endpoint: str,
     oidc_discovery_url: str | None,

--- a/nextmv/nextmv/cli/configuration/create.py
+++ b/nextmv/nextmv/cli/configuration/create.py
@@ -2,17 +2,20 @@
 This module defines the configuration create command for the Nextmv CLI.
 """
 
-from typing import Annotated
+import sys
+from typing import Annotated, Any
 
 import typer
 from rich.prompt import Prompt
 
 from nextmv.auth import (
     CLIENT_ID,
+    _strip_scheme,
     _validate_id_token,
     apply_system_certs,
     delete_tokens,
     fetch_organizations,
+    fetch_sso_provider,
     is_invalid_grant_error,
     is_token_expired,
     load_tokens,
@@ -32,11 +35,11 @@ from nextmv.config import (
     DEFAULT_ENDPOINT,
     ENDPOINT_KEY,
     OIDC_DISCOVERY_URL_KEY,
+    SSO_DOMAIN_KEY,
     SYSTEM_CERTS_KEY,
     TEAM_ID_KEY,
     AuthType,
     _normalize_oidc_discovery_url,
-    _strip_scheme,
     get_endpoint_oidc_config,
     load_config,
     load_sessions,
@@ -130,6 +133,14 @@ def create(
             metavar="PROFILE_NAME",
         ),
     ] = None,
+    email: Annotated[
+        str | None,
+        typer.Option(
+            "--email",
+            help="Your login email to detect a third-party SSO provider. Only the domain part is stored.",
+            metavar="EMAIL",
+        ),
+    ] = None,
     system_certs: Annotated[
         bool,
         typer.Option(
@@ -198,10 +209,11 @@ def create(
         )
 
     resolved_type = _resolve_auth_type(api_key, auth_type, oidc_discovery_url, oidc_client_id)
+    sso_domain = _resolve_email_domain(email)
     config = load_config()
 
     if resolved_type == AuthType.API_KEY:
-        _create_api_key_profile(config, profile, endpoint, api_key, system_certs)
+        _create_api_key_profile(config, profile, endpoint, api_key, system_certs, sso_domain)
     else:
         _create_pkce_profile(
             config=config,
@@ -212,6 +224,7 @@ def create(
             oidc_client_id=oidc_client_id,
             team=team,
             system_certs=system_certs,
+            sso_domain=sso_domain,
         )
 
 
@@ -256,6 +269,7 @@ def _create_api_key_profile(
     endpoint: str,
     api_key: str | None,
     system_certs: bool,
+    sso_domain: str | None,
 ) -> None:
     """Collect an API key (interactively if needed) and save the profile."""
     if api_key is None or not api_key.strip():
@@ -274,20 +288,16 @@ def _create_api_key_profile(
         config[API_KEY_KEY] = api_key
         config[ENDPOINT_KEY] = endpoint
         config.pop(AUTH_TYPE_KEY, None)
-        if system_certs:
-            config[SYSTEM_CERTS_KEY] = True
-        else:
-            config.pop(SYSTEM_CERTS_KEY, None)
+        _set_or_pop(config, SYSTEM_CERTS_KEY, system_certs)
+        _set_or_pop(config, SSO_DOMAIN_KEY, sso_domain)
     else:
         if profile not in config:
             config[profile] = {}
         config[profile][API_KEY_KEY] = api_key
         config[profile][ENDPOINT_KEY] = endpoint
         config[profile].pop(AUTH_TYPE_KEY, None)
-        if system_certs:
-            config[profile][SYSTEM_CERTS_KEY] = True
-        else:
-            config[profile].pop(SYSTEM_CERTS_KEY, None)
+        _set_or_pop(config[profile], SYSTEM_CERTS_KEY, system_certs)
+        _set_or_pop(config[profile], SSO_DOMAIN_KEY, sso_domain)
 
     save_config(config)
 
@@ -308,6 +318,7 @@ def _create_pkce_profile(  # noqa: C901
     oidc_client_id: str | None,
     team: str | None,
     system_certs: bool,
+    sso_domain: str | None,
 ) -> None:
     """Ensure OIDC config, resolve team, and save a pkce profile."""
     # Custom endpoints require an explicit auth session to avoid mixing tokens
@@ -367,6 +378,7 @@ def _create_pkce_profile(  # noqa: C901
         endpoint=endpoint,
         oidc_discovery_url=resolved_oidc_url,
         client_id=resolved_oidc_client_id,
+        sso_domain=sso_domain,
     )
 
     team_id = _resolve_team_id(
@@ -380,14 +392,9 @@ def _create_pkce_profile(  # noqa: C901
         config[ENDPOINT_KEY] = endpoint
         config[TEAM_ID_KEY] = team_id
         config.pop(API_KEY_KEY, None)
-        if auth_session:
-            config[AUTH_SESSION_KEY] = auth_session
-        else:
-            config.pop(AUTH_SESSION_KEY, None)
-        if system_certs:
-            config[SYSTEM_CERTS_KEY] = True
-        else:
-            config.pop(SYSTEM_CERTS_KEY, None)
+        _set_or_pop(config, AUTH_SESSION_KEY, auth_session)
+        _set_or_pop(config, SYSTEM_CERTS_KEY, system_certs)
+        _set_or_pop(config, SSO_DOMAIN_KEY, sso_domain)
     else:
         if profile not in config:
             config[profile] = {}
@@ -395,14 +402,9 @@ def _create_pkce_profile(  # noqa: C901
         config[profile][ENDPOINT_KEY] = endpoint
         config[profile][TEAM_ID_KEY] = team_id
         config[profile].pop(API_KEY_KEY, None)
-        if auth_session:
-            config[profile][AUTH_SESSION_KEY] = auth_session
-        else:
-            config[profile].pop(AUTH_SESSION_KEY, None)
-        if system_certs:
-            config[profile][SYSTEM_CERTS_KEY] = True
-        else:
-            config[profile].pop(SYSTEM_CERTS_KEY, None)
+        _set_or_pop(config[profile], AUTH_SESSION_KEY, auth_session)
+        _set_or_pop(config[profile], SYSTEM_CERTS_KEY, system_certs)
+        _set_or_pop(config[profile], SSO_DOMAIN_KEY, sso_domain)
 
     save_config(config)
 
@@ -449,11 +451,48 @@ def _resolve_oidc_config(
     return resolved_discovery_url, resolved_client_id
 
 
+def _extract_email_domain(raw: str) -> str | None:
+    """Extract the email domain from user input.
+
+    Accepts full email (``user@example.com``), bare domain (``example.com``),
+    or domain with ``@`` (``@example.com``).  Returns ``None`` for empty input.
+    """
+    stripped = raw.strip()
+    if not stripped:
+        return None
+    domain = stripped.lstrip("@").rsplit("@", 1)[-1]
+    return domain.strip() or None
+
+
+def _resolve_email_domain(email_flag: str | None) -> str | None:
+    """Resolve the email domain from the --email flag or interactive prompt."""
+    if email_flag is not None:
+        return _extract_email_domain(email_flag)
+
+    if not sys.stdin.isatty():
+        return None
+
+    raw = Prompt.ask(
+        "Enter your login email (leave empty if no SSO provider)",
+        default="",
+    ).strip()
+    return _extract_email_domain(raw)
+
+
+def _set_or_pop(d: dict, key: str, value: Any) -> None:
+    """Set *key* in *d* when *value* is truthy, otherwise remove it."""
+    if value:
+        d[key] = value
+    else:
+        d.pop(key, None)
+
+
 def _ensure_token(
     session: str,
     endpoint: str,
     oidc_discovery_url: str | None,
     client_id: str | None,
+    sso_domain: str | None = None,
 ) -> str:
     """
     Return a valid id_token for *session*, running the PKCE browser flow
@@ -521,6 +560,15 @@ def _ensure_token(
                 # Fall through to full browser flow.
 
     # No usable token — open the browser.
+    identity_provider: str | None = None
+    if sso_domain:
+        try:
+            identity_provider = fetch_sso_provider(sso_domain, endpoint)
+        except Exception:
+            warning(
+                f"Failed to check SSO status for domain [magenta]{sso_domain}[/magenta]. "
+                "Falling back to standard login."
+            )
     message(
         f"Opening browser to authenticate session [magenta]{session}[/magenta] "
         f"against [magenta]{endpoint}[/magenta]...",
@@ -528,6 +576,7 @@ def _ensure_token(
     tokens = run_pkce_flow(
         oidc_discovery_url=oidc_discovery_url,
         client_id=client_id,
+        identity_provider=identity_provider,
     )
     save_tokens(session, tokens)
     token = tokens.get("id_token")

--- a/nextmv/nextmv/config.py
+++ b/nextmv/nextmv/config.py
@@ -57,7 +57,7 @@ from typing import Any
 import yaml
 
 from nextmv.auth import CLIENT_ID as _AUTH_CLIENT_ID
-from nextmv.auth import DEFAULT_AUTH_SESSION
+from nextmv.auth import DEFAULT_AUTH_SESSION, _strip_scheme
 from nextmv.auth import OIDC_DISCOVERY_URL as _AUTH_OIDC_DISCOVERY_URL
 
 # Paths
@@ -72,6 +72,7 @@ AUTH_TYPE_KEY = "auth_type"
 AUTH_SESSION_KEY = "auth_session"
 TEAM_ID_KEY = "team_id"
 SYSTEM_CERTS_KEY = "system_certs"
+SSO_DOMAIN_KEY = "sso_domain"
 
 # Sessions keys
 OIDC_DISCOVERY_URL_KEY = "oidc_discovery_url"
@@ -99,16 +100,6 @@ _BUILTIN_OIDC: dict[str, dict[str, str]] = {
         CLIENT_ID_KEY: _AUTH_CLIENT_ID,
     },
 }
-
-
-def _strip_scheme(url: str) -> str:
-    """Strip a leading ``https://`` or ``http://`` scheme and trailing slash."""
-    s = url.strip()
-    for prefix in ("https://", "http://"):
-        if s.startswith(prefix):
-            s = s[len(prefix) :]
-            break
-    return s.rstrip("/")
 
 
 _OIDC_DISCOVERY_SUFFIX = "/.well-known/openid-configuration"
@@ -268,6 +259,7 @@ def non_profile_keys() -> set[str]:
         AUTH_SESSION_KEY,
         TEAM_ID_KEY,
         SYSTEM_CERTS_KEY,
+        SSO_DOMAIN_KEY,
         DEFAULT_AUTH_SESSION,
     }
 
@@ -391,6 +383,18 @@ def get_system_certs(config: dict, profile: str | None) -> bool:
         profile_data = config.get(profile, {})
         raw = profile_data.get(SYSTEM_CERTS_KEY, False) if isinstance(profile_data, dict) else False
     return bool(raw)
+
+
+def get_sso_domain(config: dict, profile: str | None) -> str | None:
+    """Return the SSO domain stored in *profile*, or ``None`` if not set."""
+    if profile is None:
+        raw = config.get(SSO_DOMAIN_KEY)
+    else:
+        profile_data = config.get(profile, {})
+        raw = profile_data.get(SSO_DOMAIN_KEY) if isinstance(profile_data, dict) else None
+    if raw and isinstance(raw, str) and raw.strip():
+        return raw.strip()
+    return None
 
 
 def get_profile_endpoint(config: dict, profile: str | None) -> str:


### PR DESCRIPTION
# Description

Fixes the newly introduced PKCE (non-API-key) auth flow of CLI for accounts setup with 3rd party SSO providers.

## Changes

- 3rd party SSO support for PKCE flows.
  - `--email` flag on `configuration create` (or interactive prompt) to determine whether the domain is SSO managed.
  - Storing `sso_domain` on the config. No domain means no 3rd party SSO.
