### PR TITLE
NMV-797: validate run_dir against path traversal

### DIFF
--- a/nextmv/nextmv/local/executor.py
+++ b/nextmv/nextmv/local/executor.py
@@ -78,7 +78,7 @@ def _validate_execution_input(data: dict[str, Any]) -> None:
     (:mod:`nextmv.local.runner`), so in normal operation every field is already
     well-formed. Validating here is defense-in-depth: it ensures a malformed or
     tampered payload cannot be used to traverse the filesystem via a crafted
-    ``run_id`` (path traversal / OS access violation).
+    ``run_id`` or ``run_dir`` (path traversal / OS access violation).
 
     Parameters
     ----------
@@ -88,8 +88,9 @@ def _validate_execution_input(data: dict[str, Any]) -> None:
     Raises
     ------
     ValueError
-        If a required field is missing, has the wrong type, or ``run_id``
-        contains path separators or traversal sequences.
+        If a required field is missing, has the wrong type, ``run_id`` contains
+        path separators or traversal sequences, or ``run_dir`` contains a
+        traversal sequence or does not end in the validated ``run_id``.
     """
     required: dict[str, type] = {
         "run_id": str,
@@ -109,6 +110,21 @@ def _validate_execution_input(data: dict[str, Any]) -> None:
         raise ValueError(
             f"unsafe run_id {run_id!r}: must match [A-Za-z0-9._-]+ and contain no path traversal sequences"
         )
+
+    # `run_dir` is interpolated into filesystem paths (os.path.join / os.makedirs)
+    # throughout execution. The trusted runner always builds it as
+    # `<src>/.nextmv/runs/<run_id>`, so its final component must equal the
+    # already-validated `run_id`, and it must contain no traversal sequences or
+    # null bytes. Enforcing this severs any path traversal via a tampered
+    # `run_dir` (CWE-77 / path traversal).
+    run_dir = data["run_dir"]
+    # Inspect the raw components (splitting on both separators) so an embedded
+    # `..` is caught before `os.path.normpath` can silently collapse it.
+    run_dir_parts = re.split(r"[\\/]", run_dir)
+    if "\x00" in run_dir or os.pardir in run_dir_parts:
+        raise ValueError(f"unsafe run_dir {run_dir!r}: must contain no path traversal sequences")
+    if os.path.basename(os.path.normpath(run_dir)) != run_id:
+        raise ValueError(f"unsafe run_dir {run_dir!r}: final path component must equal the validated run_id {run_id!r}")
 
 
 def main() -> None:

--- a/nextmv/nextmv/local/executor.py
+++ b/nextmv/nextmv/local/executor.py
@@ -48,7 +48,15 @@ from typing import Any
 from nextmv.content_format import ContentFormat
 from nextmv.input import INPUTS_KEY, InputFormat, load
 from nextmv.local.geojson_handler import handle_geojson_visual
-from nextmv.local.local import DEFAULT_OUTPUT_JSON_FILE, LOGS_FILE, LOGS_KEY, OUTPUT_KEY, calculate_files_size
+from nextmv.local.local import (
+    DEFAULT_OUTPUT_JSON_FILE,
+    LOGS_FILE,
+    LOGS_KEY,
+    NEXTMV_DIR,
+    OUTPUT_KEY,
+    RUNS_KEY,
+    calculate_files_size,
+)
 from nextmv.local.plotly_handler import handle_plotly_visual
 from nextmv.manifest import MANIFEST_FILE_NAME, Manifest, ManifestType, find_files, read_pyproject_dependencies
 from nextmv.output import (
@@ -78,7 +86,7 @@ def _validate_execution_input(data: dict[str, Any]) -> None:
     (:mod:`nextmv.local.runner`), so in normal operation every field is already
     well-formed. Validating here is defense-in-depth: it ensures a malformed or
     tampered payload cannot be used to traverse the filesystem via a crafted
-    ``run_id`` or ``run_dir`` (path traversal / OS access violation).
+    ``run_id``, ``src`` or ``run_dir`` (path traversal / OS access violation).
 
     Parameters
     ----------
@@ -88,9 +96,10 @@ def _validate_execution_input(data: dict[str, Any]) -> None:
     Raises
     ------
     ValueError
-        If a required field is missing, has the wrong type, ``run_id`` contains
-        path separators or traversal sequences, or ``run_dir`` contains a
-        traversal sequence or does not end in the validated ``run_id``.
+        If a required field is missing or has the wrong type, ``run_id``
+        contains path separators or traversal sequences, ``src`` is not an
+        absolute path, or ``run_dir`` does not resolve to the canonical
+        ``<src>/.nextmv/runs/<run_id>`` location.
     """
     required: dict[str, type] = {
         "run_id": str,
@@ -111,20 +120,29 @@ def _validate_execution_input(data: dict[str, Any]) -> None:
             f"unsafe run_id {run_id!r}: must match [A-Za-z0-9._-]+ and contain no path traversal sequences"
         )
 
