### PR TITLE
Fix PyPI publish: bump gh-action-pypi-publish to v1.14.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,7 +112,7 @@ jobs:
         working-directory: ./nextmv
 
       - name: python - publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           packages-dir: ./nextmv/dist
 
@@ -244,7 +244,7 @@ jobs:
         working-directory: ./nextmv-gurobipy
 
       - name: python - publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           packages-dir: ./nextmv-gurobipy/dist
 
@@ -307,7 +307,7 @@ jobs:
         working-directory: ./nextmv-scikit-learn
 
       - name: Publish package
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           packages-dir: ./nextmv-scikit-learn/dist
 


### PR DESCRIPTION
# Description

The PyPI publish job failed with `InvalidDistribution: '2.5' is not a valid metadata version`. hatchling 1.32.0 now emits `Metadata-Version: 2.5`, but the pinned `pypa/gh-action-pypi-publish@v1.14.0` bundles Twine v6, which rejects 2.5 in its pre-upload check. v1.14.2 upgrades to Twine v7, which supports metadata 2.5.

## Changes

- Bump `pypa/gh-action-pypi-publish` from `v1.14.0` to `v1.14.2` in all three publish jobs (`nextmv`, `nextmv-gurobipy`, `nextmv-scikit-learn`).

🤖 Diagnosed and patched with Claude Code (Opus 4.8)