### PR TITLE
Fix usage of write function when output is a simple dict

### DIFF
--- a/nextmv/nextmv/output.py
+++ b/nextmv/nextmv/output.py
@@ -79,6 +79,15 @@ OUTPUTS_KEY = "outputs"
 Outputs key constant used for identifying outputs in the run output.
 """
 
+_OUTPUT_ENVELOPE_KEYS = frozenset(
+    {"options", "solution", ASSETS_KEY, METRICS_KEY, STATISTICS_KEY, "csv_configurations", "json_configurations"}
+)
+"""
+Keys that `Output.to_dict()` may produce. A plain `dict` whose keys are all
+contained in this set is treated as an `Output` that was already serialized
+to a dict, rather than as arbitrary user data.
+"""
+
 
 class RunStatistics(BaseModel):
     """
@@ -1377,6 +1386,15 @@ class LocalOutputWriter(OutputWriter):
         if sys.stdout is not sys.__stdout__ and not skip_stdout_reset:
             reset_stdout()
 
+        # A plain `dict` that isn't a serialized `Output` (i.e. it has keys
+        # `Output.to_dict()` would never produce) is arbitrary user data, not
+        # a decision-problem output. We print it as-is, without interpreting
+        # it as an `Output` and without even looking at the app.yaml
+        # manifest, since none of that machinery applies to it.
+        if isinstance(output, dict) and not self.__is_output_dict(output):
+            self.__write_raw_dict(output, path=path, json_configurations=json_configurations)
+            return
+
         output_dict = self.__output_to_dict(output)
         manifest = resolve_manifest(manifest)
         content_format = self.__resolve_content_format(output, manifest, content_format)
@@ -1795,10 +1813,7 @@ class LocalOutputWriter(OutputWriter):
             if solution is not None:
                 return solution
 
-            if "solution" in output_dict.keys():
-                return output_dict["solution"]
-
-            return output_dict
+            return output_dict.get("solution") if output_dict else None
 
         # At this point we are working with multi-file.
         # We do not support a solution with multi-file because we don't know
@@ -1920,6 +1935,60 @@ class LocalOutputWriter(OutputWriter):
 
         raise TypeError(f"unsupported `output` type: {type(output)}, supported types are `Output`, `dict`, `BaseModel`")
 