+    # `src` is the trusted application root that every execution path (including
+    # `run_dir`) is derived from. The runner always passes it as an absolute
+    # path, so reject anything else; this also anchors the `run_dir` check below.
+    src = data["src"]
+    if "\x00" in src or not os.path.isabs(src):
+        raise ValueError(f"unsafe src {src!r}: must be an absolute path with no null bytes")
+
     # `run_dir` is interpolated into filesystem paths (os.path.join / os.makedirs)
-    # throughout execution. The trusted runner always builds it as
-    # `<src>/.nextmv/runs/<run_id>`, so its final component must equal the
-    # already-validated `run_id`, and it must contain no traversal sequences or
-    # null bytes. Enforcing this severs any path traversal via a tampered
-    # `run_dir` (CWE-77 / path traversal).
+    # throughout execution. The runner always builds it as the canonical
+    # `<src>/.nextmv/runs/<run_id>`, so require `run_dir` to resolve to exactly
+    # that location. Anchoring to `src` (rather than only checking the basename)
+    # stops a tampered payload from redirecting writes to an arbitrary absolute
+    # or CWD-relative directory whose final component happens to match `run_id`
+    # (CWE-77 / path traversal).
     run_dir = data["run_dir"]
-    # Inspect the raw components (splitting on both separators) so an embedded
-    # `..` is caught before `os.path.normpath` can silently collapse it.
-    run_dir_parts = re.split(r"[\\/]", run_dir)
-    if "\x00" in run_dir or os.pardir in run_dir_parts:
-        raise ValueError(f"unsafe run_dir {run_dir!r}: must contain no path traversal sequences")
-    if os.path.basename(os.path.normpath(run_dir)) != run_id:
-        raise ValueError(f"unsafe run_dir {run_dir!r}: final path component must equal the validated run_id {run_id!r}")
+    if "\x00" in run_dir:
+        raise ValueError(f"unsafe run_dir {run_dir!r}: contains a null byte")
+    expected_run_dir = os.path.realpath(os.path.join(src, NEXTMV_DIR, RUNS_KEY, run_id))
+    if os.path.realpath(run_dir) != expected_run_dir:
+        raise ValueError(
+            f"unsafe run_dir {run_dir!r}: must resolve to the canonical "
+            f"<src>/{NEXTMV_DIR}/{RUNS_KEY}/<run_id> path ({expected_run_dir!r})"
+        )
 
 
 def main() -> None:

--- a/nextmv/tests/local/test_executor.py
+++ b/nextmv/tests/local/test_executor.py
@@ -82,13 +82,18 @@ class TestLocalExecutor(unittest.TestCase):
     @patch("nextmv.local.executor.execute_run")
     def test_main_function(self, mock_execute_run, mock_load):
         """Test the main function loads input and calls execute_run."""
