### PR TITLE
Fix `BaseModel` serialization and scenario test creation

### DIFF
--- a/nextmv/nextmv/__about__.py
+++ b/nextmv/nextmv/__about__.py
@@ -1,1 +1,1 @@
-__version__ = "v1.9.6.dev0"
+__version__ = "v1.9.6.dev1"

--- a/nextmv/nextmv/__about__.py
+++ b/nextmv/nextmv/__about__.py
@@ -1,1 +1,1 @@
-__version__ = "v1.9.5"
+__version__ = "v1.9.6.dev0"

--- a/nextmv/nextmv/__about__.py
+++ b/nextmv/nextmv/__about__.py
@@ -1,1 +1,1 @@
-__version__ = "v1.9.6.dev1"
+__version__ = "v1.9.6.dev2"

--- a/nextmv/nextmv/cli/cloud/scenario/create.py
+++ b/nextmv/nextmv/cli/cloud/scenario/create.py
@@ -8,16 +8,168 @@ from typing import Annotated
 import typer
 
 from nextmv.cli.configuration.config import build_cloud_app
-from nextmv.cli.message import error, in_progress, print_json, success
+from nextmv.cli.message import enum_values, error, in_progress, print_json, success
 from nextmv.cli.options import AppIDOption, DebugOption, ProfileOption
-from nextmv.cloud.scenario import Scenario
+from nextmv.cloud.scenario import Scenario, ScenarioInputType
 from nextmv.polling import default_polling_options
 
 # Set up subcommand application.
 app = typer.Typer()
 
 