+    def __is_output_dict(self, output: dict[str, Any]) -> bool:
+        """
+        Determine whether a plain `dict` is a serialized `Output`.
+
+        A `dict` is considered a serialized `Output` when every one of its
+        keys is a key that `Output.to_dict()` could have produced (see
+        `_OUTPUT_ENVELOPE_KEYS`). Any other key means the caller passed
+        arbitrary data rather than an `Output`.
+
+        Parameters
+        ----------
+        output : dict[str, Any]
+            The dict to inspect.
+
+        Returns
+        -------
+        bool
+            `True` if the dict looks like a serialized `Output`, `False`
+            otherwise.
+        """
+
+        return set(output.keys()) <= _OUTPUT_ENVELOPE_KEYS
+
+    def __write_raw_dict(
+        self,
+        output: dict[str, Any],
+        path: str | None = None,
+        json_configurations: dict[str, Any] | None = None,
+    ) -> None:
+        """
+        Write a plain `dict` that is not a serialized `Output` as pretty
+        JSON, verbatim.
+
+        Parameters
+        ----------
+        output : dict[str, Any]
+            The raw dict to write, as-is.
+        path : str, optional
+            File path to write the serialized JSON to. When `None` or an
+            empty string, the payload is printed to stdout instead.
+        json_configurations : dict[str, Any], optional
+            Additional keyword arguments forwarded to the JSON serializer
+            (e.g. `{"indent": 2}`).
+        """
+
+        serialized = serialize_json(output, json_configurations=json_configurations)
+
+        if path is None or path == "":
+            print(serialized, file=sys.stdout)
+            return
+
+        with open(path, "w", encoding="utf-8") as file:
+            file.write(serialized + "\n")
+
     def __write_json(
         self,
         output: Output | dict[str, Any] | BaseModel | None = None,
@@ -1974,9 +2043,6 @@ class LocalOutputWriter(OutputWriter):
             output_dict[STATISTICS_KEY] = statistics
 
         if output is not None and isinstance(output, BaseModel) and not isinstance(output, Output):
-            output_dict = solution
-
-        if output is not None and isinstance(output, dict) and "solution" not in solution.keys():
             output_dict = solution
 
         serialized = serialize_json(

--- a/nextmv/nextmv/output.py
+++ b/nextmv/nextmv/output.py
@@ -1795,8 +1795,10 @@ class LocalOutputWriter(OutputWriter):
             if solution is not None:
                 return solution
 
-            if output_dict:
-                return output_dict.get("solution")
+            if "solution" in output_dict.keys():
+                return output_dict["solution"]
+
+            return output_dict
 
         # At this point we are working with multi-file.
         # We do not support a solution with multi-file because we don't know
@@ -1972,6 +1974,9 @@ class LocalOutputWriter(OutputWriter):
             output_dict[STATISTICS_KEY] = statistics
 
         if output is not None and isinstance(output, BaseModel) and not isinstance(output, Output):
+            output_dict = solution
+
+        if output is not None and isinstance(output, dict) and "solution" not in solution.keys():
             output_dict = solution
 
         serialized = serialize_json(

--- a/nextmv/tests/test_output.py
+++ b/nextmv/tests/test_output.py
@@ -251,7 +251,7 @@ class TestOutput(unittest.TestCase):
     def test_local_writer_json_stdout_default_dict_output(self):
         output = {
             "solution": {"empanadas": "are_life"},
-            "statistics": {"foo": "bar"},
+            "metrics": {"foo": "bar"},
         }
         output_writer = nextmv.LocalOutputWriter()
 
@@ -261,10 +261,9 @@ class TestOutput(unittest.TestCase):
             got = json.loads(mock_stdout.getvalue())
             expected = {
                 "solution": {"empanadas": "are_life"},
-                "statistics": {"foo": "bar"},
+                "metrics": {"foo": "bar"},
                 "options": {},
                 "assets": [],
-                "metrics": {},
             }
 
             self.assertDictEqual(got, expected)
@@ -478,13 +477,62 @@ class TestOutput(unittest.TestCase):
 
             got = json.loads(mock_stdout.getvalue())
             expected = {
-                "options": {},
-                "solution": {},
-                "assets": [],
-                "metrics": {},
+                "i_am": "a_crazy_object",
+                "with": [
+                    {"nested": "values"},
+                    {"and": "more_craziness"},
+                ],
             }
 
             self.assertDictEqual(got, expected)
+
+    def test_local_write_passthrough_output_to_file(self):
+        """A raw dict written to a file path is also passed through verbatim."""
+        output = {"i_am": "a_crazy_object"}
+        output_writer = nextmv.LocalOutputWriter()
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            fpath = os.path.join(tmp_dir, "out.json")
+            output_writer.write(output, path=fpath, skip_stdout_reset=True)
+
+            with open(fpath) as f:
+                got = json.load(f)
+
+        self.assertDictEqual(got, output)
+
+    def test_local_write_passthrough_dict_with_unknown_and_output_like_keys(self):
+        """A single unrecognized key is enough to treat the whole dict as raw
+        passthrough data, even if other keys look like `Output` fields."""
+        output = {
+            "metrics": {"foo": "bar"},
+            "not_an_output_field": True,
+        }
+        output_writer = nextmv.LocalOutputWriter()
+
+        with patch("sys.stdout", new=StringIO()) as mock_stdout:
+            output_writer.write(output, skip_stdout_reset=True)
+            got = json.loads(mock_stdout.getvalue())
+
+        self.assertDictEqual(got, output)
+
+    def test_dict_with_only_output_keys_is_treated_as_serialized_output(self):
+        """A dict whose keys are all valid `Output` fields is treated as a
+        serialized `Output`, not as raw passthrough data: missing fields
+        (like `solution` and `assets`) are defaulted."""
+        output = {"options": {"duration": 30}}
+        output_writer = nextmv.LocalOutputWriter()
+
+        with patch("sys.stdout", new=StringIO()) as mock_stdout:
+            output_writer.write(output, skip_stdout_reset=True)
+            got = json.loads(mock_stdout.getvalue())
+
+        expected = {
+            "options": {"duration": 30},
+            "solution": {},
+            "assets": [],
+            "metrics": {},
+        }
+        self.assertDictEqual(got, expected)
 
     def test_local_write_base_model(self):
         class myClass(BaseModel):
@@ -1843,6 +1891,49 @@ class TestWriteManifestFromCwd(unittest.TestCase):
             got = json.loads(mock_out.getvalue())
 
         self.assertEqual(got["solution"]["default"], 1)
+
+    def test_raw_dict_ignores_multi_file_manifest_in_cwd(self):
+        """A raw (non-`Output`) dict is written as pretty JSON to stdout even
+        when app.yaml in cwd configures MULTI_FILE: the manifest is not
+        consulted at all for this kind of output."""
+        manifest = _make_multi_file_manifest()
+        _write_app_yaml(self.tmp_dir, manifest)
+
+        output = {"i_am": "a_crazy_object", "with": [{"nested": "values"}]}
+        with patch("sys.stdout", new=StringIO()) as mock_out:
+            nextmv.write(output, skip_stdout_reset=True)
+            got = json.loads(mock_out.getvalue())
+
+        self.assertDictEqual(got, output)
+        # None of the manifest-configured multi-file output paths were created.
+        self.assertFalse(os.path.exists(os.path.join(self.tmp_dir, "outputs")))
+
+    def test_raw_dict_does_not_resolve_manifest(self):
+        """A raw dict never triggers manifest resolution at all, even when
+        app.yaml is present in cwd."""
+        manifest = _make_json_manifest()
+        _write_app_yaml(self.tmp_dir, manifest)
+
+        output = {"i_am": "a_crazy_object"}
+        with (
+            patch("nextmv.output.resolve_manifest") as mock_resolve_manifest,
+            patch("sys.stdout", new=StringIO()),
+        ):
+            nextmv.write(output, skip_stdout_reset=True)
+
+        mock_resolve_manifest.assert_not_called()
+
+    def test_serialized_output_dict_uses_multi_file_manifest_in_cwd(self):
+        """Unlike a raw dict, a dict that is a serialized `Output` (only
+        `Output`-known keys) is not passed through: it still resolves
+        `content_format` from app.yaml in cwd, so `solution` combined with
+        MULTI_FILE correctly raises."""
+        manifest = _make_multi_file_manifest()
+        _write_app_yaml(self.tmp_dir, manifest)
+
+        output = {"solution": {"cwd_mf": 1}}
+        with self.assertRaises(ValueError):
+            nextmv.write(output)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# Description

Another regression. We lost the ability to write simple dicts with the `nextmv.write` function. This should hopefully be resolved now.