### PR TITLE
Fix: cache deletion, run comparison, help msg for queuing, input sets for acceptance, input set update. Adds: `--yes-queuing` option, ensemble result to run result

### DIFF
--- a/nextmv/nextmv/cli/cache/delete.py
+++ b/nextmv/nextmv/cli/cache/delete.py
@@ -4,8 +4,8 @@ This module defines the cache delete command for the Nextmv CLI.
 
 import typer
 
-from nextmv.cache import clear_cache, format_bytes
-from nextmv.cli.message import confirmation, info, success
+from nextmv.cache import clear_cache, format_bytes, get_cache
+from nextmv.cli.message import confirmation, in_progress, info, success
 from nextmv.cli.options import DebugOption, YesOption
 
 # Set up subcommand application.
@@ -31,11 +31,13 @@ def delete(yes: YesOption = False, _: DebugOption = False) -> None:
         $ [dim]nextmv cache delete --yes[/dim]
     """
 
-    deps, bytes_deleted = clear_cache()
-    if deps == 0 and bytes_deleted == 0:
+    cache_info = get_cache()
+    deps, total_size = cache_info["num_dependencies"], cache_info["total_size"]
+    if deps == 0 and total_size == "0 B":
         info("Nothing to delete: cache is already empty.")
         return
 
+    in_progress(f"Deleting [magenta]{deps}[/magenta] dependencies ([magenta]{total_size}[/magenta]) from the cache...")
     if not yes:
         confirm = confirmation(
             "Are you sure you want to delete the Nextmv cache? This action cannot be undone.",
@@ -45,6 +47,7 @@ def delete(yes: YesOption = False, _: DebugOption = False) -> None:
             info("The Nextmv cache will not be deleted.")
             return
 
+    deps, bytes_deleted = clear_cache()
     size_str = format_bytes(bytes_deleted)
     dep_label = "dependency" if deps == 1 else "dependencies"
     success(f"Deleted [magenta]{deps}[/magenta] {dep_label} ([magenta]{size_str}[/magenta]) from the cache.")

--- a/nextmv/nextmv/cli/cloud/instance/create.py
+++ b/nextmv/nextmv/cli/cloud/instance/create.py
@@ -91,7 +91,7 @@ def create(
     no_queuing: Annotated[
         bool,
         typer.Option(
-            "--no-queuing",
+            "--no-queuing/--yes-queuing",
             help="Do not queue when running the instance. Default is [magenta]False[/magenta], "
             "meaning the instance's run [italic]will[/italic] be queued.",
             rich_help_panel="Instance configuration",

--- a/nextmv/nextmv/cli/cloud/instance/create.py
+++ b/nextmv/nextmv/cli/cloud/instance/create.py
@@ -92,8 +92,8 @@ def create(
         bool,
         typer.Option(
             "--no-queuing/--yes-queuing",
-            help="Do not queue when running the instance. Default is [magenta]False[/magenta], "
-            "meaning the instance's run [italic]will[/italic] be queued.",
+            help="Whether to queue when running the instance. "
+            "Default is [magenta]False[/magenta], meaning the instance's run [italic]will[/italic] be queued.",
             rich_help_panel="Instance configuration",
         ),
     ] = False,

--- a/nextmv/nextmv/cli/cloud/instance/update.py
+++ b/nextmv/nextmv/cli/cloud/instance/update.py
@@ -97,7 +97,7 @@ def update(
     no_queuing: Annotated[
         bool | None,
         typer.Option(
-            "--no-queuing",
+            "--no-queuing/--yes-queuing",
             help="Do not queue when running the instance.",
             rich_help_panel="Instance configuration",
         ),

--- a/nextmv/nextmv/cli/cloud/instance/update.py
+++ b/nextmv/nextmv/cli/cloud/instance/update.py
@@ -98,7 +98,8 @@ def update(
         bool | None,
         typer.Option(
             "--no-queuing/--yes-queuing",
-            help="Do not queue when running the instance.",
+            help="Whether to queue when running the instance. "
+            "Default is [magenta]False[/magenta], meaning the instance's run [italic]will[/italic] be queued.",
             rich_help_panel="Instance configuration",
         ),
     ] = None,

--- a/nextmv/nextmv/cli/cloud/run/clone.py
+++ b/nextmv/nextmv/cli/cloud/run/clone.py
@@ -171,8 +171,8 @@ def clone(
         bool,
         typer.Option(
             "--no-queuing/--yes-queuing",
-            help="Do not queue run. Default is [magenta]False[/magenta], "
-            "meaning the run [italic]will[/italic] be queued.",
+            help="Whether to queue when running. "
+            "Default is [magenta]False[/magenta], meaning the run [italic]will[/italic] be queued.",
             rich_help_panel="Run configuration",
         ),
     ] = False,

--- a/nextmv/nextmv/cli/cloud/run/clone.py
+++ b/nextmv/nextmv/cli/cloud/run/clone.py
@@ -170,7 +170,7 @@ def clone(
     no_queuing: Annotated[
         bool,
         typer.Option(
-            "--no-queuing",
+            "--no-queuing/--yes-queuing",
             help="Do not queue run. Default is [magenta]False[/magenta], "
             "meaning the run [italic]will[/italic] be queued.",
             rich_help_panel="Run configuration",

--- a/nextmv/nextmv/cli/cloud/run/create.py
+++ b/nextmv/nextmv/cli/cloud/run/create.py
@@ -163,7 +163,7 @@ def create(
     no_queuing: Annotated[
         bool,
         typer.Option(
-            "--no-queuing",
+            "--no-queuing/--yes-queuing",
             help="Do not queue run. Default is [magenta]False[/magenta], "
             "meaning the run [italic]will[/italic] be queued.",
             rich_help_panel="Run configuration",

--- a/nextmv/nextmv/cli/cloud/run/create.py
+++ b/nextmv/nextmv/cli/cloud/run/create.py
@@ -164,8 +164,8 @@ def create(
         bool,
         typer.Option(
             "--no-queuing/--yes-queuing",
-            help="Do not queue run. Default is [magenta]False[/magenta], "
-            "meaning the run [italic]will[/italic] be queued.",
+            help="Whether to queue when running. "
+            "Default is [magenta]False[/magenta], meaning the run [italic]will[/italic] be queued.",
             rich_help_panel="Run configuration",
         ),
     ] = False,

--- a/nextmv/nextmv/cloud/application/_acceptance.py
+++ b/nextmv/nextmv/cloud/application/_acceptance.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any
 import requests
 
 from nextmv.cloud.acceptance_test import AcceptanceTest, Metric
-from nextmv.cloud.batch_experiment import BatchExperimentRun, ExperimentStatus
+from nextmv.cloud.batch_experiment import ExperimentStatus, to_runs
 from nextmv.polling import DEFAULT_POLLING_OPTIONS, PollingOptions, poll
 from nextmv.safe import safe_id
 
@@ -242,26 +242,9 @@ class ApplicationAcceptanceMixin:
                     f"batch experiment {id} does not exist, input_set_id must be defined to create a new one"
                 ) from e
         else:
-            # Get all input IDs from the input set.
+            # Build runs from the input set.
             input_set = self.input_set(input_set_id=input_set_id)
-            if not input_set.input_ids:
-                raise ValueError(f"input set {input_set_id} does not contain any inputs")
-            runs = []
-            for input_id in input_set.input_ids:
-                runs.append(
-                    BatchExperimentRun(
-                        instance_id=candidate_instance_id,
-                        input_set_id=input_set_id,
-                        input_id=input_id,
-                    )
-                )
-                runs.append(
-                    BatchExperimentRun(
-                        instance_id=baseline_instance_id,
-                        input_set_id=input_set_id,
-                        input_id=input_id,
-                    )
-                )
+            runs = to_runs(instance_ids=[candidate_instance_id, baseline_instance_id], input_set=input_set)
             batch_experiment_id = self.new_batch_experiment(
                 name=name,
                 description=description,

--- a/nextmv/nextmv/cloud/application/_input_set.py
+++ b/nextmv/nextmv/cloud/application/_input_set.py
@@ -262,7 +262,7 @@ class ApplicationInputSetMixin:
             payload["name"] = name
         if description is not None:
             payload["description"] = description
-        if inputs is not None:
+        if inputs is not None and len(inputs) > 0:
             payload["inputs"] = [input.to_dict() for input in inputs]
 
         response = self.client.request(

--- a/nextmv/nextmv/cloud/application/_run.py
+++ b/nextmv/nextmv/cloud/application/_run.py
@@ -461,11 +461,11 @@ class ApplicationRunMixin:
             # Gather the metrics.
             metrics = metadata.metrics
 
-            # If metrics come nested, we extract them.
-            if len(metrics.keys()) == 1 and list(metrics.keys())[0] == METRICS_KEY:
-                metrics = metadata.metrics[METRICS_KEY]
-
             if metrics:
+                # If metrics come nested, we extract them.
+                if len(metrics.keys()) == 1 and list(metrics.keys())[0] == METRICS_KEY:
+                    metrics = metadata.metrics[METRICS_KEY]
+
                 for k, v in metrics.items():
                     if isinstance(v, (int, float)):
                         v = round(v, 5)

--- a/nextmv/nextmv/cloud/application/_run.py
+++ b/nextmv/nextmv/cloud/application/_run.py
@@ -41,6 +41,7 @@ from nextmv.run import (
     RunQueuing,
     RunResult,
     RunTrackingMetadata,
+    RunType,
     TimestampedRunLog,
     TrackedRun,
 )
@@ -1830,6 +1831,14 @@ class ApplicationRunMixin:
         )
         result = RunResult.from_dict(response.json())
         result.console_url = self.__console_url(result.id)
+
+        if result.metadata.run_type.run_type == RunType.ENSEMBLE:
+            ensemble_response = self.client.request(
+                method="GET",
+                endpoint=f"{self.endpoint}/runs/{run_id}/ensemble",
+            )
+            ensemble_result = ensemble_response.json()
+            result.ensemble = ensemble_result
 
         # If we don't need to use a presigned URL, we can return the output
         # directly. Only attempt to download the output once the run has

--- a/nextmv/nextmv/cloud/application/_run.py
+++ b/nextmv/nextmv/cloud/application/_run.py
@@ -26,7 +26,7 @@ from nextmv.deprecated import deprecated
 from nextmv.input import Input, InputFormat
 from nextmv.logger import log
 from nextmv.options import Options
-from nextmv.output import ASSETS_KEY, STATISTICS_KEY, Asset, Output, Statistics
+from nextmv.output import ASSETS_KEY, METRICS_KEY, STATISTICS_KEY, Asset, Output, Statistics
 from nextmv.polling import DEFAULT_POLLING_OPTIONS, PollingOptions, poll
 from nextmv.run import (
     ComparisonValues,
@@ -459,6 +459,11 @@ class ApplicationRunMixin:
 
             # Gather the metrics.
             metrics = metadata.metrics
+
+            # If metrics come nested, we extract them.
+            if len(metrics.keys()) == 1 and list(metrics.keys())[0] == METRICS_KEY:
+                metrics = metadata.metrics[METRICS_KEY]
+
             if metrics:
                 for k, v in metrics.items():
                     if isinstance(v, (int, float)):

--- a/nextmv/nextmv/run.py
+++ b/nextmv/nextmv/run.py
@@ -309,6 +309,8 @@ class RunType(str, Enum):
         External run type.
     ENSEMBLE : str
         Ensemble run type.
+    ENSEMBLE_CHILD : str
+        A child run of an ensemble run type.
 
     Examples
     --------
@@ -323,10 +325,6 @@ class RunType(str, Enum):
     >>> external_type = RunType("external")
     >>> external_type
     <RunType.EXTERNAL: 'external'>
-
-    >>> # All available types
-    >>> list(RunType)
-    [<RunType.STANDARD: 'standard'>, <RunType.EXTERNAL: 'external'>, <RunType.ENSEMBLE: 'ensemble'>]
     """
 
     STANDARD = "standard"