-@app.command()
+@app.command(
+    # AVOID USING THE HELP PARAMETER WITH TYPER COMMAND DECORATOR. For
+    # consistency, commands should be documented using docstrings. We were
+    # forced to use help here to work around f-string limitations in
+    # docstrings.
+    help=f"""
+    Create a new Nextmv Cloud scenario test.
+
+    A scenario test allows you to run multiple scenarios with different inputs,
+    instances/versions, and configurations in a single test.
+
+    Use the --wait flag to wait for the scenario test to complete,
+    polling for results. Using the --output flag will also
+    activate waiting, and allows you to specify a destination file for the
+    results.
+
+    [bold][underline]Scenarios[/underline][/bold]
+
+    Scenarios are provided as [magenta]json[/magenta] objects using the
+    --scenarios flag. Each scenario defines the configuration for a scenario
+    test execution.
+
+    You can provide scenarios in three ways:
+    - A single scenario as a [magenta]json[/magenta] object.
+    - Multiple scenarios by repeating the --scenarios flag.
+    - Multiple scenarios as a [magenta]json[/magenta] array in a single --scenarios flag.
+
+    Each scenario must have the following fields:
+    - [magenta]instance_id[/magenta]: ID of the instance to use for this scenario (required).
+    - [magenta]scenario_input[/magenta]: Object containing the scenario input (required), with:
+        - [magenta]scenario_input_type[/magenta]: Type of the scenario input (required).
+            Allowed values: {enum_values(ScenarioInputType)}.
+        - [magenta]scenario_input_data[/magenta]: Data for the scenario input (required).
+            - For [magenta]input_set[/magenta]: a str (the input set ID).
+            - For [magenta]input[/magenta]: an array of str (list of input IDs).
+            - For [magenta]new[/magenta]: an array of objects (raw data).
+    - [magenta]scenario_id[/magenta]: ID of the scenario (optional). The
+      default value will be set as [magenta]scenario-<index>[/magenta] if not set.
+    - [magenta]configuration[/magenta]: An array of configuration objects
+      (optional). Use this attribute to configure variation of options for the scenario. Each scenario
+      configuration object requires:
+        - [magenta]name[/magenta]: Name of the configuration option.
+        - [magenta]values[/magenta]: List of values for the configuration option.
+
+    Object format:
+    [dim]{{
+        "instance_id": "bunny-hopper-v2",
+        "scenario_input": {{
+            "scenario_input_type": "input_set",
+            "scenario_input_data": "spring-gardens"
+        }},
+        "configuration": [
+            {{
+                "name": "speed",
+                "values": ["optimized", "balanced", "safe"]
+            }}
+        ]
+    }}[/dim]
+
+    [bold][underline]Examples[/underline][/bold]
+
+    - Create a scenario test with a single scenario.
+
+        $ [dim]SCENARIO='{{
+            "instance_id": "warren-planner-v1",
+            "scenario_input": {{
+                "scenario_input_type": "input_set",
+                "scenario_input_data": "spring-gardens"
+            }}
+        }}'
+        nextmv cloud scenario create --app-id hare-app --scenarios "$SCENARIO"[/dim]
+
+    - Create with multiple scenarios by repeating the flag.
+
+        $ [dim]SCENARIO1='{{
+            "instance_id": "hop-optimizer",
+            "scenario_input": {{
+                "scenario_input_type": "input_set",
+                "scenario_input_data": "veggie-gardens"
+            }}
+        }}'
+        SCENARIO2='{{
+            "instance_id": "hop-optimizer",
+            "scenario_input": {{
+                "scenario_input_type": "input_set",
+                "scenario_input_data": "lettuce-field-2"
+            }}
+        }}'
+        nextmv cloud scenario create --app-id hare-app --scenarios "$SCENARIO1" --scenarios "$SCENARIO2"[/dim]
+
+    - Create with multiple scenarios in a single [magenta]json[/magenta] array.
+
+        $ [dim]SCENARIOS='[
+            {{
+                "instance_id": "burrow-builder",
+                "scenario_input": {{
+                    "scenario_input_type": "input_set",
+                    "scenario_input_data": "warren-zone-a"
+                }}
+            }},
+            {{
+                "instance_id": "tunnel-planner-v3",
+                "scenario_input": {{
+                    "scenario_input_type": "input_set",
+                    "scenario_input_data": "warren-zone-b"
+                }}
+            }}
+        ]'
+        nextmv cloud scenario create --app-id hare-app --scenarios "$SCENARIOS"[/dim]
+
+    - Create a scenario test and wait for it to complete.
+
+        $ [dim]SCENARIO='{{
+            "instance_id": "foraging-route",
+            "scenario_input": {{
+                "scenario_input_type": "input_set",
+                "scenario_input_data": "harvest-season"
+            }}
+        }}'
+        nextmv cloud scenario create --app-id hare-app --scenarios "$SCENARIO" \\
+            --wait[/dim]
+
+    - Create a scenario test and save the results to a file, waiting for
+      completion.
+
+        $ [dim]SCENARIO='{{
+            "instance_id": "safe-hopper",
+            "scenario_input": {{
+                "scenario_input_type": "input_set",
+                "scenario_input_data": "danger-zones"
+            }}
+        }}'
+        nextmv cloud scenario create --app-id hare-app --scenarios "$SCENARIO" \\
+            --output bunny-safety-results.json[/dim]
+
+    - Create a scenario test with configuration options.
+
+        $ [dim]SCENARIO='{{
+            "instance_id": "hop-optimizer",
+            "scenario_input": {{
+                "scenario_input_type": "input_set",
+                "scenario_input_data": "garden-paths"
+            }},
+            "configuration": [
+                {{
+                    "name": "speed",
+                    "values": ["fast", "careful"]
+                }}
+            ]
+        }}'
+        nextmv cloud scenario create --app-id hare-app --scenarios "$SCENARIO"[/dim]
+    """
+)
 def create(
     app_id: AppIDOption,
     # Options for scenario test configuration.
@@ -107,177 +259,6 @@ def create(
     _: DebugOption = False,
     profile: ProfileOption = None,
 ) -> None:
-    """
-    Create a new Nextmv Cloud scenario test.
-
-    A scenario test allows you to run multiple scenarios with different inputs,
-    instances/versions, and configurations in a single test.
-
-    Use the --wait flag to wait for the scenario test to complete,
-    polling for results. Using the --output flag will also
-    activate waiting, and allows you to specify a destination file for the
-    results.
-
-    [bold][underline]Scenarios[/underline][/bold]
-
-    Scenarios are provided as [magenta]json[/magenta] objects using the
-    --scenarios flag. Each scenario defines the configuration for a scenario
-    test execution.
-
-    You can provide scenarios in three ways:
-    - A single scenario as a [magenta]json[/magenta] object.
-    - Multiple scenarios by repeating the --scenarios flag.
-    - Multiple scenarios as a [magenta]json[/magenta] array in a single --scenarios flag.
-
-    Each scenario must have the following fields:
-    - [magenta]instance_id[/magenta]: ID of the instance to use for this scenario (required).
-    - [magenta]scenario_input[/magenta]: Object containing the scenario input (required), with:
-        - [magenta]scenario_input_type[/magenta]: Type of the scenario input (required).
-        - [magenta]scenario_input_data[/magenta]: Data for the scenario input (required).
-    - [magenta]scenario_id[/magenta]: ID of the scenario (optional). The
-      default value will be set as [magenta]scenario-<index>[/magenta] if not set.
-    - [magenta]configuration[/magenta]: An array of configuration objects
-      (optional). Use this attribute to configure variation of options for the scenario. Each scenario
-      configuration object requires:
-        - [magenta]name[/magenta]: Name of the configuration option.
-        - [magenta]values[/magenta]: List of values for the configuration option.
-
-    Example object format:
-    [dim]{
-        "instance_id": "bunny-hopper-v2",
-        "scenario_input": {
-            "scenario_input_type": "input_set",
-            "scenario_input_data": {
-                "input_id": "meadow-input-a1",
-                "input_set_id": "spring-gardens"
-            }
-        },
-        "configuration": [
-            {
-                "name": "speed",
-                "values": ["optimized", "balanced", "safe"]
-            }
-        ]
-    }[/dim]
-
-    [bold][underline]Examples[/underline][/bold]
-
-    - Create a scenario test with a single scenario.
-
-        $ [dim]SCENARIO='{
-            "instance_id": "warren-planner-v1",
-            "scenario_input": {
-                "scenario_input_type": "input_set",
-                "scenario_input_data": {
-                    "input_id": "carrot-patch-a",
-                    "input_set_id": "spring-gardens"
-                }
-            }
-        }'
-        nextmv cloud scenario create --app-id hare-app --scenarios "$SCENARIO"[/dim]
-
-    - Create with multiple scenarios by repeating the flag.
-
-        $ [dim]SCENARIO1='{
-            "instance_id": "hop-optimizer",
-            "scenario_input": {
-                "scenario_input_type": "input_set",
-                "scenario_input_data": {
-                    "input_id": "lettuce-field-1",
-                    "input_set_id": "veggie-gardens"
-                }
-            }
-        }'
-        SCENARIO2='{
-            "instance_id": "hop-optimizer",
-            "scenario_input": {
-                "scenario_input_type": "input_set",
-                "scenario_input_data": {
-                    "input_id": "lettuce-field-2",
-                    "input_set_id": "veggie-gardens"
-                }
-            }
-        }'
-        nextmv cloud scenario create --app-id hare-app --scenarios "$SCENARIO1" --scenarios "$SCENARIO2"[/dim]
-
-    - Create with multiple scenarios in a single [magenta]json[/magenta] array.
-
-        $ [dim]SCENARIOS='[
-            {
-                "instance_id": "burrow-builder",
-                "scenario_input": {
-                    "scenario_input_type": "input_set",
-                    "scenario_input_data": {
-                        "input_id": "warren-zone-a",
-                        "input_set_id": "burrow-sites"
-                    }
-                }
-            },
-            {
-                "instance_id": "tunnel-planner-v3",
-                "scenario_input": {
-                    "scenario_input_type": "input_set",
-                    "scenario_input_data": {
-                        "input_id": "warren-zone-b",
-                        "input_set_id": "burrow-sites"
-                    }
-                }
-            }
-        ]'
-        nextmv cloud scenario create --app-id hare-app --scenarios "$SCENARIOS"[/dim]
-
-    - Create a scenario test and wait for it to complete.
-
-        $ [dim]SCENARIO='{
-            "instance_id": "foraging-route",
-            "scenario_input": {
-                "scenario_input_type": "input_set",
-                "scenario_input_data": {
-                    "input_id": "carrot-harvest",
-                    "input_set_id": "harvest-season"
-                }
-            }
-        }'
-        nextmv cloud scenario create --app-id hare-app --scenarios "$SCENARIO" \\
-            --wait[/dim]
-
-    - Create a scenario test and save the results to a file, waiting for
-      completion.
-
-        $ [dim]SCENARIO='{
-            "instance_id": "safe-hopper",
-            "scenario_input": {
-                "scenario_input_type": "input_set",
-                "scenario_input_data": {
-                    "input_id": "predator-zones",
-                    "input_set_id": "danger-zones"
-                }
-            }
-        }'
-        nextmv cloud scenario create --app-id hare-app --scenarios "$SCENARIO" \\
-            --output bunny-safety-results.json[/dim]
-
-    - Create a scenario test with configuration options.
-
-        $ [dim]SCENARIO='{
-            "instance_id": "hop-optimizer",
-            "scenario_input": {
-                "scenario_input_type": "input_set",
-                "scenario_input_data": {
-                    "input_id": "garden-route-1",
-                    "input_set_id": "garden-paths"
-                }
-            },
-            "configuration": [
-                {
-                    "name": "speed",
-                    "values": ["fast", "careful"]
-                }
-            ]
-        }'
-        nextmv cloud scenario create --app-id hare-app --scenarios "$SCENARIO"[/dim]
-    """
-
     cloud_app, _ = build_cloud_app(app_id=app_id, profile=profile)
 
     # Build the scenario list from the CLI options

--- a/nextmv/nextmv/cloud/scenario.py
+++ b/nextmv/nextmv/cloud/scenario.py
@@ -13,13 +13,13 @@ Scenario
 """
 
 import itertools
-from dataclasses import dataclass
 from enum import Enum
 from typing import Any
 
+from nextmv.base_model import BaseModel
 
-@dataclass
-class ScenarioConfiguration:
+
+class ScenarioConfiguration(BaseModel):
     """
     Configuration for a scenario.
 
@@ -56,7 +56,7 @@ class ScenarioConfiguration:
     values: list[str]
     """List of values for the configuration option."""
 
-    def __post_init__(self):
+    def model_post_init(self, __context) -> None:
         """
         Post-initialization method to ensure that the values are unique.
 
@@ -103,8 +103,7 @@ class ScenarioInputType(str, Enum):
     """The data in the scenario is new data."""
 
 
-@dataclass
-class ScenarioInput:
+class ScenarioInput(BaseModel):
     """
     Input to be processed in a scenario.
 
@@ -164,7 +163,7 @@ class ScenarioInput:
     list of input IDs (`list[str]`), or raw data (`list[dict[str, Any]]`).
     """
 
-    def __post_init__(self):
+    def model_post_init(self, __context) -> None:
         """
         Post-initialization method to ensure that the input data is valid.
 
@@ -183,8 +182,7 @@ class ScenarioInput:
             raise ValueError("Scenario input type must be a list when using new data.")
 
 
-@dataclass
-class Scenario:
+class Scenario(BaseModel):
     """
     A scenario is a test case that is used to compare a decision model being
     executed with a set of inputs and configurations.

--- a/nextmv/nextmv/output.py
+++ b/nextmv/nextmv/output.py
@@ -1395,6 +1395,7 @@ class LocalOutputWriter(OutputWriter):
 
         if content_format in {ContentFormat.JSON, OutputFormat.TEXT}:
             self.__write_json(
+                output,
                 options,
                 solution,
                 assets,
@@ -1469,6 +1470,8 @@ class LocalOutputWriter(OutputWriter):
         """
 
         resolved_content_format = None
+        if output is not None and isinstance(output, BaseModel) and not isinstance(output, Output):
+            resolved_content_format = ContentFormat.JSON
         if content_format is not None:
             resolved_content_format = content_format
         elif manifest is not None:
@@ -1728,7 +1731,7 @@ class LocalOutputWriter(OutputWriter):
 
         return None
 
-    def __resolve_solution(
+    def __resolve_solution(  # noqa: C901
         self,
         content_format: ContentFormat,
         output: Output | dict[str, Any] | BaseModel | None = None,
@@ -1775,6 +1778,7 @@ class LocalOutputWriter(OutputWriter):
             If ``solution_files`` are provided for a non-multi-file format, or
             if a plain ``solution`` is provided for ``ContentFormat.MULTI_FILE``.
         """
+
         if content_format != ContentFormat.MULTI_FILE:
             if solution_files is not None:
                 raise ValueError(
@@ -1782,6 +1786,11 @@ class LocalOutputWriter(OutputWriter):
                     f"`ContentFormat.MULTI_FILE`: {content_format}. If you want to use `solution_files`, "
                     f"set `content_format` to `ContentFormat.MULTI_FILE`."
                 )
+
+            # We need to handle the special case where base model is passed and
+            # we don't extract solutions.
+            if output is not None and isinstance(output, BaseModel) and not isinstance(output, Output):
+                return output_dict
 
             if solution is not None:
                 return solution
@@ -1911,6 +1920,7 @@ class LocalOutputWriter(OutputWriter):
 
     def __write_json(
         self,
+        output: Output | dict[str, Any] | BaseModel | None = None,
         options: dict[str, Any] | None = None,
         solution: dict[str, Any] | Any | dict[str, list[dict[str, Any]]] | None = None,
         assets: list[dict[str, Any]] | None = None,
@@ -1928,6 +1938,9 @@ class LocalOutputWriter(OutputWriter):
 
         Parameters
         ----------
+        output : Union[Output, dict[str, Any], BaseModel], optional
+            Output data to write. Can be an Output object, a dictionary, or a
+            BaseModel.
         options : dict[str, Any], optional
             Options dictionary to include in the output payload.
         solution : dict[str, Any] or Any, optional
@@ -1957,6 +1970,9 @@ class LocalOutputWriter(OutputWriter):
 
         if statistics is not None:
             output_dict[STATISTICS_KEY] = statistics
+
+        if output is not None and isinstance(output, BaseModel) and not isinstance(output, Output):
+            output_dict = solution
 
         serialized = serialize_json(
             output_dict,

--- a/nextmv/nextmv/output.py
+++ b/nextmv/nextmv/output.py
@@ -1472,7 +1472,7 @@ class LocalOutputWriter(OutputWriter):
         resolved_content_format = None
         if output is not None and isinstance(output, BaseModel) and not isinstance(output, Output):
             resolved_content_format = ContentFormat.JSON
-        if content_format is not None:
+        elif content_format is not None:
             resolved_content_format = content_format
         elif manifest is not None:
             resolved_content_format = manifest.configuration.content.format

--- a/nextmv/tests/cloud/test_scenario.py
+++ b/nextmv/tests/cloud/test_scenario.py
@@ -1,6 +1,13 @@
 import unittest
 
-from nextmv.cloud.scenario import Scenario, ScenarioConfiguration, _option_sets, _scenarios_by_id
+from nextmv.cloud.scenario import (
+    Scenario,
+    ScenarioConfiguration,
+    ScenarioInput,
+    ScenarioInputType,
+    _option_sets,
+    _scenarios_by_id,
+)
 
 
 class TestScenarioTest(unittest.TestCase):
@@ -8,7 +15,10 @@ class TestScenarioTest(unittest.TestCase):
         all_option_sets = _option_sets(
             scenarios=[
                 Scenario(
-                    scenario_input="",
+                    scenario_input=ScenarioInput(
+                        scenario_input_type=ScenarioInputType.INPUT_SET,
+                        scenario_input_data="foo",
+                    ),
                     instance_id="",
                     configuration=[
                         ScenarioConfiguration(
@@ -26,7 +36,10 @@ class TestScenarioTest(unittest.TestCase):
                     ],
                 ),
                 Scenario(
-                    scenario_input="",
+                    scenario_input=ScenarioInput(
+                        scenario_input_type=ScenarioInputType.INPUT_SET,
+                        scenario_input_data="foo",
+                    ),
                     instance_id="",
                     configuration=[
                         ScenarioConfiguration(
@@ -75,12 +88,18 @@ class TestScenarioTest(unittest.TestCase):
     def test_scenarios_by_id(self):
         scenarios = [
             Scenario(
-                scenario_input=None,
+                scenario_input=ScenarioInput(
+                    scenario_input_type=ScenarioInputType.INPUT_SET,
+                    scenario_input_data="bar",
+                ),
                 instance_id="foo",
             ),
             Scenario(
-                scenario_input=None,
-                instance_id="bar",
+                scenario_input=ScenarioInput(
+                    scenario_input_type=ScenarioInputType.INPUT_SET,
+                    scenario_input_data="baz",
+                ),
+                instance_id="roh",
             ),
         ]
 
@@ -91,7 +110,10 @@ class TestScenarioTest(unittest.TestCase):
         scenarios.append(
             Scenario(
                 scenario_id="scenario-1",
-                scenario_input=None,
+                scenario_input=ScenarioInput(
+                    scenario_input_type=ScenarioInputType.INPUT_SET,
+                    scenario_input_data="foo",
+                ),
                 instance_id="foo",
             ),
         )
@@ -102,7 +124,10 @@ class TestScenarioTest(unittest.TestCase):
 class TestScenario(unittest.TestCase):
     def test_option_combinations(self):
         scenario = Scenario(
-            scenario_input="",
+            scenario_input=ScenarioInput(
+                scenario_input_type=ScenarioInputType.INPUT_SET,
+                scenario_input_data="foo",
+            ),
             instance_id="",
             configuration=[
                 ScenarioConfiguration(

--- a/nextmv/tests/test_output.py
+++ b/nextmv/tests/test_output.py
@@ -509,10 +509,13 @@ class TestOutput(unittest.TestCase):
             # The writer extracts known Output fields from the BaseModel's dict;
             # custom fields are not preserved in the envelope.
             expected = {
-                "options": {},
-                "solution": {},
-                "assets": [],
-                "metrics": {},
+                "output": {
+                    "i_am": "a_crazy_object",
+                    "with": [
+                        {"nested": "values"},
+                        {"and": "more_craziness"},
+                    ],
+                }
             }
 
             self.assertDictEqual(got, expected)


### PR DESCRIPTION
# Description

There was an issue when the refactor for `app.yaml` took place. The refactor was done to automatically configure paths, metrics, and more stuff based on the `app.yaml` being present at the root. Quietly, serialization for `BaseModel` stopped working, meaning that when we do stuff like `nextmv.write(input_set)`, where `input_set` is one of our classes, the function didn't write anything. This should fix it now.

This PR also fixes scenario test creation. When using the CLI, we weren't correctly parsing the JSON scenarios. It worked with the SDK because we were using classes directly. The fix is to use `BaseModel` class to deserialize JSON scenarios correctly. Also, the help message for `nextmv cloud scenario create` was off.