+        # Build absolute, canonical paths so the fixture is valid on every OS
+        # (a POSIX-style "/test/src" is not absolute on Windows).
+        src = os.path.abspath(os.path.join("test", "src"))
+        run_dir = os.path.join(src, ".nextmv", "runs", "test_run_id")
+
         # Setup mock input
         mock_input = Mock()
         mock_input.data = {
             "run_id": "test_run_id",
-            "src": "/test/src",
+            "src": src,
             "manifest_dict": {"execution": {"entrypoint": "main.py"}, "type": "python"},
-            "run_dir": "/test/src/.nextmv/runs/test_run_id",
+            "run_dir": run_dir,
             "run_config": {"format": {"input": {"type": "json"}}},
             "inputs_dir_path": None,
             "options": {"duration": "10s"},
@@ -105,9 +110,9 @@ class TestLocalExecutor(unittest.TestCase):
         # Verify execute_run was called with correct parameters
         mock_execute_run.assert_called_once_with(
             run_id="test_run_id",
-            src="/test/src",
+            src=src,
             manifest_dict={"execution": {"entrypoint": "main.py"}, "type": "python"},
-            run_dir="/test/src/.nextmv/runs/test_run_id",
+            run_dir=run_dir,
             run_config={"format": {"input": {"type": "json"}}},
             inputs_dir_path=None,
             options={"duration": "10s"},
@@ -1322,12 +1327,18 @@ class TestExecutorEncoding(unittest.TestCase):
 class TestValidateExecutionInput(unittest.TestCase):
     """Test cases for the `_validate_execution_input` path-safety guard."""
 
+    # Absolute paths are built with os.path so the fixtures are valid on every
+    # OS (a POSIX-style "/test/src" is not absolute on Windows).
+    SRC = os.path.abspath(os.path.join("test", "src"))
+    RUN_ID = "local-abc123"
+    RUN_DIR = os.path.join(SRC, ".nextmv", "runs", RUN_ID)
+
     def _valid_payload(self, **overrides):
         payload = {
-            "run_id": "local-abc123",
-            "src": "/test/src",
+            "run_id": self.RUN_ID,
+            "src": self.SRC,
             "manifest_dict": {"type": "python"},
-            "run_dir": "/test/src/.nextmv/runs/local-abc123",
+            "run_dir": self.RUN_DIR,
             "run_config": {"format": {"input": {"type": "json"}}},
         }
         payload.update(overrides)
@@ -1355,39 +1366,43 @@ class TestValidateExecutionInput(unittest.TestCase):
     def test_run_dir_traversal_rejected(self):
         # A run_dir escaping via `..` must be rejected even if its final
         # component matches the run_id.
+        bad = os.path.join(self.SRC, ".nextmv", "runs", "..", "..", "..", self.RUN_ID)
         with self.assertRaises(ValueError):
-            _validate_execution_input(self._valid_payload(run_dir="/test/src/.nextmv/runs/../../../local-abc123"))
+            _validate_execution_input(self._valid_payload(run_dir=bad))
 
     def test_run_dir_null_byte_rejected(self):
         with self.assertRaises(ValueError):
-            _validate_execution_input(self._valid_payload(run_dir="/test/src/.nextmv/runs/local-abc123\x00"))
+            _validate_execution_input(self._valid_payload(run_dir=self.RUN_DIR + "\x00"))
 
     def test_run_dir_outside_src_rejected(self):
         # An absolute run_dir whose basename matches run_id but which does not
         # live under src must be rejected (must be anchored to src, not just
         # matched on basename).
+        bad = os.path.abspath(os.path.join("tmp", "evil", self.RUN_ID))
         with self.assertRaises(ValueError):
-            _validate_execution_input(self._valid_payload(run_dir="/tmp/evil/local-abc123"))
+            _validate_execution_input(self._valid_payload(run_dir=bad))
 
     def test_run_dir_relative_rejected(self):
         # A CWD-relative run_dir must be rejected: it would resolve against the
         # executor's working directory rather than under src.
         with self.assertRaises(ValueError):
-            _validate_execution_input(self._valid_payload(run_dir="local-abc123"))
+            _validate_execution_input(self._valid_payload(run_dir=self.RUN_ID))
 
     def test_run_dir_not_under_src_rejected(self):
+        bad = os.path.abspath(os.sep + "etc")
         with self.assertRaises(ValueError):
-            _validate_execution_input(self._valid_payload(run_dir="/etc"))
+            _validate_execution_input(self._valid_payload(run_dir=bad))
 
     def test_src_must_be_absolute(self):
+        rel_src = os.path.join("relative", "src")
         with self.assertRaises(ValueError):
             _validate_execution_input(
-                self._valid_payload(src="relative/src", run_dir="relative/src/.nextmv/runs/local-abc123")
+                self._valid_payload(src=rel_src, run_dir=os.path.join(rel_src, ".nextmv", "runs", self.RUN_ID))
             )
 
     def test_src_null_byte_rejected(self):
         with self.assertRaises(ValueError):
-            _validate_execution_input(self._valid_payload(src="/test/\x00src"))
+            _validate_execution_input(self._valid_payload(src=self.SRC + "\x00"))
 
 
 if __name__ == "__main__":

--- a/nextmv/tests/local/test_executor.py
+++ b/nextmv/tests/local/test_executor.py
@@ -18,6 +18,7 @@ from nextmv.local.executor import (
     _process_run_assets,
     _process_run_solutions,
     _process_run_statistics,
+    _validate_execution_input,
     execute_run,
     main,
     options_args,
@@ -87,7 +88,7 @@ class TestLocalExecutor(unittest.TestCase):
             "run_id": "test_run_id",
             "src": "/test/src",
             "manifest_dict": {"execution": {"entrypoint": "main.py"}, "type": "python"},
-            "run_dir": "/test/run_dir",
+            "run_dir": "/test/src/.nextmv/runs/test_run_id",
             "run_config": {"format": {"input": {"type": "json"}}},
             "inputs_dir_path": None,
             "options": {"duration": "10s"},
@@ -106,7 +107,7 @@ class TestLocalExecutor(unittest.TestCase):
             run_id="test_run_id",
             src="/test/src",
             manifest_dict={"execution": {"entrypoint": "main.py"}, "type": "python"},
-            run_dir="/test/run_dir",
+            run_dir="/test/src/.nextmv/runs/test_run_id",
             run_config={"format": {"input": {"type": "json"}}},
             inputs_dir_path=None,
             options={"duration": "10s"},
@@ -1316,6 +1317,55 @@ class TestExecutorEncoding(unittest.TestCase):
         call_kwargs = mock_popen.call_args[1]
         self.assertEqual(call_kwargs.get("encoding"), "utf-8")
         self.assertEqual(call_kwargs.get("errors"), "replace")
+
+
+class TestValidateExecutionInput(unittest.TestCase):
+    """Test cases for the `_validate_execution_input` path-safety guard."""
+
+    def _valid_payload(self, **overrides):
+        payload = {
+            "run_id": "local-abc123",
+            "src": "/test/src",
+            "manifest_dict": {"type": "python"},
+            "run_dir": "/test/src/.nextmv/runs/local-abc123",
+            "run_config": {"format": {"input": {"type": "json"}}},
+        }
+        payload.update(overrides)
+        return payload
+
+    def test_valid_payload_passes(self):
+        # A well-formed payload from the trusted runner must validate cleanly.
+        _validate_execution_input(self._valid_payload())
+
+    def test_missing_required_field(self):
+        payload = self._valid_payload()
+        del payload["run_dir"]
+        with self.assertRaises(ValueError):
+            _validate_execution_input(payload)
+
+    def test_wrong_type_field(self):
+        with self.assertRaises(ValueError):
+            _validate_execution_input(self._valid_payload(run_dir=123))
+
+    def test_run_id_traversal_rejected(self):
+        for bad in ["../evil", "a/b", "foo/../bar"]:
+            with self.assertRaises(ValueError):
+                _validate_execution_input(self._valid_payload(run_id=bad))
+
+    def test_run_dir_traversal_rejected(self):
+        # A run_dir escaping via `..` must be rejected even if its final
+        # component matches the run_id.
+        with self.assertRaises(ValueError):
+            _validate_execution_input(self._valid_payload(run_dir="/test/src/.nextmv/runs/../../../local-abc123"))
+
+    def test_run_dir_null_byte_rejected(self):
+        with self.assertRaises(ValueError):
+            _validate_execution_input(self._valid_payload(run_dir="/test/src/.nextmv/runs/local-abc123\x00"))
+
+    def test_run_dir_basename_must_match_run_id(self):
+        # A run_dir pointing somewhere other than `<...>/<run_id>` is rejected.
+        with self.assertRaises(ValueError):
+            _validate_execution_input(self._valid_payload(run_dir="/etc"))
 
 
 if __name__ == "__main__":

--- a/nextmv/tests/local/test_executor.py
+++ b/nextmv/tests/local/test_executor.py
@@ -1362,10 +1362,32 @@ class TestValidateExecutionInput(unittest.TestCase):
         with self.assertRaises(ValueError):
             _validate_execution_input(self._valid_payload(run_dir="/test/src/.nextmv/runs/local-abc123\x00"))
 
-    def test_run_dir_basename_must_match_run_id(self):
-        # A run_dir pointing somewhere other than `<...>/<run_id>` is rejected.
+    def test_run_dir_outside_src_rejected(self):
+        # An absolute run_dir whose basename matches run_id but which does not
+        # live under src must be rejected (must be anchored to src, not just
+        # matched on basename).
+        with self.assertRaises(ValueError):
+            _validate_execution_input(self._valid_payload(run_dir="/tmp/evil/local-abc123"))
+
+    def test_run_dir_relative_rejected(self):
+        # A CWD-relative run_dir must be rejected: it would resolve against the
+        # executor's working directory rather than under src.
+        with self.assertRaises(ValueError):
+            _validate_execution_input(self._valid_payload(run_dir="local-abc123"))
+
+    def test_run_dir_not_under_src_rejected(self):
         with self.assertRaises(ValueError):
             _validate_execution_input(self._valid_payload(run_dir="/etc"))
+
+    def test_src_must_be_absolute(self):
+        with self.assertRaises(ValueError):
+            _validate_execution_input(
+                self._valid_payload(src="relative/src", run_dir="relative/src/.nextmv/runs/local-abc123")
+            )
+
+    def test_src_null_byte_rejected(self):
+        with self.assertRaises(ValueError):
+            _validate_execution_input(self._valid_payload(src="/test/\x00src"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Extends the local executor's input validation to reject a `run_dir` with traversal sequences/null bytes and require its final component to equal the validated `run_id`. Closes the Checkmarx CWE-77 finding on `executor.py`; adds tests.

Note: the jackson-databind findings are already resolved on `develop` (templates use jackson 3.x), and the pymdown-extensions finding is not in this repo (docs-build tooling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)