@@ -335,6 +333,8 @@ class RunType(str, Enum):
     """External run type."""
     ENSEMBLE = "ensemble"
     """Ensemble run type."""
+    ENSEMBLE_CHILD = "ensemble-child"
+    """A child run of an ensemble run type."""
 
 
 class RunTypeConfiguration(BaseModel):
@@ -1344,6 +1344,8 @@ class RunResult(RunInformation):
     """Error log of the run. Only available if the run failed."""
     output: dict[str, Any] | None = None
     """Output of the run. Only available if the run succeeded."""
+    ensemble: dict[str, Any] | None = None
+    """Ensemble result of the run. Only available if the run was part of an ensemble run."""
 
 
 class RunLog(BaseModel):

--- a/nextmv/tests/integration/cloud/test_integration_cloud.py
+++ b/nextmv/tests/integration/cloud/test_integration_cloud.py
@@ -911,7 +911,7 @@ class CloudIntegrationWorkflow(FlowSpec):
             rules=[
                 cloud.EvaluationRule(
                     id="eval-rule-1",
-                    statistics_path="result.value",
+                    statistics_path="$.value",
                     objective=cloud.RuleObjective.MAXIMIZE,
                     tolerance=cloud.RuleTolerance(
                         value=0.01,

--- a/nextmv/tests/integration/cloud/test_integration_cloud.py
+++ b/nextmv/tests/integration/cloud/test_integration_cloud.py
@@ -905,6 +905,7 @@ class CloudIntegrationWorkflow(FlowSpec):
                 cloud.RunGroup(
                     id="run-group-1",
                     instance_id=inst1.id,
+                    repetitions=2,
                 ),
             ],
             rules=[
@@ -962,6 +963,7 @@ class CloudIntegrationWorkflow(FlowSpec):
         assert result.metadata.status_v2 == nextmv.StatusV2.succeeded
         assert result.metadata.run_type.run_type == nextmv.RunType.ENSEMBLE
         assert result.metadata.run_type.definition_id == definition.id
+        assert result.ensemble is not None
 
         # We can delete an ensemble definition.
         app.delete_ensemble_definition(ensemble_definition_id=definition.id)


### PR DESCRIPTION
# Description

This PR addresses several issues that were found during the update of the docs.

## Features
- Adds the `--yes-queuing` flag to turn queuing back on. When an instance is updated to turn off queuing, there was no way to turn it back on.
- Adds the `.ensemble` result to a run result that is an `ensemble` run.

## Fixes
- Cache deletion logic. The cache was being deleted before asking the user for confirmation.
- Run comparison. Runs with nested metrics under a `metrics` key could not be compared. This special case was addressed to flatten the metrics.
- Help message for queuing. Given that the `--yes-queuing` option is being added to the CLI, the help message was adjusted.
- Input sets for acceptance tests. When creating a new acceptance test, an input set created from runs could not be used. This was fixed so that input sets created from either runs or managed inputs can be used for acceptance tests.
- Input set updating. When attempting to update an input set's name/description, the inputs would get cleared out. This was fixes so that we don't have to always give updated inputs to the input set when updating it. What is intended to be patch behavior is now rectified.